### PR TITLE
fix: correct Auth Overview link

### DIFF
--- a/www/content/docs/index.mdx
+++ b/www/content/docs/index.mdx
@@ -179,7 +179,7 @@ Complete reference for all documentation pages.
 
 | Page | When to Use |
 |------|-------------|
-| [Auth Overview](/docs/auth/index) | Architecture overview. When to use Better Auth vs other auth solutions. |
+| [Auth Overview](/docs/auth) | Architecture overview. When to use Better Auth vs other auth solutions. |
 | [Auth Server](/docs/auth/server) | Complete Better Auth setup: schema, adapters, HTTP routes, helpers. |
 | [Auth Client](/docs/auth/client) | `useAuth`, `Authenticated`/`Unauthenticated` components. |
 | [Auth Triggers](/docs/auth/triggers) | User lifecycle hooks: `beforeCreate`, `onCreate`, `onDelete`. |


### PR DESCRIPTION
## Summary
- Fixed broken link in docs index page
- Changed `/docs/auth/index` to `/docs/auth` which returns 404

## Test plan
- [x] Verify https://www.better-convex.com/docs/auth exists and is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)