### PR TITLE
feat: GitHub Actions for Claude slash commands

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -66,6 +66,7 @@ jobs:
           claude_args: |
             --max-turns 1000
             --allowedTools "Bash,Edit,Glob,Grep,Read,Task,Write,WebFetch,WebSearch,mcp__github_comment__update_claude_comment"
+            --system-prompt "When you receive a slash command like /lfg, /plan, /work, /review, /brainstorm, first read .claude/commands/{command}.md to understand the workflow steps to execute."
 
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -147,6 +147,7 @@ jobs:
           claude_args: |
             --max-turns 1000
             --allowedTools "Bash,Edit,Glob,Grep,Read,Task,Write,WebFetch,WebSearch,mcp__github_comment__update_claude_comment"
+            --system-prompt "When you receive a slash command like /lfg, /plan, /work, /review, /brainstorm, first read .claude/commands/{command}.md to understand the workflow steps to execute."
 
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary
- Add claude.yml workflow with two jobs: interactive (@claude) and slash-commands (/)
- Add claude-review.yml for auto PR review
- Configure plugins: compound-engineering, dig, debug, test
- Add --system-prompt to read local .claude/commands/ files
- Full Bash access with --allowedTools
- Bun install + cache for CLAUDE.md generation

## Test Issues
- #64: @claude test (JSDoc)
- #65: /lfg test (dark mode)

🤖 Generated with [Claude Code](https://claude.ai/code)