### PR TITLE
Fix: Tanstack start docs

### DIFF
--- a/www/content/docs/tanstack-start.mdx
+++ b/www/content/docs/tanstack-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: Setup
+title: Tanstack Start
 description: Set up better-convex with Better Auth for a TanStack Start app.
 links:
   doc: https://labs.convex.dev/better-auth/framework-guides/tanstack-start


### PR DESCRIPTION
Recent changes to the docs resulted in the different framework's getting mapped all under "Integrations", but the tanstack start docs remained labeled as "Setup" this pr renames it to "Tanstack Start"