### PR TITLE
fix: preserve nested nullable fields in arrayOf(objectOf(...))

### DIFF
--- a/.changeset/funny-donuts-judge.md
+++ b/.changeset/funny-donuts-judge.md
@@ -1,0 +1,7 @@
+---
+"better-convex": patch
+---
+
+## Patches
+
+- Fix nested `arrayOf(objectOf(...))` field nullability so `text()` and `text().notNull()` produce distinct schema/data-model types and avoid deploy mismatches.

--- a/packages/better-convex/src/orm/builders/custom.test.ts
+++ b/packages/better-convex/src/orm/builders/custom.test.ts
@@ -148,6 +148,33 @@ describe('custom array/object sugar', () => {
     expect(timeline.fieldType.value.type).toBe('object');
   });
 
+  test('keeps nullable builder semantics in arrayOf(objectOf(...))', () => {
+    const productions = convexTable('productions_nullable_nested_test', {
+      timeline: arrayOf(
+        objectOf({
+          requiredNote: text().notNull(),
+          optionalNote: text(),
+        })
+      ).notNull(),
+    });
+
+    const timeline = (productions.validator as any).json.value.timeline;
+    const fields = timeline.fieldType.value.value;
+
+    expect(fields.requiredNote.fieldType.type).toBe('string');
+    expect(fields.optionalNote.fieldType.type).toBe('union');
+    expect(
+      fields.optionalNote.fieldType.value.some(
+        (item: any) => item.type === 'null'
+      )
+    ).toBe(true);
+    expect(
+      fields.optionalNote.fieldType.value.some(
+        (item: any) => item.type === 'string'
+      )
+    ).toBe(true);
+  });
+
   test('arrayOf throws clear error for invalid element input', () => {
     expect(() => arrayOf(42 as any)).toThrow(
       'arrayOf(element) expected a column builder, Convex validator, or nested object shape. Got number.'

--- a/packages/better-convex/src/orm/builders/custom.ts
+++ b/packages/better-convex/src/orm/builders/custom.ts
@@ -31,7 +31,9 @@ type InferBuilderNestedValue<TBuilder extends AnyColumnBuilder> =
   }
     ? TType
     : TBuilder['_'] extends { data: infer TData }
-      ? TData
+      ? TBuilder['_'] extends { notNull: true }
+        ? TData
+        : TData | null
       : never;
 
 type InferValidatorNestedValue<TValidator extends AnyValidator> = Exclude<
@@ -74,25 +76,27 @@ function toRequiredValidator(validator: AnyValidator): AnyValidator {
     : validator;
 }
 
-function stripNullUnionMember(validator: AnyValidator): AnyValidator {
-  if (validator.kind !== 'union') {
-    return validator;
+function toRequiredBuilderValidator(validator: AnyValidator): AnyValidator {
+  const requiredValidator = toRequiredValidator(validator);
+
+  if (requiredValidator.kind !== 'union') {
+    return requiredValidator;
   }
 
-  const members = validator.members.filter((member) => member.kind !== 'null');
-  if (members.length === validator.members.length || members.length === 0) {
-    return validator;
-  }
-  if (members.length === 1) {
-    return members[0] as AnyValidator;
-  }
-  return v.union(...members);
-}
+  const nonNullMembers = requiredValidator.members.filter(
+    (member) => member.kind !== 'null'
+  );
 
-function toRequiredNonNullBuilderValidator(
-  validator: AnyValidator
-): AnyValidator {
-  return stripNullUnionMember(toRequiredValidator(validator));
+  if (nonNullMembers.length !== 1) {
+    return requiredValidator;
+  }
+
+  const [member] = nonNullMembers;
+  if (member.kind === 'object' || member.kind === 'array') {
+    return member as AnyValidator;
+  }
+
+  return requiredValidator;
 }
 
 function formatInvalidInput(path: string, value: unknown): string {
@@ -123,7 +127,7 @@ function nestedInputToValidator(
   path: string
 ): AnyValidator {
   if (isColumnBuilder(input)) {
-    return toRequiredNonNullBuilderValidator(
+    return toRequiredBuilderValidator(
       (input as any).convexValidator as AnyValidator
     );
   }

--- a/packages/better-convex/src/orm/builders/custom.types.test.ts
+++ b/packages/better-convex/src/orm/builders/custom.types.test.ts
@@ -30,7 +30,7 @@ test('arrayOf/objectOf infer nested select and insert model types', () => {
       timestamp: number;
       type: 'status' | 'milestone' | 'note';
       content: string;
-      note: string;
+      note: string | null;
     }>
   >();
 
@@ -39,7 +39,7 @@ test('arrayOf/objectOf infer nested select and insert model types', () => {
       timestamp: number;
       type: 'status' | 'milestone' | 'note';
       content: string;
-      note: string;
+      note: string | null;
     }>
   >();
 });
@@ -47,7 +47,7 @@ test('arrayOf/objectOf infer nested select and insert model types', () => {
 test('objectOf keeps top-level column nullability semantics', () => {
   expectTypeOf<ProductionSelect['payload']>().toEqualTypeOf<{
     actor: string;
-    source: string;
+    source: string | null;
   }>();
 
   expectTypeOf<ProductionSelect['optionalPayload']>().toEqualTypeOf<{


### PR DESCRIPTION
### Motivation
- `objectOf` used inside `arrayOf` normalized nested validators as required which made `text()` and `text().notNull()` indistinguishable and caused Convex schema/deploy errors.

### Description
- Add nullable-awareness to nested builder types by making `InferBuilderNestedValue` return `TData | null` when the builder is not `notNull`.
- Replace union-stripping helper with `toRequiredBuilderValidator` that only unwraps optional unions for structural validators (`object`/`array`) so leaf validators keep `null` semantics.
- Add a runtime test to assert `arrayOf(objectOf(...))` preserves `text()` vs `text().notNull()` differences and update type tests to expect nullable nested fields (`note`, `payload.source`).
- Add a patch changeset `.changeset/funny-donuts-judge.md` and build the package.

### Testing
- Ran `bun test packages/better-convex/src/orm/builders/custom.test.ts` and the test suite passed.
- Ran `bun typecheck` and it succeeded.
- Ran `bun lint:fix` and `bun --cwd packages/better-convex build` which both completed successfully.
- Touched `example/convex/functions/schema.ts` to trigger the example rebuild.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3adf6710c83329dca3c9a7c79f793)