### PR TITLE
fix(server/cli): fix createEnv throwing during better-convex dev

### DIFF
--- a/.changeset/fix-createenv-codegen-fallback.md
+++ b/.changeset/fix-createenv-codegen-fallback.md
@@ -1,0 +1,5 @@
+---
+"better-convex": patch
+---
+
+Fix `createEnv` throwing "Invalid environment variables" during `better-convex dev`. The CLI now sets a `globalThis.__BETTER_CONVEX_CODEGEN__` sentinel before importing Convex files via jiti, and `createEnv` reads that sentinel (instead of `process.env`) to activate a safe fallback — using `options[0]` for `z.enum` fields instead of `""` to avoid false validation failures.

--- a/packages/better-convex/src/cli/analyze.ts
+++ b/packages/better-convex/src/cli/analyze.ts
@@ -513,25 +513,35 @@ const listConvexHandlerExports = async (
 const scanHandlerExportsByEntry = async (
   entryPoints: string[]
 ): Promise<Map<string, string[]>> => {
-  const jitiInstance = createJiti(process.cwd(), {
-    interopDefault: true,
-    moduleCache: false,
-  });
+  // Signal to createEnv that we are in the CLI's Node.js parse context.
+  // Use globalThis instead of process.env so Convex's auth-config env-var
+  // scanner never sees this as a required dashboard variable.
+  (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__ = true;
 
-  const results = await Promise.all(
-    entryPoints.map(async (entryPoint) => ({
-      entryPoint,
-      exportNames: await listConvexHandlerExports(entryPoint, jitiInstance),
-    }))
-  );
+  try {
+    const jitiInstance = createJiti(process.cwd(), {
+      interopDefault: true,
+      moduleCache: false,
+    });
 
-  const byEntry = new Map<string, string[]>();
-  for (const result of results) {
-    if (result.exportNames.length > 0) {
-      byEntry.set(result.entryPoint, result.exportNames);
+    const results = await Promise.all(
+      entryPoints.map(async (entryPoint) => ({
+        entryPoint,
+        exportNames: await listConvexHandlerExports(entryPoint, jitiInstance),
+      }))
+    );
+
+    const byEntry = new Map<string, string[]>();
+    for (const result of results) {
+      if (result.exportNames.length > 0) {
+        byEntry.set(result.entryPoint, result.exportNames);
+      }
     }
+    return byEntry;
+  } finally {
+    // biome-ignore lint/performance/noDelete: globalThis property, not a plain object — delete is correct here
+    delete (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__;
   }
-  return byEntry;
 };
 
 const parseArgs = (argv: string[]): AnalyzeOptions => {

--- a/packages/better-convex/src/cli/codegen.ts
+++ b/packages/better-convex/src/cli/codegen.ts
@@ -1402,74 +1402,84 @@ export async function generateMeta(
   });
 
   if (generateApi) {
-    // Create jiti instance for importing TypeScript files
-    const jitiInstance = createJiti(process.cwd(), {
-      interopDefault: true,
-      moduleCache: false,
-    });
+    // Signal to createEnv that we are in the CLI's Node.js parse context.
+    // Use globalThis instead of process.env so Convex's auth-config env-var
+    // scanner never sees this as a required dashboard variable.
+    (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__ = true;
 
-    const files = listFilesRecursive(functionsDir).filter(
-      (file) => file.endsWith('.ts') && isValidConvexFile(file)
-    );
-    const runtimePlaceholderModules = [
-      ...new Set([
-        ...files.map((file) => file.replace(TS_EXTENSION_RE, '')),
-        ...(hasRelationsExport ? ['generated/server'] : []),
-        ...(generateAuth ? [generatedAuthModuleName] : []),
-      ]),
-    ];
-    createdRuntimePlaceholders = ensureGeneratedRuntimePlaceholders(
-      functionsDir,
-      runtimePlaceholderModules
-    );
+    try {
+      // Create jiti instance for importing TypeScript files
+      const jitiInstance = createJiti(process.cwd(), {
+        interopDefault: true,
+        moduleCache: false,
+      });
 
-    for (const file of files) {
-      const filePath = path.join(functionsDir, file);
-      // Use path (minus .ts) as namespace key: 'items/queries' for nested files
-      const moduleName = file.replace(TS_EXTENSION_RE, '');
+      const files = listFilesRecursive(functionsDir).filter(
+        (file) => file.endsWith('.ts') && isValidConvexFile(file)
+      );
+      const runtimePlaceholderModules = [
+        ...new Set([
+          ...files.map((file) => file.replace(TS_EXTENSION_RE, '')),
+          ...(hasRelationsExport ? ['generated/server'] : []),
+          ...(generateAuth ? [generatedAuthModuleName] : []),
+        ]),
+      ];
+      createdRuntimePlaceholders = ensureGeneratedRuntimePlaceholders(
+        functionsDir,
+        runtimePlaceholderModules
+      );
 
-      try {
-        const {
-          meta: moduleMeta,
-          httpRoutes,
-          procedures,
-        } = await parseModuleRuntime(filePath, jitiInstance);
+      for (const file of files) {
+        const filePath = path.join(functionsDir, file);
+        // Use path (minus .ts) as namespace key: 'items/queries' for nested files
+        const moduleName = file.replace(TS_EXTENSION_RE, '');
 
-        if (moduleMeta) {
-          meta[moduleName] = moduleMeta;
-          const fnCount = Object.keys(moduleMeta).length;
-          totalFunctions += fnCount;
-          if (debug) {
-            console.info(`  ✓ ${moduleName}: ${fnCount} functions`);
+        try {
+          const {
+            meta: moduleMeta,
+            httpRoutes,
+            procedures,
+          } = await parseModuleRuntime(filePath, jitiInstance);
+
+          if (moduleMeta) {
+            meta[moduleName] = moduleMeta;
+            const fnCount = Object.keys(moduleMeta).length;
+            totalFunctions += fnCount;
+            if (debug) {
+              console.info(`  ✓ ${moduleName}: ${fnCount} functions`);
+            }
+          }
+
+          // Merge HTTP routes
+          if (Object.keys(httpRoutes).length > 0 && debug) {
+            console.info(
+              `  ✓ ${moduleName}: ${Object.keys(httpRoutes).length} HTTP routes`
+            );
+          }
+          Object.assign(allHttpRoutes, httpRoutes);
+
+          for (const procedure of procedures) {
+            procedureEntries.push({
+              moduleName,
+              exportName: procedure.exportName,
+              internal: procedure.internal,
+              type: procedure.type,
+              kind: 'crpc',
+            });
+          }
+        } catch (error) {
+          runtimeFilesPreservedFromParseFailures.add(
+            getGeneratedRuntimeOutputFile(functionsDir, moduleName)
+          );
+          // Always log http.ts errors as they contain critical HTTP routes
+          if (debug || file === 'http.ts') {
+            console.error(`  ⚠ Failed to parse ${file}:`, error);
           }
         }
-
-        // Merge HTTP routes
-        if (Object.keys(httpRoutes).length > 0 && debug) {
-          console.info(
-            `  ✓ ${moduleName}: ${Object.keys(httpRoutes).length} HTTP routes`
-          );
-        }
-        Object.assign(allHttpRoutes, httpRoutes);
-
-        for (const procedure of procedures) {
-          procedureEntries.push({
-            moduleName,
-            exportName: procedure.exportName,
-            internal: procedure.internal,
-            type: procedure.type,
-            kind: 'crpc',
-          });
-        }
-      } catch (error) {
-        runtimeFilesPreservedFromParseFailures.add(
-          getGeneratedRuntimeOutputFile(functionsDir, moduleName)
-        );
-        // Always log http.ts errors as they contain critical HTTP routes
-        if (debug || file === 'http.ts') {
-          console.error(`  ⚠ Failed to parse ${file}:`, error);
-        }
       }
+    } finally {
+      // biome-ignore lint/performance/noDelete: globalThis property, not a plain object — delete is correct here
+      delete (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__;
     }
   }
 

--- a/packages/better-convex/src/server/env.test.ts
+++ b/packages/better-convex/src/server/env.test.ts
@@ -3,14 +3,10 @@ import { createEnv } from './env';
 import { CRPCError } from './error';
 
 describe('server/env', () => {
-  const originalNodeEnv = process.env.NODE_ENV;
-
+  // Restore BETTER_CONVEX_CODEGEN after each test so tests are fully isolated.
   afterEach(() => {
-    if (originalNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-      return;
-    }
-    process.env.NODE_ENV = originalNodeEnv;
+    // biome-ignore lint/performance/noDelete: globalThis property, not a plain object — delete is correct here
+    delete (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__;
   });
 
   test('parses runtimeEnv and applies schema defaults', () => {
@@ -114,8 +110,23 @@ describe('server/env', () => {
     expect(safeParseSpy).toHaveBeenCalledTimes(2);
   });
 
-  test('supports codegen fallback when NODE_ENV is missing', () => {
-    delete process.env.NODE_ENV;
+  test('throws at Convex runtime when a required var is missing (no sentinel, no codegenFallback)', () => {
+    // Neither BETTER_CONVEX_CODEGEN nor codegenFallback — simulates normal Convex runtime.
+    const schema = z.object({
+      BC_REQUIRED_A: z.string(),
+    });
+
+    const getEnv = createEnv({
+      schema,
+      runtimeEnv: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(() => getEnv()).toThrow(CRPCError);
+  });
+
+  test('sentinel alone activates fallback without codegenFallback (CLI default path)', () => {
+    // The CLI sets BETTER_CONVEX_CODEGEN=1 but users need not set codegenFallback.
+    (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__ = true;
 
     const schema = z.object({
       ADMIN: z
@@ -140,7 +151,7 @@ describe('server/env', () => {
   });
 
   test('codegen fallback merges defaults and keeps runtimeEnv precedence', () => {
-    delete process.env.NODE_ENV;
+    (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__ = true;
 
     const schema = z.object({
       BC_REQUIRED_A: z.string(),
@@ -158,5 +169,36 @@ describe('server/env', () => {
       BC_REQUIRED_A: '',
       BC_REQUIRED_B: 'from-runtime',
     });
+  });
+
+  test('codegen fallback uses enum defaults', () => {
+    (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__ = true;
+
+    const schema = z.object({
+      DEPLOY_ENV: z.enum(['development', 'production']),
+    });
+
+    const getEnv = createEnv({
+      schema,
+      runtimeEnv: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(getEnv()).toEqual({
+      DEPLOY_ENV: 'development',
+    });
+  });
+
+  test('codegenFallback: true activates fallback even without sentinel (custom setups)', () => {
+    const schema = z.object({
+      BC_REQUIRED_A: z.string(),
+    });
+
+    const getEnv = createEnv({
+      schema,
+      codegenFallback: true,
+      runtimeEnv: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(getEnv()).toEqual({ BC_REQUIRED_A: '' });
   });
 });

--- a/packages/better-convex/src/server/env.ts
+++ b/packages/better-convex/src/server/env.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import { z } from 'zod';
 import { CRPCError } from './error';
 
 export type CreateEnvOptions<TSchema extends z.ZodObject<z.ZodRawShape>> = {
@@ -15,7 +15,7 @@ export function createEnv<TSchema extends z.ZodObject<z.ZodRawShape>>(
     schema,
     runtimeEnv = process.env,
     cache = true,
-    codegenFallback = true,
+    codegenFallback = false,
   } = options;
   let cached: z.infer<TSchema> | undefined;
 
@@ -23,14 +23,30 @@ export function createEnv<TSchema extends z.ZodObject<z.ZodRawShape>>(
     if (cache && cached) {
       return cached;
     }
-
-    const isCodegen = codegenFallback && !process.env.NODE_ENV;
-    const envForParse = isCodegen
+    // Apply schema fallback when the CLI's sentinel is set.
+    // We use globalThis rather than process.env so Convex's auth-config env-var
+    // scanner never sees a process.env reference for this internal key.
+    // The CLI sets this exclusively during the Node.js jiti parse in `better-convex dev`,
+    // so the fallback never fires at actual Convex runtime — where a missing required
+    // var must still throw "Invalid environment variables".
+    // codegenFallback keeps its role as an explicit opt-in for custom setups that
+    // need to replicate this behavior outside of the CLI.
+    const isCodegenParse =
+      (globalThis as Record<string, unknown>).__BETTER_CONVEX_CODEGEN__ ===
+        true || codegenFallback;
+    const envForParse = isCodegenParse
       ? {
           ...Object.fromEntries(
             Object.entries(schema.shape).map(([key, zodType]) => {
               const result = (zodType as z.ZodType).safeParse(undefined);
               if (!result.success) {
+                // Use first allowed value for enums so parse succeeds when Convex env is not in process.env
+                if (
+                  zodType instanceof z.ZodEnum &&
+                  Array.isArray(zodType.options) &&
+                  zodType.options.length > 0
+                )
+                  return [key, zodType.options[0]];
                 return [key, ''];
               }
               return [


### PR DESCRIPTION
## Summary

- `createEnv()` called at import time throws "Invalid environment variables" during `better-convex dev` because Convex env vars aren't in `process.env` during the CLI parse (jiti import)
- The CLI now sets `globalThis.__BETTER_CONVEX_CODEGEN__ = true` before jiti imports and cleans it up in a `finally` block
- `createEnv` reads that sentinel to activate a safe fallback, using `options[0]` for `z.enum` fields instead of `""` to avoid false validation failures
- Uses `globalThis` (not `process.env`) to avoid Convex's static env scanner flagging unset variables