### PR TITLE
fix: correct polar webhook plugin path to polar/webhooks

### DIFF
--- a/skills/convex/references/features/auth-polar.md
+++ b/skills/convex/references/features/auth-polar.md
@@ -538,7 +538,7 @@ Polar webhooks require a public URL.
 ```json
 { "scripts": { "dev": "concurrently 'next dev' 'bun ngrok'", "ngrok": "ngrok http --url=your-domain.ngrok-free.app 3000" } }
 ```
-3. Configure webhook URL in Polar Dashboard: `https://your-domain.ngrok-free.app/api/auth/polar/webhook`
+3. Configure webhook URL in Polar Dashboard: `https://your-domain.ngrok-free.app/api/auth/polar/webhooks`
 
 ## Common Patterns
 

--- a/www/content/docs/auth/plugins/polar.mdx
+++ b/www/content/docs/auth/plugins/polar.mdx
@@ -684,7 +684,7 @@ Polar webhooks require a public URL. Use ngrok to expose your local server:
 4. Configure the webhook URL in [Polar Dashboard](https://polar.sh/dashboard) → Settings → Webhooks:
 
 ```
-https://your-domain.ngrok-free.app/api/auth/polar/webhook
+https://your-domain.ngrok-free.app/api/auth/polar/webhooks
 ```
 
 ## Common Patterns


### PR DESCRIPTION
The Polar plugin path was referenced as `/polar/webhook`, but the correct path is `/polar/webhooks` according to Better Auth documentation.

This PR updates the reference to prevent confusion.