### PR TITLE
Fix ssr caller factory for non-next apps

### DIFF
--- a/.changeset/fix-ssr-caller-convex-url.md
+++ b/.changeset/fix-ssr-caller-convex-url.md
@@ -1,0 +1,7 @@
+---
+"better-convex": patch
+---
+
+Pass the Convex deployment URL through the SSR server caller instead of falling back to `NEXT_PUBLIC_CONVEX_URL`.
+
+`createCallerFactory` now derives the `.convex.cloud` URL from `convexSiteUrl` by default and also accepts an explicit `convexUrl` override for frameworks that do not use Next.js env naming.

--- a/packages/better-convex/src/auth-nextjs/index.ts
+++ b/packages/better-convex/src/auth-nextjs/index.ts
@@ -37,6 +37,7 @@ type AuthOptions = {
 type ConvexBetterAuthOptions<TApi> = Omit<GetTokenOptions, 'jwtCache'> & {
   api: TApi;
   convexSiteUrl: string;
+  convexUrl?: string;
   /** Auth options. JWT caching is enabled by default (set `auth.jwtCache: false` to disable). */
   auth?: AuthOptions;
 };
@@ -72,7 +73,6 @@ export function convexBetterAuth<TApi extends Record<string, unknown>>(
 
   const { createContext, createCaller } = createCallerFactory({
     api: opts.api,
-    convexSiteUrl: opts.convexSiteUrl,
     auth: jwtCacheEnabled
       ? {
           getToken: (siteUrl, headers, getTokenOpts) => {
@@ -91,11 +91,13 @@ export function convexBetterAuth<TApi extends Record<string, unknown>>(
           isUnauthorized: auth.isUnauthorized ?? defaultIsUnauthorized,
         }
       : undefined,
+    convexSiteUrl: opts.convexSiteUrl,
+    convexUrl: opts.convexUrl,
   });
 
   return {
-    createContext,
     createCaller,
+    createContext,
     handler: nextJsHandler(opts.convexSiteUrl),
   };
 }

--- a/packages/better-convex/src/server/caller-factory.test.ts
+++ b/packages/better-convex/src/server/caller-factory.test.ts
@@ -13,8 +13,8 @@ const withQueryLeafMeta = (api: {
   ({
     posts: {
       list: Object.assign(api.posts.list, {
-        type: 'query',
         functionRef: api.posts.list,
+        type: 'query',
       }),
     },
   }) as const;
@@ -59,8 +59,8 @@ describe('server/caller-factory', () => {
 
     const { createContext } = createCallerFactory({
       api: apiWithMeta,
-      convexSiteUrl: 'https://example.convex.site',
       auth: { getToken },
+      convexSiteUrl: 'https://example.convex.site',
     });
 
     const ctx = await createContext({ headers: new Headers() });
@@ -68,6 +68,61 @@ describe('server/caller-factory', () => {
       ctx.caller.posts.list({}, { skipUnauth: true })
     ).resolves.toBeNull();
     expect(fetchQuerySpy.mock.calls.length).toBe(0);
+  });
+
+  test('passes a Convex deployment url to server fetch helpers', async () => {
+    const fetchQuerySpy = spyOn(convexNextjs, 'fetchQuery').mockImplementation(
+      async () => 'ok'
+    );
+
+    const api = {
+      posts: { list: makeFunctionReference<'query'>('posts:list') },
+    };
+    const apiWithMeta = withQueryLeafMeta(api);
+
+    const getToken = mock(async () => ({ isFresh: true, token: 't0' }));
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta,
+      auth: { getToken },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(ctx.caller.posts.list({})).resolves.toBe('ok');
+
+    expect(fetchQuerySpy.mock.calls[0]?.[2]).toMatchObject({
+      token: 't0',
+      url: 'https://example.convex.cloud',
+    });
+  });
+
+  test('prefers an explicit convexUrl when provided', async () => {
+    const fetchQuerySpy = spyOn(convexNextjs, 'fetchQuery').mockImplementation(
+      async () => 'ok'
+    );
+
+    const api = {
+      posts: { list: makeFunctionReference<'query'>('posts:list') },
+    };
+    const apiWithMeta = withQueryLeafMeta(api);
+
+    const getToken = mock(async () => ({ isFresh: true, token: 't0' }));
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta,
+      auth: { getToken },
+      convexSiteUrl: 'https://example.convex.site',
+      convexUrl: 'https://custom.example.convex.cloud',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(ctx.caller.posts.list({})).resolves.toBe('ok');
+
+    expect(fetchQuerySpy.mock.calls[0]?.[2]).toMatchObject({
+      token: 't0',
+      url: 'https://custom.example.convex.cloud',
+    });
   });
 
   test('returns null for unauthorized errors (no retry)', async () => {
@@ -84,11 +139,10 @@ describe('server/caller-factory', () => {
     };
     const apiWithMeta = withQueryLeafMeta(api);
 
-    const getToken = mock(async () => ({ token: 't0', isFresh: true }));
+    const getToken = mock(async () => ({ isFresh: true, token: 't0' }));
 
     const { createContext } = createCallerFactory({
       api: apiWithMeta,
-      convexSiteUrl: 'https://example.convex.site',
       auth: {
         getToken,
         isUnauthorized: (e) =>
@@ -97,6 +151,7 @@ describe('server/caller-factory', () => {
           'code' in e &&
           (e as any).code === 'UNAUTHORIZED',
       },
+      convexSiteUrl: 'https://example.convex.site',
     });
 
     const ctx = await createContext({ headers: new Headers() });
@@ -122,15 +177,15 @@ describe('server/caller-factory', () => {
 
     const getToken = mock(
       async (_siteUrl: string, _headers: Headers, opts?: any) => {
-        if (opts?.forceRefresh) return { token: 't1', isFresh: true };
-        return { token: 't0', isFresh: false };
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
       }
     );
 
     const { createContext } = createCallerFactory({
       api: apiWithMeta,
-      convexSiteUrl: 'https://example.convex.site',
       auth: { getToken, isUnauthorized: () => false },
+      convexSiteUrl: 'https://example.convex.site',
     });
 
     const ctx = await createContext({ headers: new Headers() });
@@ -160,14 +215,13 @@ describe('server/caller-factory', () => {
 
     const getToken = mock(
       async (_siteUrl: string, _headers: Headers, opts?: any) => {
-        if (opts?.forceRefresh) return { token: 't1', isFresh: true };
-        return { token: 't0', isFresh: false };
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
       }
     );
 
     const { createContext } = createCallerFactory({
       api: apiWithMeta,
-      convexSiteUrl: 'https://example.convex.site',
       auth: {
         getToken,
         isUnauthorized: (e) =>
@@ -176,6 +230,7 @@ describe('server/caller-factory', () => {
           'code' in e &&
           (e as any).code === 'UNAUTHORIZED',
       },
+      convexSiteUrl: 'https://example.convex.site',
     });
 
     const ctx = await createContext({ headers: new Headers() });
@@ -201,12 +256,12 @@ describe('server/caller-factory', () => {
     };
     const apiWithMeta = withQueryLeafMeta(api);
 
-    const getToken = mock(async () => ({ token: 't0', isFresh: true }));
+    const getToken = mock(async () => ({ isFresh: true, token: 't0' }));
 
     const { createContext } = createCallerFactory({
       api: apiWithMeta,
-      convexSiteUrl: 'https://example.convex.site',
       auth: { getToken, isUnauthorized: () => false },
+      convexSiteUrl: 'https://example.convex.site',
     });
 
     const ctx = await createContext({ headers: new Headers() });
@@ -231,20 +286,20 @@ describe('server/caller-factory', () => {
     };
     const apiWithMeta = withQueryLeafMeta(api);
 
-    const getToken = mock(async () => ({ token: 't0', isFresh: true }));
+    const getToken = mock(async () => ({ isFresh: true, token: 't0' }));
 
     const { createContext } = createCallerFactory({
       api: apiWithMeta,
-      convexSiteUrl: 'https://example.convex.site',
       auth: { getToken, isUnauthorized: () => false },
+      convexSiteUrl: 'https://example.convex.site',
       transformer: {
         input: {
-          serialize: (value: unknown) => ({ $in: value }),
           deserialize: (value: unknown) => value,
+          serialize: (value: unknown) => ({ $in: value }),
         },
         output: {
-          serialize: (value: unknown) => value,
           deserialize: (value: unknown) => (value as any)?.$out ?? value,
+          serialize: (value: unknown) => value,
         },
       },
     });

--- a/packages/better-convex/src/server/caller-factory.ts
+++ b/packages/better-convex/src/server/caller-factory.ts
@@ -21,6 +21,8 @@ import {
 } from './caller';
 import { createLazyCaller, type LazyCaller } from './lazy-caller';
 
+const CONVEX_SITE_URL_RE = /\.convex\.site(?=\/|$)/;
+
 // Token result from getToken
 type TokenResult = {
   token?: string;
@@ -47,6 +49,11 @@ type CreateCallerFactoryOptions<TApi> = {
   api: TApi;
   /** Convex site URL (must end in `.convex.site`). */
   convexSiteUrl: string;
+  /**
+   * Convex deployment URL (must end in `.convex.cloud`).
+   * Defaults to `convexSiteUrl` with the domain swapped.
+   */
+  convexUrl?: string;
   /** Auth options. Pass to enable authenticated calls with JWT caching. */
   auth?: AuthOptions;
   /** Optional wire transformer for request/response payloads (always composed with Date). */
@@ -60,8 +67,12 @@ type OptionalArgs<FuncRef extends FunctionReference<any, any>> =
 
 const getArgsAndOptions = <FuncRef extends FunctionReference<any, any>>(
   args: OptionalArgs<FuncRef>,
-  token?: string
-): ArgsAndOptions<FuncRef, { token?: string }> => [args[0], { token }];
+  token?: string,
+  url?: string
+): ArgsAndOptions<FuncRef, { token?: string; url?: string }> => [
+  args[0],
+  { token, url },
+];
 
 const parseConvexSiteUrl = (url: string) => {
   if (!url) {
@@ -75,6 +86,14 @@ const parseConvexSiteUrl = (url: string) => {
     );
   }
   return url;
+};
+
+const getConvexUrl = (siteUrl: string, convexUrl?: string) => {
+  if (convexUrl) {
+    return convexUrl;
+  }
+
+  return siteUrl.replace(CONVEX_SITE_URL_RE, '.convex.cloud');
 };
 
 // Context shape returned by createContext
@@ -103,6 +122,7 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
   opts: CreateCallerFactoryOptions<TApi>
 ) {
   const siteUrl = parseConvexSiteUrl(opts.convexSiteUrl);
+  const convexUrl = getConvexUrl(siteUrl, opts.convexUrl);
   const getToken = opts.auth?.getToken ?? noAuthGetToken;
   const isUnauthorized = opts.auth?.isUnauthorized;
   const crpcMeta = buildMetaIndex(opts.api);
@@ -163,7 +183,7 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
       }
       return callWithTokenAndRetry(
         (token) => {
-          const argsAndOptions = getArgsAndOptions([args], token);
+          const argsAndOptions = getArgsAndOptions([args], token, convexUrl);
           return fetchQuery(query, argsAndOptions[0], argsAndOptions[1]);
         },
         tokenResult,
@@ -183,7 +203,7 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
       }
       return callWithTokenAndRetry(
         (token) => {
-          const argsAndOptions = getArgsAndOptions([args], token);
+          const argsAndOptions = getArgsAndOptions([args], token, convexUrl);
           return fetchMutation(mutation, argsAndOptions[0], argsAndOptions[1]);
         },
         tokenResult,
@@ -201,7 +221,7 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
       }
       return callWithTokenAndRetry(
         (token) => {
-          const argsAndOptions = getArgsAndOptions([args], token);
+          const argsAndOptions = getArgsAndOptions([args], token, convexUrl);
           return fetchAction(action, argsAndOptions[0], argsAndOptions[1]);
         },
         tokenResult,
@@ -210,15 +230,15 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
     };
 
     return {
-      token: tokenResult.token,
-      isAuthenticated: !!tokenResult.token,
       caller: createServerCaller(opts.api, {
-        fetchQuery: fetchAuthQuery,
-        fetchMutation: fetchAuthMutation,
         fetchAction: fetchAuthAction,
+        fetchMutation: fetchAuthMutation,
+        fetchQuery: fetchAuthQuery,
         meta: crpcMeta,
         transformer: opts.transformer,
       }),
+      isAuthenticated: !!tokenResult.token,
+      token: tokenResult.token,
     };
   };
 
@@ -227,5 +247,5 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
     ctxFn: () => Promise<ConvexContext<TApi>>
   ): LazyCaller<TApi> => createLazyCaller(opts.api, ctxFn);
 
-  return { createContext, createCaller };
+  return { createCaller, createContext };
 }


### PR DESCRIPTION
## Problem

I hit this in a Vite app using TanStack Start after following the docs pattern here:

- `src/lib/convex/server.ts`
- `https://www.better-convex.com/docs/tanstack-start#caller-factory--server-context`

The issue is in `packages/better-convex/src/server/caller-factory.ts`.

The SSR path was forwarding `{ token }` into `fetchQuery` / `fetchMutation` / `fetchAction`, but it was not forwarding the Convex deployment URL.

When that happens, `convex/nextjs` falls back to `NEXT_PUBLIC_CONVEX_URL`.

That works in Next.js, but it breaks in a Vite app like mine because that env var does not exist there.

The error was:

`Error: Environment variable NEXT_PUBLIC_CONVEX_URL is not set`

## Fix

This keeps the design framework-agnostic:

- derive the `.convex.cloud` deployment URL from `convexSiteUrl`
- pass that URL through the SSR server caller
- allow an explicit `convexUrl` override when needed

So the server caller no longer depends on a Next-specific env var.

## Validation

- `bun check`
- `bun test packages/better-convex/src/server/caller-factory.test.ts`
- `bun --cwd packages/better-convex build`

I also verified this in my app by pointing it at this patched package. The dashboard SSR route stopped throwing and went back to the normal unauthenticated redirect flow.
