### PR TITLE
Fix ORM auth writes dropping createdAt columns

### DIFF
--- a/.changeset/calm-trains-laugh.md
+++ b/.changeset/calm-trains-laugh.md
@@ -1,0 +1,5 @@
+---
+'better-convex': patch
+---
+
+Preserve real `createdAt` columns during ORM writes so auth records keep schema-defaulted timestamps when created through the generated auth runtime.

--- a/packages/better-convex/src/auth/create-api.factory.test.ts
+++ b/packages/better-convex/src/auth/create-api.factory.test.ts
@@ -706,6 +706,81 @@ describe('auth/create-api createApi()', () => {
       });
     });
 
+    test('create keeps ORM-created createdAt values when the table defaults them', async () => {
+      const api = createApi(schema, getAuth as any);
+      const ormCreatedAt = new Date('2026-03-06T18:42:31.000Z');
+      const ormUpdatedAt = new Date('2026-03-06T18:42:31.500Z');
+      const store = new Map<string, any>();
+      const ormInsert = mock((_table: any) => ({
+        values: (_data: Record<string, unknown>) => ({
+          returning: async () => {
+            const id = `user-${store.size + 1}`;
+            const doc = {
+              _creationTime: ormCreatedAt.getTime() + 17,
+              _id: id,
+              createdAt: ormCreatedAt,
+              email: 'd@site.com',
+              name: 'dave',
+              updatedAt: ormUpdatedAt,
+            };
+            store.set(id, doc);
+            return [doc];
+          },
+        }),
+      }));
+
+      const ctx = {
+        db: {
+          delete: mock(async () => {
+            throw new Error('db.delete should not be called when orm exists');
+          }),
+          get: async (id: string) => store.get(id) ?? null,
+          insert: mock(async () => {
+            throw new Error('db.insert should not be called when orm exists');
+          }),
+          patch: mock(async () => {
+            throw new Error('db.patch should not be called when orm exists');
+          }),
+        },
+        orm: {
+          delete: mock(() => ({
+            where: async () => undefined,
+          })),
+          insert: ormInsert,
+          update: mock(() => ({
+            set: () => ({
+              where: async () => [],
+            }),
+          })),
+        },
+        runMutation: mock(async () => undefined),
+      };
+
+      const created = await (api.create as any)._handler(ctx, {
+        input: {
+          data: {
+            email: 'd@site.com',
+            name: 'dave',
+          },
+          model: 'user',
+        },
+      });
+
+      expect(ormInsert).toHaveBeenCalledTimes(1);
+      expect(created).toMatchObject({
+        createdAt: ormCreatedAt.getTime(),
+        email: 'd@site.com',
+        name: 'dave',
+        updatedAt: ormUpdatedAt.getTime(),
+      });
+      expect(Array.from(store.values())[0]).toMatchObject({
+        createdAt: ormCreatedAt,
+        email: 'd@site.com',
+        name: 'dave',
+        updatedAt: ormUpdatedAt,
+      });
+    });
+
     test('create normalizes ORM docs for create.after hooks and serializes Date values', async () => {
       const after = mock(async () => undefined);
       const change = mock(async () => undefined);

--- a/packages/better-convex/src/orm/mutation-utils.test.ts
+++ b/packages/better-convex/src/orm/mutation-utils.test.ts
@@ -344,7 +344,7 @@ describe('mutation-utils', () => {
     ).toThrow(/use `createdAt`/i);
   });
 
-  test('normalizeDateFieldsForWrite reserves createdAt for system alias', () => {
+  test('normalizeDateFieldsForWrite preserves explicit user createdAt columns', () => {
     const normalized = normalizeDateFieldsForWrite(usersWithCreatedAt, {
       name: 'Alice',
       createdAt: 123,
@@ -352,12 +352,12 @@ describe('mutation-utils', () => {
 
     expect(normalized).toMatchObject({
       name: 'Alice',
+      createdAt: 123,
     });
     expect(normalized).not.toHaveProperty('_creationTime');
-    expect(normalized).not.toHaveProperty('createdAt');
   });
 
-  test('normalizeDateFieldsForWrite drops defaulted createdAt without writing _creationTime', () => {
+  test('normalizeDateFieldsForWrite preserves defaulted user createdAt without writing _creationTime', () => {
     const withDefaults = applyDefaults(usersWithTimestampCreatedAt, {
       name: 'Alice',
     }) as { name: string; createdAt?: unknown };
@@ -367,8 +367,10 @@ describe('mutation-utils', () => {
     ) as any;
 
     expect(withDefaults.createdAt).toBeInstanceOf(Date);
-    expect(normalized).toMatchObject({ name: 'Alice' });
-    expect(normalized).not.toHaveProperty('createdAt');
+    expect(normalized).toMatchObject({
+      name: 'Alice',
+      createdAt: (withDefaults.createdAt as Date).getTime(),
+    });
     expect(normalized).not.toHaveProperty('_creationTime');
   });
 

--- a/packages/better-convex/src/orm/mutation-utils.ts
+++ b/packages/better-convex/src/orm/mutation-utils.ts
@@ -36,6 +36,7 @@ import {
 import type { ConvexTable } from './table';
 import {
   CREATED_AT_MIGRATION_MESSAGE,
+  hasUserCreatedAtColumn,
   INTERNAL_CREATION_TIME_FIELD,
   PUBLIC_CREATED_AT_FIELD,
   usesSystemCreatedAtAlias,
@@ -336,13 +337,18 @@ export const normalizeDateFieldsForWrite = <T extends Record<string, unknown>>(
   value: T
 ): T => {
   const useSystemCreatedAt = usesSystemCreatedAtAlias(table);
+  const hasUserCreatedAt = hasUserCreatedAtColumn(table);
   const temporalColumns = getTemporalColumnDescriptors(table);
   const result = { ...value } as Record<string, unknown>;
 
   if (Object.hasOwn(result, INTERNAL_CREATION_TIME_FIELD)) {
     throw new Error(CREATED_AT_MIGRATION_MESSAGE);
   }
-  if (useSystemCreatedAt && Object.hasOwn(result, PUBLIC_CREATED_AT_FIELD)) {
+  if (
+    useSystemCreatedAt &&
+    !hasUserCreatedAt &&
+    Object.hasOwn(result, PUBLIC_CREATED_AT_FIELD)
+  ) {
     // createdAt is a reserved public alias for system _creationTime.
     // Writes must never set _creationTime explicitly (Convex controls it).
     delete result[PUBLIC_CREATED_AT_FIELD];


### PR DESCRIPTION
## What happened

This is a follow-up to the previous fix in https://github.com/udecode/better-convex/pull/124.

That PR fixed the raw auth create path by backfilling `createdAt` / `updatedAt` when Better Auth omits them.

But there was still one missing path: when auth writes go through the ORM.

## The bug

If an auth model defines a real `createdAt` column in the schema, the ORM write normalization step was still treating `createdAt` like the public alias for Convex `_creationTime` and dropping it before insert.

So auth creation still succeeded, `_creationTime` still existed, but the actual persisted `createdAt` field could remain unset.

That is what I was seeing in a real app with generated auth + ORM-backed writes.

## Fix

Keep the existing `_creationTime` protection, but preserve `createdAt` during writes when the table actually has a real `createdAt` column.

In short:

- still reject direct writes to `_creationTime`
- still preserve alias behavior where needed
- but do **not** strip `createdAt` if it is an actual schema column

This makes the ORM path line up with the raw auth path fixed in that earlier PR.

## Why this is separate

The earlier PR covered auth-level timestamp backfilling.

This PR covers the ORM normalization layer underneath it.

So they are complementary: the earlier fix makes sure auth creation provides the timestamp, and this patch makes sure ORM writes do not throw it away.

## Validation

Tested in three ways:

- local `better-convex` test suite
- targeted regression coverage added in this PR
- real app integration locally: auth user creation now persists `createdAt` correctly

Ran:

- `bun --cwd packages/better-convex build`
- `bun lint:fix`
- `bun typecheck`
- `bun run test`