### PR TITLE
fix(codegen): support dedicated triggers.ts for schema-safe triggers

### DIFF
--- a/.changeset/schema-safe-triggers.md
+++ b/.changeset/schema-safe-triggers.md
@@ -1,0 +1,5 @@
+---
+"better-convex": patch
+---
+
+Support loading ORM triggers from `triggers.ts` during codegen, with fallback to `schema.ts` for backward compatibility. This keeps `schema.ts` schema-safe when triggers need generated runtime helpers like `createXCaller(...)`.

--- a/packages/better-convex/src/cli/codegen.test.ts
+++ b/packages/better-convex/src/cli/codegen.test.ts
@@ -1043,6 +1043,98 @@ describe('cli/codegen', () => {
     }
   });
 
+  test('generateMeta prefers dedicated triggers file when triggers export exists there', async () => {
+    const dir = mkTempDir();
+    const oldCwd = process.cwd();
+
+    process.chdir(dir);
+    try {
+      writeFile(
+        path.join(dir, 'node_modules', 'better-convex', 'package.json'),
+        JSON.stringify({
+          name: 'better-convex',
+          type: 'module',
+          exports: {
+            './server': './server.js',
+          },
+        })
+      );
+      writeFile(
+        path.join(dir, 'node_modules', 'better-convex', 'server.js'),
+        `
+        export const createApiLeaf = (fn, meta) =>
+          Object.assign(fn, meta, { functionRef: fn });
+        `.trim()
+      );
+
+      writeFile(
+        path.join(dir, 'convex', '_generated', 'api.js'),
+        `
+        export const api = {
+          todos: {
+            list: { ref: 'todos:list' },
+          },
+        };
+        `.trim()
+      );
+
+      writeFile(
+        path.join(dir, 'convex', 'todos.ts'),
+        `
+        export const list = {
+          _crpcMeta: {
+            type: 'query',
+          },
+        };
+        `.trim()
+      );
+
+      writeFile(
+        path.join(dir, 'convex', 'schema.ts'),
+        `
+        export const tables = {
+          todos: { table: 'todos' },
+        };
+        export const relations = {
+          todos: {},
+        };
+        export default {};
+        `.trim()
+      );
+
+      writeFile(
+        path.join(dir, 'convex', 'triggers.ts'),
+        `
+        export const triggers = {
+          todos: {},
+        };
+        `.trim()
+      );
+
+      await generateMeta(undefined, { silent: true });
+
+      const generatedServerFile = path.join(
+        dir,
+        'convex',
+        'generated',
+        'server.ts'
+      );
+      const generatedServer = fs.readFileSync(generatedServerFile, 'utf-8');
+      expect(generatedServer).toContain(
+        "import schema, { relations } from '../schema';"
+      );
+      expect(generatedServer).toContain(
+        "import { triggers } from '../triggers';"
+      );
+      expect(generatedServer).not.toContain(
+        "import schema, { relations, triggers } from '../schema';"
+      );
+      expect(generatedServer).toContain('triggers,');
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
   test('generateMeta wires migrations manifest into generated server when present', async () => {
     const dir = mkTempDir();
     const oldCwd = process.cwd();
@@ -1131,7 +1223,7 @@ describe('cli/codegen', () => {
       );
 
       await expect(generateMeta(undefined, { silent: true })).rejects.toThrow(
-        "schema.ts exports 'triggers' but is missing 'relations'"
+        "triggers require a 'relations' export from schema.ts"
       );
     } finally {
       process.chdir(oldCwd);

--- a/packages/better-convex/src/cli/codegen.ts
+++ b/packages/better-convex/src/cli/codegen.ts
@@ -266,6 +266,15 @@ function getSchemaImportPath(outputFile: string, functionsDir: string): string {
   return ensureRelativeImportPath(normalizeImportPath(relativePath));
 }
 
+function getTriggersImportPath(
+  outputFile: string,
+  functionsDir: string
+): string {
+  const triggersFile = path.join(functionsDir, 'triggers');
+  const relativePath = path.relative(path.dirname(outputFile), triggersFile);
+  return ensureRelativeImportPath(normalizeImportPath(relativePath));
+}
+
 function getServerTypesImportPath(
   outputFile: string,
   functionsDir: string
@@ -489,6 +498,7 @@ function emitGeneratedServerFile(
   functionsDir: string,
   hasRelationsExport: boolean,
   hasTriggersExport: boolean,
+  triggersImportSource: 'schema' | 'triggers',
   hasMigrationsManifest: boolean
 ): string {
   const asSingleQuotedImport = (importPath: string) =>
@@ -503,6 +513,7 @@ function emitGeneratedServerFile(
     functionsDir
   );
   const schemaImportPath = getSchemaImportPath(outputFile, functionsDir);
+  const triggersImportPath = getTriggersImportPath(outputFile, functionsDir);
   const migrationsManifestImportPath = getModuleImportPath(
     outputFile,
     functionsDir,
@@ -512,6 +523,7 @@ function emitGeneratedServerFile(
   const dataModelImportLiteral = asSingleQuotedImport(dataModelImportPath);
   const runtimeApiImportLiteral = asSingleQuotedImport(runtimeApiImportPath);
   const schemaImportLiteral = asSingleQuotedImport(schemaImportPath);
+  const triggersImportLiteral = asSingleQuotedImport(triggersImportPath);
   const migrationsManifestImportLiteral = asSingleQuotedImport(
     migrationsManifestImportPath
   );
@@ -542,10 +554,15 @@ export const initCRPC = baseInitCRPC.dataModel<DataModel>();
     moduleNamespace.split('/').filter(Boolean)
   );
 
-  const schemaNamedImports = hasTriggersExport
-    ? 'relations, triggers'
-    : 'relations';
+  const schemaNamedImports =
+    hasTriggersExport && triggersImportSource === 'schema'
+      ? 'relations, triggers'
+      : 'relations';
   const triggersConfigLine = hasTriggersExport ? '  triggers,\n' : '';
+  const triggersImportLine =
+    hasTriggersExport && triggersImportSource === 'triggers'
+      ? `import { triggers } from ${triggersImportLiteral};\n`
+      : '';
   const migrationsImportLine = hasMigrationsManifest
     ? `import { migrations } from ${migrationsManifestImportLiteral};\n`
     : '';
@@ -566,6 +583,7 @@ import type {
 } from ${serverTypesImportLiteral};
 import { internalMutation } from ${serverTypesImportLiteral};
 import schema, { ${schemaNamedImports} } from ${schemaImportLiteral};
+${triggersImportLine}
 ${migrationsImportLine}
 
 const ormFunctions = ${ormFunctionsAccessor} as OrmFunctions;
@@ -1452,16 +1470,25 @@ export async function generateMeta(
     path.join(functionsDir, 'schema.ts'),
     'relations'
   );
-  const hasTriggersExport = hasNamedExport(
+  const hasSchemaTriggersExport = hasNamedExport(
     path.join(functionsDir, 'schema.ts'),
     'triggers'
   );
+  const hasDedicatedTriggersExport = hasNamedExport(
+    path.join(functionsDir, 'triggers.ts'),
+    'triggers'
+  );
+  const hasTriggersExport =
+    hasSchemaTriggersExport || hasDedicatedTriggersExport;
+  const triggersImportSource = hasDedicatedTriggersExport
+    ? 'triggers'
+    : 'schema';
   const hasMigrationsManifest = fs.existsSync(
     path.join(functionsDir, 'migrations', 'manifest.ts')
   );
   if (hasTriggersExport && !hasRelationsExport) {
     throw new Error(
-      "Codegen error: schema.ts exports 'triggers' but is missing 'relations'. Export `relations` and define triggers via `defineTriggers(relations, { ... })`."
+      "Codegen error: triggers require a 'relations' export from schema.ts. Export `relations` from schema.ts and define triggers via `defineTriggers(relations, { ... })` in schema.ts or triggers.ts."
     );
   }
 
@@ -1673,6 +1700,7 @@ ${optionalTypeExports}
     functionsDir,
     hasRelationsExport,
     hasTriggersExport,
+    triggersImportSource,
     hasMigrationsManifest
   );
 


### PR DESCRIPTION
## Context
This follows up on #129.

PR #129 fixed one part of the issue: it made generated trigger callers safer at import time and fixed the typing side of the trigger caller flow.

However, it did not fix the remaining schema-bundling problem.

## Problem
`better-convex` currently assumes ORM triggers live in `schema.ts`.

That assumption breaks down when a trigger needs generated runtime helpers such as `createXCaller(...)`.

In that setup, `schema.ts` ends up importing generated runtime code. Even if that runtime code is lazy at execution time, Convex still rejects the schema during evaluation because the schema bundle now depends on runtime modules. The failure shows up as `NoImportModuleInSchema`.

In simple terms:
- `schema.ts` must stay schema-only
- trigger runtime code must live outside `schema.ts`

So the issue was not only eager runtime execution. It was also that codegen still coupled schema definition and trigger runtime through `schema.ts`.

## Why PR #129 was not enough
PR #129 addressed the runtime behavior of generated callers.

This PR addresses a different remaining problem: generated server code still expected `triggers` to come from `schema.ts`, which forced users to keep runtime-aware triggers in the schema module.

That is what still caused the Convex schema evaluation failure in real usage.

## Fix
This PR adds support for a dedicated `triggers.ts` file.

When `triggers.ts` exports `triggers`, generated server code now:
- imports `schema` and `relations` from `schema.ts`
- imports `triggers` from `triggers.ts`

If `triggers.ts` is not present, codegen keeps the existing behavior and falls back to `schema.ts` for backward compatibility.

## Why this fixes it
It removes the need for `schema.ts` to import runtime caller code.

That keeps the schema module schema-safe for Convex evaluation, while still allowing triggers to use generated callers and other runtime helpers from a separate module.

## Verification
- added codegen coverage for dedicated `triggers.ts`
- kept backward-compatible support for triggers exported from `schema.ts`
- built the package successfully
- verified in a real app that `bunx better-convex codegen --debug` now succeeds past the previous `NoImportModuleInSchema` failure