### PR TITLE
Fix auth scaffold selection dedupe and auth demo redirect bounce

### DIFF
--- a/.changeset/nasty-timers-jog.md
+++ b/.changeset/nasty-timers-jog.md
@@ -1,0 +1,8 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix interactive scaffold selection so duplicate file paths are shown once and the active preset stays selected.
+- Fix generated auth demo pages so sign-in and sign-up stay on the signed-in view instead of bouncing back to the auth route.

--- a/packages/kitcn/src/cli/backend-core.ts
+++ b/packages/kitcn/src/cli/backend-core.ts
@@ -6056,6 +6056,16 @@ export async function run(
       presetTemplateIds,
       availableTemplateIds: allTemplates.map((template) => template.id),
     });
+    const selectableTemplateIds =
+      selectionSource === 'lockfile'
+        ? [...new Set([...existingTemplateIds, ...presetTemplateIds])]
+        : presetTemplateIds;
+    const selectableTemplates = resolveTemplatesByIdOrThrow(
+      pluginDescriptor,
+      allTemplates,
+      selectableTemplateIds,
+      'add selection prompt'
+    );
     const scaffoldRoots = resolvePluginScaffoldRoots(
       effectiveFunctionsDir,
       pluginDescriptor,
@@ -6066,7 +6076,7 @@ export async function run(
         ? await promptForScaffoldTemplateSelection(
             promptAdapter,
             pluginDescriptor,
-            allTemplates,
+            selectableTemplates,
             defaultTemplateIds,
             scaffoldRoots
           )

--- a/packages/kitcn/src/cli/commands/add.ts
+++ b/packages/kitcn/src/cli/commands/add.ts
@@ -447,6 +447,16 @@ export const handleAddCommand = async (argv: string[], deps: AddDeps = {}) => {
     presetTemplateIds,
     availableTemplateIds: allTemplates.map((template) => template.id),
   });
+  const selectableTemplateIds =
+    selectionSource === 'lockfile'
+      ? [...new Set([...existingTemplateIds, ...presetTemplateIds])]
+      : presetTemplateIds;
+  const selectableTemplates = resolveTemplatesByIdOrThrow(
+    pluginDescriptor,
+    allTemplates,
+    selectableTemplateIds,
+    'add selection prompt'
+  );
   const scaffoldRoots = resolvePluginScaffoldRoots(
     effectiveFunctionsDir,
     pluginDescriptor,
@@ -458,7 +468,7 @@ export const handleAddCommand = async (argv: string[], deps: AddDeps = {}) => {
       ? await promptForScaffoldTemplateSelection(
           promptAdapter,
           pluginDescriptor,
-          allTemplates,
+          selectableTemplates,
           defaultTemplateIds,
           scaffoldRoots
         )

--- a/packages/kitcn/src/cli/registry/items/auth/auth-page.template.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-page.template.ts
@@ -33,16 +33,11 @@ export default function AuthPage() {
   const isPending =
     signIn.isPending || signUp.isPending || signOut.isPending;
 
-  function getCallbackURL() {
-    return '/auth';
-  }
-
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     if (mode === 'signup') {
       signUp.mutate({
-        callbackURL: getCallbackURL(),
         email,
         name,
         password,
@@ -51,7 +46,6 @@ export default function AuthPage() {
     }
 
     signIn.mutate({
-      callbackURL: getCallbackURL(),
       email,
       password,
     });

--- a/packages/kitcn/src/cli/registry/selection.test.ts
+++ b/packages/kitcn/src/cli/registry/selection.test.ts
@@ -1,0 +1,185 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { ResolvedScaffoldRoots, ScaffoldTemplate } from '../types.js';
+import { getPluginCatalogEntry } from './index.js';
+import {
+  collectPluginScaffoldTemplates,
+  promptForScaffoldTemplateSelection,
+  resolvePresetScaffoldTemplates,
+  resolveTemplatesByIdOrThrow,
+} from './selection.js';
+
+const createRoots = (cwd: string): ResolvedScaffoldRoots => ({
+  functionsRootDir: path.join(cwd, 'convex', 'functions'),
+  libRootDir: path.join(cwd, 'convex', 'lib'),
+  appRootDir: null,
+  clientLibRootDir: null,
+  crpcFilePath: path.join(cwd, 'convex', 'lib', 'crpc.ts'),
+  sharedApiFilePath: path.join(cwd, 'convex', 'shared', 'api.ts'),
+  envFilePath: path.join(cwd, 'convex', 'lib', 'get-env.ts'),
+  projectContext: null,
+});
+
+describe('promptForScaffoldTemplateSelection', () => {
+  test('scopes auth options to the resolved preset', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-selection-auth-preset-')
+    );
+
+    try {
+      const descriptor = getPluginCatalogEntry('auth');
+      const allTemplates = collectPluginScaffoldTemplates(descriptor);
+      const presetTemplateIds = resolvePresetScaffoldTemplates(
+        descriptor,
+        'default'
+      ).map((template) => template.id);
+      const selectableTemplates = resolveTemplatesByIdOrThrow(
+        descriptor,
+        allTemplates,
+        presetTemplateIds,
+        'selection test'
+      );
+      const multiselectPromptStub = mock(
+        async <TValue extends string>(params: {
+          initialValues?: readonly TValue[];
+        }) => params.initialValues ?? []
+      );
+
+      const selectedTemplateIds = await promptForScaffoldTemplateSelection(
+        {
+          multiselect: multiselectPromptStub as any,
+        } as any,
+        descriptor,
+        selectableTemplates,
+        presetTemplateIds,
+        createRoots(dir)
+      );
+
+      const callArgs = (
+        multiselectPromptStub.mock.calls[0] as unknown[]
+      )[0] as {
+        initialValues: string[];
+        options: Array<{ label: string; value: string }>;
+      };
+      const expectedLabels = [
+        path.relative(
+          process.cwd(),
+          path.join(dir, 'convex', 'functions', 'auth', 'page.tsx')
+        ),
+        path.relative(
+          process.cwd(),
+          path.join(dir, 'convex', 'functions', 'convex', 'auth-client.ts')
+        ),
+        path.relative(
+          process.cwd(),
+          path.join(dir, 'convex', 'functions', 'auth.config.ts')
+        ),
+        path.relative(
+          process.cwd(),
+          path.join(dir, 'convex', 'functions', 'auth.ts')
+        ),
+      ].map((label) => label.replaceAll('\\', '/'));
+
+      expect(callArgs.options.map((option) => option.label)).toEqual(
+        expectedLabels
+      );
+      expect(
+        callArgs.options.some((option) =>
+          option.label.endsWith('authSchema.ts')
+        )
+      ).toBe(false);
+      expect(selectedTemplateIds).toEqual(presetTemplateIds);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('dedupes duplicate output paths and prefers the initial template ids', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-selection-auth-dedupe-')
+    );
+
+    try {
+      const selectableTemplates: ScaffoldTemplate[] = [
+        {
+          id: 'auth-runtime',
+          path: 'auth.ts',
+          target: 'functions',
+          content: 'runtime',
+          requires: [],
+        },
+        {
+          id: 'auth-runtime-convex',
+          path: 'auth.ts',
+          target: 'functions',
+          content: 'runtime convex',
+          requires: [],
+        },
+        {
+          id: 'auth-client',
+          path: 'convex/auth-client.ts',
+          target: 'client-lib',
+          content: 'client',
+          requires: [],
+        },
+        {
+          id: 'auth-client-convex',
+          path: 'convex/auth-client.ts',
+          target: 'client-lib',
+          content: 'client convex',
+          requires: [],
+        },
+      ];
+      const initialTemplateIds = ['auth-runtime-convex', 'auth-client-convex'];
+      const multiselectPromptStub = mock(
+        async <TValue extends string>(params: {
+          initialValues?: readonly TValue[];
+        }) => params.initialValues ?? []
+      );
+
+      const selectedTemplateIds = await promptForScaffoldTemplateSelection(
+        {
+          multiselect: multiselectPromptStub as any,
+        } as any,
+        { key: 'auth' } as any,
+        selectableTemplates,
+        initialTemplateIds,
+        createRoots(dir)
+      );
+
+      const callArgs = (
+        multiselectPromptStub.mock.calls[0] as unknown[]
+      )[0] as {
+        initialValues: string[];
+        options: Array<{ label: string; value: string }>;
+      };
+      const expectedOptions = [
+        {
+          label: path
+            .relative(
+              process.cwd(),
+              path.join(dir, 'convex', 'functions', 'auth.ts')
+            )
+            .replaceAll('\\', '/'),
+          value: 'auth-runtime-convex',
+        },
+        {
+          label: path
+            .relative(
+              process.cwd(),
+              path.join(dir, 'convex', 'functions', 'convex', 'auth-client.ts')
+            )
+            .replaceAll('\\', '/'),
+          value: 'auth-client-convex',
+        },
+      ];
+
+      expect(callArgs.options).toEqual(expectedOptions);
+      expect(callArgs.initialValues).toEqual(initialTemplateIds);
+      expect(selectedTemplateIds).toEqual(initialTemplateIds);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/kitcn/src/cli/registry/selection.ts
+++ b/packages/kitcn/src/cli/registry/selection.ts
@@ -306,27 +306,82 @@ export const resolveAddTemplateDefaults = (params: {
 export const promptForScaffoldTemplateSelection = async (
   promptAdapter: PromptAdapter,
   descriptor: PluginDescriptor,
-  allTemplates: readonly ScaffoldTemplate[],
-  presetTemplateIds: readonly string[],
+  selectableTemplates: readonly ScaffoldTemplate[],
+  initialTemplateIds: readonly string[],
   roots: ResolvedScaffoldRoots
 ): Promise<string[]> => {
+  const resolveTemplateRootDir = (template: ScaffoldTemplate) => {
+    if (template.target === 'lib') {
+      return roots.libRootDir;
+    }
+    if (template.target === 'app') {
+      return roots.appRootDir ?? roots.functionsRootDir;
+    }
+    if (template.target === 'client-lib') {
+      return roots.clientLibRootDir ?? roots.functionsRootDir;
+    }
+    return roots.functionsRootDir;
+  };
+
+  const resolveTemplateLabel = (template: ScaffoldTemplate) =>
+    normalizePath(
+      relative(
+        process.cwd(),
+        join(resolveTemplateRootDir(template), template.path)
+      )
+    );
+
+  const preferredTemplateIds = new Set(
+    initialTemplateIds
+      .map((templateId) => templateId.trim())
+      .filter((templateId) => templateId.length > 0)
+  );
+  const optionsByLabel = new Map<string, ScaffoldTemplate>();
+  for (const template of selectableTemplates) {
+    const label = resolveTemplateLabel(template);
+    const existing = optionsByLabel.get(label);
+    if (!existing) {
+      optionsByLabel.set(label, template);
+      continue;
+    }
+
+    const existingPreferred = preferredTemplateIds.has(existing.id);
+    const nextPreferred = preferredTemplateIds.has(template.id);
+    if (nextPreferred && !existingPreferred) {
+      optionsByLabel.set(label, template);
+    }
+  }
+
+  const optionTemplateById = new Map(
+    [...optionsByLabel.values()].map(
+      (template) => [template.id, template] as const
+    )
+  );
+  const templateById = new Map(
+    selectableTemplates.map((template) => [template.id, template] as const)
+  );
+  const normalizedInitialTemplateIds = [
+    ...new Set(
+      initialTemplateIds.flatMap((templateId) => {
+        const template = templateById.get(templateId.trim());
+        if (!template) {
+          return [];
+        }
+        const selectedTemplate = optionsByLabel.get(
+          resolveTemplateLabel(template)
+        );
+        return selectedTemplate ? [selectedTemplate.id] : [];
+      })
+    ),
+  ].filter((templateId) => optionTemplateById.has(templateId));
+
   const selected = await promptAdapter.multiselect({
     message: `Select scaffold files for plugin "${descriptor.key}". Space to toggle. Enter to submit.`,
-    options: allTemplates.map((template) => ({
+    options: [...optionsByLabel.entries()].map(([label, template]) => ({
       value: template.id,
-      label: normalizePath(
-        relative(
-          process.cwd(),
-          join(
-            template.target === 'lib'
-              ? roots.libRootDir
-              : roots.functionsRootDir,
-            template.path
-          )
-        )
-      ),
+      label,
     })),
-    initialValues: presetTemplateIds,
+    initialValues: normalizedInitialTemplateIds,
     required: true,
   });
 


### PR DESCRIPTION
## Summary

- limit interactive scaffold selection to templates relevant to the resolved preset
- dedupe scaffold prompt entries by final output path while preserving the preferred selected template
- remove the generated auth demo `callbackURL` redirect so sign-in and sign-up stay on the signed-in view
- add coverage for preset-scoped and deduped scaffold selection behavior
- add a patch changeset for the CLI fixes

## Testing

- Not run (not requested)