### PR TITLE
fix: honor remote convex dev targets

### DIFF
--- a/.changeset/few-emus-laugh.md
+++ b/.changeset/few-emus-laugh.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `kitcn dev` so projects with a remote Convex deployment in `.env.local` keep using that remote target instead of falling back to local Convex.

--- a/docs/solutions/integration-issues/dev-must-honor-remote-convex-deployments-from-env-local-20260404.md
+++ b/docs/solutions/integration-issues/dev-must-honor-remote-convex-deployments-from-env-local-20260404.md
@@ -1,0 +1,90 @@
+---
+title: kitcn dev must honor remote Convex deployments from .env.local
+date: 2026-04-04
+category: integration-issues
+module: cli
+problem_type: integration_issue
+component: development_workflow
+symptoms:
+  - `kitcn dev` prints `Bootstrapping local Convex...` in an app that already has a remote Convex dev deployment in `.env.local`
+  - migrated Convex apps fall back to local runtime behavior without any config change
+  - internal dev follow-up commands (`init`, env sync, migrations, aggregate backfill) stop targeting the remote deployment unless the target is carried explicitly
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+tags:
+  - convex
+  - dev
+  - env-local
+  - remote-deployment
+  - cli
+---
+
+# kitcn dev must honor remote Convex deployments from .env.local
+
+## Problem
+
+`kitcn dev` treated `backend=convex` as shorthand for "use local Convex."
+That breaks migrated Convex apps that already have a real remote dev
+deployment configured in `.env.local`.
+
+## Symptoms
+
+- Running `kitcn dev` in a remote-backed app logs `Bootstrapping local Convex...`
+  even though `.env.local` already contains `CONVEX_DEPLOYMENT`.
+- Direct repro with remote-looking env showed the command taking the local lane
+  immediately.
+- A naive `--env-file .env.local` fix looked promising, but `convex init` and
+  `convex run` do not accept that flag even though `convex dev` does.
+
+## What Didn't Work
+
+- Treating `--env-file .env.local` as a universal Convex target flag.
+  That broke direct repro because `convex init` rejected `--env-file`.
+- Relying on `targetArgs` alone.
+  The existing code only considered explicit CLI target flags like `--prod` or
+  `--deployment-name`, so remote deployments configured through `.env.local`
+  never entered the decision path.
+
+## Solution
+
+Keep the remote deployment target as environment overrides for the internal
+Convex subprocesses instead of trying to force everything through CLI flags.
+
+- Read remote Convex deployment env from `.env.local` only when no explicit
+  Convex target flags are present.
+- Pass those deployment env vars into the internal `convex init`, `convex run`,
+  `convex env`, migration, and aggregate-backfill subprocesses.
+- Keep `convex dev` arguments unchanged.
+- Suppress the misleading `Bootstrapping local Convex...` summary whenever the
+  resolved dev target is remote.
+
+## Why This Works
+
+Convex has two different target contracts:
+
+- `convex dev` accepts `--env-file`
+- `convex init`, `convex run`, and env commands target deployments through env
+  variables
+
+The broken implementation assumed one target transport would work everywhere.
+The fix matches the real CLI behavior instead:
+
+- env-file remains a `convex dev` concern
+- deployment env is what the rest of the subprocess chain consumes
+
+That keeps the whole `kitcn dev` flow pointed at the same remote deployment.
+
+## Prevention
+
+- Do not assume a target flag supported by one Convex subcommand works for all
+  subcommands.
+- Test remote-target dev flows with a real `.env.local` fixture, not just local
+  anonymous deployments.
+- Keep one regression test on `handleDevCommand(...)` proving remote
+  `.env.local` suppresses the local bootstrap lane.
+
+## Related Issues
+
+- [local-bootstrap-first-class-20260324.md](/Users/zbeyens/git/better-convex/docs/solutions/integration-issues/local-bootstrap-first-class-20260324.md)
+- [bootstrap-docs-must-use-latest-remote-cli-but-local-runtime-commands-stay-local-20260331.md](/Users/zbeyens/git/better-convex/docs/solutions/integration-issues/bootstrap-docs-must-use-latest-remote-cli-but-local-runtime-commands-stay-local-20260331.md)

--- a/fixtures/next-auth/app/auth/page.tsx
+++ b/fixtures/next-auth/app/auth/page.tsx
@@ -33,16 +33,11 @@ export default function AuthPage() {
   const isPending =
     signIn.isPending || signUp.isPending || signOut.isPending;
 
-  function getCallbackURL() {
-    return '/auth';
-  }
-
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     if (mode === 'signup') {
       signUp.mutate({
-        callbackURL: getCallbackURL(),
         email,
         name,
         password,
@@ -51,7 +46,6 @@ export default function AuthPage() {
     }
 
     signIn.mutate({
-      callbackURL: getCallbackURL(),
       email,
       password,
     });

--- a/packages/kitcn/src/cli/backend-core.ts
+++ b/packages/kitcn/src/cli/backend-core.ts
@@ -835,6 +835,7 @@ const CONVEX_DEPLOYMENT_ENV_KEYS = [
   'CONVEX_SELF_HOSTED_URL',
   'CONVEX_SELF_HOSTED_ADMIN_KEY',
 ] as const;
+const LOCAL_CONVEX_DEPLOYMENT_PREFIXES = ['local:', 'anonymous:'] as const;
 
 export function createBackendCommandEnv(
   overrides?: Record<string, string | undefined>
@@ -847,6 +848,63 @@ export function createBackendCommandEnv(
     ...clearedDeploymentEnv,
     ...overrides,
   };
+}
+
+export function hasRemoteConvexDeploymentEnv(
+  env: Record<string, string | undefined>
+): boolean {
+  const deployment = env.CONVEX_DEPLOYMENT?.trim();
+  if (
+    deployment &&
+    !LOCAL_CONVEX_DEPLOYMENT_PREFIXES.some((prefix) =>
+      deployment.startsWith(prefix)
+    )
+  ) {
+    return true;
+  }
+
+  return Boolean(
+    env.CONVEX_DEPLOY_KEY?.trim() ||
+      env.CONVEX_SELF_HOSTED_URL?.trim() ||
+      env.CONVEX_SELF_HOSTED_ADMIN_KEY?.trim()
+  );
+}
+
+function readConvexTargetEnvFile(
+  args: string[],
+  cwd = process.cwd()
+): Record<string, string> | null {
+  const envFile = readOptionalCliFlagValue(args, '--env-file');
+  if (!envFile) {
+    return null;
+  }
+
+  const envFilePath = resolve(cwd, envFile);
+  if (!fs.existsSync(envFilePath)) {
+    return null;
+  }
+
+  return parseDotEnv(fs.readFileSync(envFilePath, 'utf8'));
+}
+
+function resolveRemoteConvexDeploymentKey(
+  env: Record<string, string | undefined>
+): string | null {
+  if (!hasRemoteConvexDeploymentEnv(env)) {
+    return null;
+  }
+
+  const deployment = env.CONVEX_DEPLOYMENT?.trim();
+  if (deployment) {
+    return `deployment-env:${deployment}`;
+  }
+
+  const selfHostedUrl = env.CONVEX_SELF_HOSTED_URL?.trim();
+  if (selfHostedUrl) {
+    return `self-hosted-env:${selfHostedUrl}`;
+  }
+
+  return 'remote-env';
 }
 
 async function withLocalConvexEnv<T>(
@@ -3499,7 +3557,11 @@ function writeAggregateFingerprintState(
   fs.renameSync(tmpPath, statePath);
 }
 
-export function getAggregateBackfillDeploymentKey(args: string[]): string {
+export function getAggregateBackfillDeploymentKey(
+  args: string[],
+  cwd = process.cwd(),
+  env?: Record<string, string | undefined>
+): string {
   if (args.includes('--prod')) {
     return 'prod';
   }
@@ -3512,6 +3574,19 @@ export function getAggregateBackfillDeploymentKey(args: string[]): string {
   const previewName = readOptionalCliFlagValue(args, '--preview-name');
   if (previewName) {
     return `preview:${previewName}`;
+  }
+
+  const envKey = env ? resolveRemoteConvexDeploymentKey(env) : null;
+  if (envKey) {
+    return envKey;
+  }
+
+  const envFileVars = readConvexTargetEnvFile(args, cwd);
+  if (envFileVars) {
+    const envFileKey = resolveRemoteConvexDeploymentKey(envFileVars);
+    if (envFileKey) {
+      return envFileKey;
+    }
   }
 
   return 'local';
@@ -3913,17 +3988,6 @@ function didConvexInitCreateConfiguration(output: string) {
   return CONVEX_INIT_CREATED_CONFIG_RE.test(output);
 }
 
-function hasRemoteConvexInitTargetArgs(targetArgs?: string[]) {
-  return (
-    targetArgs?.some(
-      (arg) =>
-        arg === '--prod' ||
-        arg === '--preview-name' ||
-        arg === '--deployment-name'
-    ) ?? false
-  );
-}
-
 export async function runConvexInitIfNeeded(params: {
   execaFn: typeof execa;
   backendAdapter: BackendAdapter;
@@ -3947,7 +4011,12 @@ export async function runConvexInitIfNeeded(params: {
   }
 
   const shouldUseAnonymousAgentMode =
-    params.yes && !hasRemoteConvexInitTargetArgs(params.targetArgs);
+    params.yes &&
+    getAggregateBackfillDeploymentKey(
+      params.targetArgs ?? [],
+      process.cwd(),
+      params.env
+    ) === 'local';
   const agentModeOverride = shouldUseAnonymousAgentMode
     ? 'anonymous'
     : params.env?.CONVEX_AGENT_MODE;
@@ -4898,6 +4967,7 @@ export async function runBackendFunction(
   targetArgs: string[],
   options?: {
     echoOutput?: boolean;
+    env?: Record<string, string | undefined>;
   }
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const result = await execaFn(
@@ -4911,7 +4981,7 @@ export async function runBackendFunction(
     ],
     {
       cwd: process.cwd(),
-      env: createBackendCommandEnv(),
+      env: createBackendCommandEnv(options?.env),
       reject: false,
       stdio: 'pipe',
     }
@@ -4941,6 +5011,7 @@ export async function runAggregateBackfillFlow(params: {
   backfillConfig: AggregateBackfillConfig;
   mode: 'resume' | 'rebuild';
   targetArgs: string[];
+  env?: Record<string, string | undefined>;
   signal?: AbortSignal;
   context: 'deploy' | 'dev' | 'aggregate';
 }): Promise<number> {
@@ -4950,6 +5021,7 @@ export async function runAggregateBackfillFlow(params: {
     backfillConfig,
     mode,
     targetArgs,
+    env,
     signal,
     context,
   } = params;
@@ -4972,6 +5044,7 @@ export async function runAggregateBackfillFlow(params: {
     targetArgs,
     {
       echoOutput: false,
+      env,
     }
   );
 
@@ -5061,6 +5134,7 @@ export async function runAggregateBackfillFlow(params: {
       targetArgs,
       {
         echoOutput: false,
+        env,
       }
     );
     if (statusResult.exitCode !== 0) {
@@ -5307,6 +5381,7 @@ export async function runMigrationFlow(params: {
   backendAdapter: BackendAdapter;
   migrationConfig: MigrationConfig;
   targetArgs: string[];
+  env?: Record<string, string | undefined>;
   signal?: AbortSignal;
   context: 'deploy' | 'dev' | 'migration';
   direction: 'up' | 'down';
@@ -5318,6 +5393,7 @@ export async function runMigrationFlow(params: {
     backendAdapter,
     migrationConfig,
     targetArgs,
+    env,
     signal,
     context,
     direction,
@@ -5342,6 +5418,7 @@ export async function runMigrationFlow(params: {
     targetArgs,
     {
       echoOutput: false,
+      env,
     }
   );
 
@@ -5439,6 +5516,7 @@ export async function runMigrationFlow(params: {
       targetArgs,
       {
         echoOutput: false,
+        env,
       }
     );
     if (statusResult.exitCode !== 0) {
@@ -5520,6 +5598,7 @@ export async function runDevSchemaBackfillIfNeeded(params: {
   backfillConfig: AggregateBackfillConfig;
   functionsDir: string;
   targetArgs: string[];
+  env?: Record<string, string | undefined>;
   signal: AbortSignal;
 }): Promise<number> {
   const {
@@ -5528,6 +5607,7 @@ export async function runDevSchemaBackfillIfNeeded(params: {
     backfillConfig,
     functionsDir,
     targetArgs,
+    env,
     signal,
   } = params;
   const fingerprint = await computeAggregateIndexFingerprint(functionsDir);
@@ -5535,7 +5615,11 @@ export async function runDevSchemaBackfillIfNeeded(params: {
     return 0;
   }
 
-  const deploymentKey = getAggregateBackfillDeploymentKey(targetArgs);
+  const deploymentKey = getAggregateBackfillDeploymentKey(
+    targetArgs,
+    process.cwd(),
+    env
+  );
   const statePath = getDevAggregateBackfillStatePath();
   const state = readAggregateFingerprintState(statePath);
   const existing = state.entries[deploymentKey];
@@ -5553,6 +5637,7 @@ export async function runDevSchemaBackfillIfNeeded(params: {
     },
     mode: 'resume',
     targetArgs,
+    env,
     signal,
     context: 'dev',
   });

--- a/packages/kitcn/src/cli/cli.commands.ts
+++ b/packages/kitcn/src/cli/cli.commands.ts
@@ -1775,7 +1775,8 @@ describe('cli/cli', () => {
         path.join(dir, 'app', 'auth', 'page.tsx'),
         'utf8'
       );
-      expect(authPageSource).toContain("return '/auth';");
+      expect(authPageSource).not.toContain("return '/auth';");
+      expect(authPageSource).not.toContain('callbackURL:');
       expect(authPageSource).not.toContain('NEXT_PUBLIC_SITE_URL');
 
       const schemaSource = fs.readFileSync(
@@ -2856,6 +2857,29 @@ describe('cli/cli', () => {
       getAggregateBackfillDeploymentKey(['--preview-name=feature-123'])
     ).toBe('preview:feature-123');
     expect(getAggregateBackfillDeploymentKey([])).toBe('local');
+  });
+
+  test('getAggregateBackfillDeploymentKey resolves remote env-file targets', () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-cli-dev-env-file-target-')
+    );
+    const remoteEnvPath = path.join(dir, '.env.remote');
+    const localEnvPath = path.join(dir, '.env.local');
+    fs.writeFileSync(
+      remoteEnvPath,
+      'CONVEX_DEPLOYMENT=dev:remote-app\nNEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud\n'
+    );
+    fs.writeFileSync(
+      localEnvPath,
+      'CONVEX_DEPLOYMENT=local:demo\nNEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210\n'
+    );
+
+    expect(
+      getAggregateBackfillDeploymentKey(['--env-file', '.env.remote'], dir)
+    ).toBe('deployment-env:dev:remote-app');
+    expect(
+      getAggregateBackfillDeploymentKey(['--env-file', '.env.local'], dir)
+    ).toBe('local');
   });
 
   test('getDevAggregateBackfillStatePath lives under .convex', () => {
@@ -6375,7 +6399,7 @@ describe('cli/cli', () => {
       expect(calls.length).toBe(3);
       expect(calls[0]).toEqual({
         cmd: 'node',
-        args: ['/fake/convex/main.js', 'init', '--env-file', '.env.agent'],
+        args: ['/fake/convex/main.js', 'init'],
         opts: {
           cwd: process.cwd(),
           env: expect.objectContaining({
@@ -6390,7 +6414,7 @@ describe('cli/cli', () => {
         force: true,
         sharedDir: 'out',
         silent: true,
-        targetArgs: ['--env-file', '.env.agent'],
+        targetArgs: [],
       });
 
       expect(calls[1].cmd).toBe('bun');

--- a/packages/kitcn/src/cli/commands/dev.test.ts
+++ b/packages/kitcn/src/cli/commands/dev.test.ts
@@ -9,6 +9,7 @@ import {
   resolveConcaveLocalDevContract,
   resolveConcaveLocalSiteUrl,
   resolveDevStartupRetryDelayMs,
+  resolveImplicitConvexRemoteDeploymentEnv,
   resolveSupportedLocalNodeEnvOverrides,
   resolveWatcherCommand,
   runDevStartupRetryLoop,
@@ -201,6 +202,36 @@ describe('cli/commands/dev', () => {
 
     expect(resolveConcaveLocalSiteUrl(viteDir)).toBe('http://localhost:4020');
     expect(resolveConcaveLocalSiteUrl(emptyDir)).toBe('http://localhost:3000');
+  });
+
+  test('resolveImplicitConvexRemoteDeploymentEnv reads remote deployment env from .env.local only', () => {
+    const remoteDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-dev-implicit-remote-')
+    );
+    const localDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-dev-implicit-local-')
+    );
+    const emptyDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-dev-implicit-empty-')
+    );
+
+    fs.writeFileSync(
+      path.join(remoteDir, '.env.local'),
+      'CONVEX_DEPLOYMENT=dev:remote-app\nNEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud\n'
+    );
+    fs.writeFileSync(
+      path.join(localDir, '.env.local'),
+      'CONVEX_DEPLOYMENT=local:demo\nNEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210\n'
+    );
+
+    expect(resolveImplicitConvexRemoteDeploymentEnv(remoteDir)).toEqual({
+      CONVEX_DEPLOYMENT: 'dev:remote-app',
+      CONVEX_DEPLOY_KEY: undefined,
+      CONVEX_SELF_HOSTED_ADMIN_KEY: undefined,
+      CONVEX_SELF_HOSTED_URL: undefined,
+    });
+    expect(resolveImplicitConvexRemoteDeploymentEnv(localDir)).toBeNull();
+    expect(resolveImplicitConvexRemoteDeploymentEnv(emptyDir)).toBeNull();
   });
 
   test('resolveConcaveLocalDevContract defaults concave dev to Convex local ports', () => {
@@ -581,6 +612,215 @@ describe('cli/commands/dev', () => {
     } finally {
       process.chdir(oldCwd);
       stderrSpy.mockRestore();
+    }
+  });
+
+  test('handleDevCommand uses remote .env.local deployment targets instead of local bootstrap defaults', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-dev-remote-env-local-')
+    );
+    const oldCwd = process.cwd();
+    const onSpy = spyOn(process, 'on').mockImplementation(() => process as any);
+    fs.mkdirSync(path.join(dir, 'convex', 'shared'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(dir, '.env.local'),
+      'CONVEX_DEPLOYMENT=dev:remote-app\nNEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud\n'
+    );
+
+    const watcherProcess = createPendingProcess();
+    const convexProcess = createPersistentProcess();
+    const execaCalls: Array<{ cmd: string; args: string[]; opts?: any }> = [];
+    const execaStub = mock((cmd: string, args: string[], opts?: any): any => {
+      execaCalls.push({ cmd, args, opts });
+      if (cmd === 'bun' && (args[0] as string).endsWith('/watcher.ts')) {
+        return watcherProcess.process;
+      }
+      if (args[1] === 'init') {
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+      }
+      return convexProcess.process;
+    });
+    const generateMetaStub = mock(async () => {});
+    const syncEnvStub = mock(async () => {});
+    const loadConfigStub = mock(() => ({
+      ...createDefaultConfig(),
+      dev: {
+        ...createDefaultConfig().dev,
+        aggregateBackfill: {
+          ...createDefaultConfig().dev.aggregateBackfill,
+          enabled: 'off' as const,
+        },
+        migrations: {
+          ...createDefaultConfig().dev.migrations,
+          enabled: 'off' as const,
+        },
+      },
+    }));
+    const infoMessages: string[] = [];
+    const originalInfo = console.info;
+    console.info = (...args: unknown[]) => {
+      infoMessages.push(args.join(' '));
+    };
+
+    process.chdir(dir);
+
+    try {
+      const runPromise = handleDevCommand(['dev', '--once'], {
+        realConvex: '/fake/convex/main.js',
+        execa: execaStub as any,
+        generateMeta: generateMetaStub as any,
+        syncEnv: syncEnvStub as any,
+        loadCliConfig: loadConfigStub as any,
+      } as any);
+
+      await waitFor(() => execaCalls.some(({ args }) => args[1] === 'dev'));
+
+      convexProcess.emitStdout('13:35:25 Convex functions ready! (1.22s)\n');
+      convexProcess.resolveExit({ exitCode: 0 });
+
+      const exitCode = await runPromise;
+
+      expect(exitCode).toBe(0);
+      expect(execaCalls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            args: ['/fake/convex/main.js', 'init'],
+            opts: expect.objectContaining({
+              env: expect.objectContaining({
+                CONVEX_DEPLOYMENT: 'dev:remote-app',
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            args: ['/fake/convex/main.js', 'dev', '--once'],
+            opts: expect.objectContaining({
+              env: expect.objectContaining({
+                CONVEX_DEPLOYMENT: 'dev:remote-app',
+              }),
+            }),
+          }),
+        ])
+      );
+      expect(syncEnvStub).not.toHaveBeenCalled();
+      expect(
+        infoMessages.some((line) => line.includes('Bootstrapping local Convex'))
+      ).toBe(false);
+    } finally {
+      console.info = originalInfo;
+      process.chdir(oldCwd);
+      onSpy.mockRestore();
+    }
+  });
+
+  test('handleDevCommand keeps explicit --env-file targets for convex dev and reuses their deployment env internally', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-dev-explicit-env-file-')
+    );
+    const oldCwd = process.cwd();
+    const onSpy = spyOn(process, 'on').mockImplementation(() => process as any);
+    fs.mkdirSync(path.join(dir, 'convex', 'shared'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(dir, 'convex', '.env'),
+      'SITE_URL=http://localhost:3000\n'
+    );
+    fs.writeFileSync(
+      path.join(dir, '.env.agent'),
+      'CONVEX_DEPLOYMENT=dev:explicit-remote\nNEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud\n'
+    );
+
+    const watcherProcess = createPendingProcess();
+    const convexProcess = createPersistentProcess();
+    const execaCalls: Array<{ cmd: string; args: string[]; opts?: any }> = [];
+    const execaStub = mock((cmd: string, args: string[], opts?: any): any => {
+      execaCalls.push({ cmd, args, opts });
+      if (cmd === 'bun' && (args[0] as string).endsWith('/watcher.ts')) {
+        return watcherProcess.process;
+      }
+      if (args[1] === 'init') {
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+      }
+      return convexProcess.process;
+    });
+    const generateMetaStub = mock(async () => {});
+    const syncEnvStub = mock(async () => {});
+    const loadConfigStub = mock(() => ({
+      ...createDefaultConfig(),
+      dev: {
+        ...createDefaultConfig().dev,
+        args: ['--env-file', '.env.agent'],
+        aggregateBackfill: {
+          ...createDefaultConfig().dev.aggregateBackfill,
+          enabled: 'off' as const,
+        },
+        migrations: {
+          ...createDefaultConfig().dev.migrations,
+          enabled: 'off' as const,
+        },
+      },
+    }));
+
+    process.chdir(dir);
+
+    try {
+      const runPromise = handleDevCommand(['dev', '--once'], {
+        realConvex: '/fake/convex/main.js',
+        execa: execaStub as any,
+        generateMeta: generateMetaStub as any,
+        syncEnv: syncEnvStub as any,
+        loadCliConfig: loadConfigStub as any,
+      } as any);
+
+      await waitFor(() => execaCalls.some(({ args }) => args[1] === 'dev'));
+
+      convexProcess.emitStdout('13:35:25 Convex functions ready! (1.22s)\n');
+      convexProcess.resolveExit({ exitCode: 0 });
+
+      const exitCode = await runPromise;
+
+      expect(exitCode).toBe(0);
+      expect(execaCalls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            args: ['/fake/convex/main.js', 'init'],
+            opts: expect.objectContaining({
+              env: expect.objectContaining({
+                CONVEX_DEPLOYMENT: 'dev:explicit-remote',
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            args: [
+              '/fake/convex/main.js',
+              'dev',
+              '--env-file',
+              '.env.agent',
+              '--once',
+            ],
+            opts: expect.objectContaining({
+              env: expect.objectContaining({
+                CONVEX_DEPLOYMENT: 'dev:explicit-remote',
+              }),
+            }),
+          }),
+        ])
+      );
+      expect(syncEnvStub).toHaveBeenCalledWith({
+        authSyncMode: 'skip',
+        commandEnv: expect.objectContaining({
+          CONVEX_DEPLOYMENT: 'dev:explicit-remote',
+        }),
+        force: true,
+        sharedDir: 'convex/shared',
+        silent: true,
+        targetArgs: [],
+      });
+    } finally {
+      process.chdir(oldCwd);
+      onSpy.mockRestore();
     }
   });
 

--- a/packages/kitcn/src/cli/commands/dev.ts
+++ b/packages/kitcn/src/cli/commands/dev.ts
@@ -13,6 +13,8 @@ import {
   extractBackfillCliOptions,
   extractConcaveRunTargetArgs,
   extractMigrationCliOptions,
+  getAggregateBackfillDeploymentKey,
+  hasRemoteConvexDeploymentEnv,
   isConvexDevPreRunConflictFlag,
   parseArgs,
   type RunDeps,
@@ -660,6 +662,82 @@ export function resolveConcaveLocalSiteUrl(cwd = process.cwd()): string {
   );
 }
 
+export function resolveImplicitConvexRemoteDeploymentEnv(
+  cwd = process.cwd()
+): Record<string, string | undefined> | null {
+  const envLocalPath = join(cwd, '.env.local');
+  if (!fs.existsSync(envLocalPath)) {
+    return null;
+  }
+
+  const parsed = parseEnv(fs.readFileSync(envLocalPath, 'utf8'));
+  if (!hasRemoteConvexDeploymentEnv(parsed)) {
+    return null;
+  }
+
+  return {
+    CONVEX_DEPLOYMENT: parsed.CONVEX_DEPLOYMENT,
+    CONVEX_DEPLOY_KEY: parsed.CONVEX_DEPLOY_KEY,
+    CONVEX_SELF_HOSTED_URL: parsed.CONVEX_SELF_HOSTED_URL,
+    CONVEX_SELF_HOSTED_ADMIN_KEY: parsed.CONVEX_SELF_HOSTED_ADMIN_KEY,
+  };
+}
+
+function resolveConvexEnvFileCommandEnv(
+  args: string[],
+  cwd = process.cwd()
+): Record<string, string | undefined> | null {
+  let envFilePath: string | null = null;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--env-file') {
+      envFilePath = args[i + 1] ?? null;
+      break;
+    }
+    if (arg.startsWith('--env-file=')) {
+      envFilePath = arg.slice('--env-file='.length) || null;
+      break;
+    }
+  }
+
+  if (!envFilePath) {
+    return null;
+  }
+
+  const resolvedPath = resolve(cwd, envFilePath);
+  if (!fs.existsSync(resolvedPath)) {
+    return null;
+  }
+
+  const parsed = parseEnv(fs.readFileSync(resolvedPath, 'utf8'));
+  return {
+    CONVEX_DEPLOYMENT: parsed.CONVEX_DEPLOYMENT,
+    CONVEX_DEPLOY_KEY: parsed.CONVEX_DEPLOY_KEY,
+    CONVEX_SELF_HOSTED_URL: parsed.CONVEX_SELF_HOSTED_URL,
+    CONVEX_SELF_HOSTED_ADMIN_KEY: parsed.CONVEX_SELF_HOSTED_ADMIN_KEY,
+  };
+}
+
+function stripConvexEnvFileTargetArgs(args: string[]): string[] {
+  const nextArgs: string[] = [];
+  let skipNext = false;
+  for (const arg of args) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (arg === '--env-file') {
+      skipNext = true;
+      continue;
+    }
+    if (arg.startsWith('--env-file=')) {
+      continue;
+    }
+    nextArgs.push(arg);
+  }
+  return nextArgs;
+}
+
 export const resolveWatcherCommand = (
   currentFilename = __filename,
   currentDir = __dirname
@@ -992,6 +1070,20 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
   assertNoRemovedDevPreRunFlag(config.dev.args);
   const { bootstrap, remainingArgs: convexDevArgs } =
     extractDevBootstrapCliFlag([...config.dev.args, ...devCommandArgs]);
+  const explicitConvexTargetArgs = extractBackendRunTargetArgs(
+    'convex',
+    convexDevArgs
+  );
+  const explicitConvexCommandEnv =
+    resolveConvexEnvFileCommandEnv(convexDevArgs);
+  const implicitConvexCommandEnv =
+    backend === 'convex' &&
+    explicitConvexTargetArgs.length === 0 &&
+    explicitConvexCommandEnv === null
+      ? resolveImplicitConvexRemoteDeploymentEnv()
+      : null;
+  const effectiveConvexCommandEnv =
+    explicitConvexCommandEnv ?? implicitConvexCommandEnv;
   const preRunFunction = config.dev.preRun;
   if (bootstrap && backend !== 'convex') {
     throw new Error(
@@ -1045,7 +1137,9 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
       : 'filtered';
   const targetArgs =
     concaveLocalDevContract?.targetArgs ??
-    extractBackendRunTargetArgs(backend, convexDevArgs);
+    stripConvexEnvFileTargetArgs(
+      extractBackendRunTargetArgs(backend, convexDevArgs)
+    );
   const trimSegments = resolveCodegenTrimSegments(config);
   const localNodeEnvOverrides =
     backend === 'convex'
@@ -1054,7 +1148,16 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
         })
       : {};
 
-  if (!bootstrap && backend === 'convex' && !debug) {
+  if (
+    !bootstrap &&
+    backend === 'convex' &&
+    !debug &&
+    getAggregateBackfillDeploymentKey(
+      targetArgs,
+      process.cwd(),
+      effectiveConvexCommandEnv ?? undefined
+    ) === 'local'
+  ) {
     logger.info('Bootstrapping local Convex...');
   }
 
@@ -1088,7 +1191,10 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
     execaFn,
     backendAdapter,
     echoOutput: false,
-    env: localNodeEnvOverrides,
+    env: {
+      ...localNodeEnvOverrides,
+      ...effectiveConvexCommandEnv,
+    },
     targetArgs,
   });
   if (convexInitResult.exitCode !== 0) {
@@ -1111,6 +1217,7 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
   ) {
     await syncEnvFn({
       authSyncMode: authEnvState.installed ? 'prepare' : 'skip',
+      commandEnv: effectiveConvexCommandEnv ?? undefined,
       force: true,
       sharedDir,
       silent: true,
@@ -1155,6 +1262,7 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
       cwd: process.cwd(),
       env: createBackendCommandEnv({
         ...localNodeEnvOverrides,
+        ...effectiveConvexCommandEnv,
         ...concaveLocalDevContract?.backendEnv,
       }),
       reject: false,
@@ -1180,6 +1288,7 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
             runTask: () =>
               syncEnvFn({
                 authSyncMode: 'complete',
+                commandEnv: effectiveConvexCommandEnv ?? undefined,
                 force: true,
                 sharedDir,
                 silent: true,
@@ -1206,6 +1315,7 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
         backendAdapter,
         backfillConfig: devBackfillConfig,
         functionsDir,
+        env: effectiveConvexCommandEnv ?? undefined,
         targetArgs,
         signal: backfillAbortController.signal,
       });
@@ -1254,6 +1364,7 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
       await authEnvSyncPromise;
       await syncEnvFn({
         authSyncMode: 'auto',
+        commandEnv: effectiveConvexCommandEnv ?? undefined,
         force: true,
         sharedDir,
         silent: true,
@@ -1296,6 +1407,7 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
             runMigrationFlow({
               execaFn,
               backendAdapter,
+              env: effectiveConvexCommandEnv ?? undefined,
               migrationConfig: devMigrationConfig,
               targetArgs,
               signal: backfillAbortController.signal,
@@ -1334,6 +1446,7 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
               execaFn,
               backendAdapter,
               backfillConfig: devBackfillConfig,
+              env: effectiveConvexCommandEnv ?? undefined,
               mode: 'resume',
               targetArgs,
               signal: backfillAbortController.signal,

--- a/packages/kitcn/src/cli/env.ts
+++ b/packages/kitcn/src/cli/env.ts
@@ -12,6 +12,7 @@ import { logger } from './utils/logger.js';
 
 export interface PushOptions {
   authSyncMode?: 'auto' | 'prepare' | 'complete' | 'skip';
+  commandEnv?: Record<string, string | undefined>;
   force?: boolean;
   fromFilePath?: string;
   rotate?: boolean;
@@ -22,6 +23,7 @@ export interface PushOptions {
 }
 
 export interface PullOptions {
+  commandEnv?: Record<string, string | undefined>;
   outFilePath?: string;
   targetArgs?: string[];
 }
@@ -32,7 +34,11 @@ type CommandResult = {
   stdout: string;
 };
 
-type RunCommand = (args: string[], cwd: string) => Promise<CommandResult>;
+type RunCommand = (
+  args: string[],
+  cwd: string,
+  env?: Record<string, string | undefined>
+) => Promise<CommandResult>;
 
 type PushEnvDeps = {
   runCommand?: RunCommand;
@@ -65,8 +71,9 @@ const CONVEX_MANAGED_ENV_KEYS = new Set([
 
 const defaultRunCommand: RunCommand = async (
   args: string[],
-  cwd: string
-): Promise<CommandResult> => runLocalConvexCommand(args, { cwd });
+  cwd: string,
+  env?: Record<string, string | undefined>
+): Promise<CommandResult> => runLocalConvexCommand(args, { cwd, env });
 
 export const generateAuthSecret = () => randomBytes(32).toString('base64url');
 
@@ -184,9 +191,10 @@ const ensureAuthSecret = (params: {
 const runConvexCommand = async (
   runCommand: RunCommand,
   cwd: string,
-  args: string[]
+  args: string[],
+  env?: Record<string, string | undefined>
 ) => {
-  const result = await runCommand(args, cwd);
+  const result = await runCommand(args, cwd, env);
   if (result.exitCode !== 0) {
     throw new Error(formatConvexCommandFailure(args, result));
   }
@@ -290,6 +298,7 @@ export async function pushEnv(
   const rotate = options.rotate ?? false;
   const silent = options.silent ?? false;
   const targetArgs = options.targetArgs ?? [];
+  const commandEnv = options.commandEnv;
   const runCommand = deps.runCommand ?? defaultRunCommand;
   const secretGenerator = deps.secretGenerator ?? defaultSecretGenerator;
   const envPath = path.join(cwd, 'convex', '.env');
@@ -331,7 +340,8 @@ export async function pushEnv(
           envFilePath: tempEnvPath,
           force,
           targetArgs,
-        })
+        }),
+        commandEnv
       );
       return true;
     } finally {
@@ -386,20 +396,22 @@ export async function pushEnv(
     });
     ensureManagedAuthSecret();
     if (rotate) {
-      await runConvexCommand(runCommand, cwd, [
-        'run',
-        AUTH_ROTATE_KEYS_FUNCTION,
-        ...targetArgs,
-      ]);
+      await runConvexCommand(
+        runCommand,
+        cwd,
+        ['run', AUTH_ROTATE_KEYS_FUNCTION, ...targetArgs],
+        commandEnv
+      );
       if (!silent) {
         logger.info('Rotated auth keys.');
       }
     }
-    const jwksResult = await runConvexCommand(runCommand, cwd, [
-      'run',
-      AUTH_JWKS_FUNCTION,
-      ...targetArgs,
-    ]);
+    const jwksResult = await runConvexCommand(
+      runCommand,
+      cwd,
+      ['run', AUTH_JWKS_FUNCTION, ...targetArgs],
+      commandEnv
+    );
     nextVars.JWKS = parseConvexRunValue(jwksResult.stdout);
     await finalizePush();
     return;
@@ -420,21 +432,23 @@ export async function pushEnv(
   }
 
   if (rotate) {
-    await runConvexCommand(runCommand, cwd, [
-      'run',
-      AUTH_ROTATE_KEYS_FUNCTION,
-      ...targetArgs,
-    ]);
+    await runConvexCommand(
+      runCommand,
+      cwd,
+      ['run', AUTH_ROTATE_KEYS_FUNCTION, ...targetArgs],
+      commandEnv
+    );
     if (!silent) {
       logger.info('Rotated auth keys.');
     }
   }
 
-  const jwksResult = await runConvexCommand(runCommand, cwd, [
-    'run',
-    AUTH_JWKS_FUNCTION,
-    ...targetArgs,
-  ]);
+  const jwksResult = await runConvexCommand(
+    runCommand,
+    cwd,
+    ['run', AUTH_JWKS_FUNCTION, ...targetArgs],
+    commandEnv
+  );
   nextVars.JWKS = parseConvexRunValue(jwksResult.stdout);
   await finalizePush();
 }
@@ -446,11 +460,13 @@ export async function pullEnv(
   const cwd = process.cwd();
   const runCommand = deps.runCommand ?? defaultRunCommand;
   const targetArgs = options.targetArgs ?? [];
-  const result = await runConvexCommand(runCommand, cwd, [
-    'env',
-    'list',
-    ...targetArgs,
-  ]);
+  const commandEnv = options.commandEnv;
+  const result = await runConvexCommand(
+    runCommand,
+    cwd,
+    ['env', 'list', ...targetArgs],
+    commandEnv
+  );
 
   if (options.outFilePath) {
     const outputPath = path.resolve(cwd, options.outFilePath);


### PR DESCRIPTION
## Summary
- honor remote Convex deployments from `.env.local` during `kitcn dev` instead of silently falling back to the local Convex lane
- carry the resolved deployment env through internal Convex subprocesses used by dev init, env sync, migrations, and aggregate backfill
- add regression coverage for implicit remote `.env.local` targets and explicit `--env-file` targets, plus a changeset and solution note
- sync the `next-auth` fixture to the current auth page output so the repo gate matches the generated scaffold

## Verification
- `bun check`
- direct built-CLI repro against a temp app with fake remote `.env.local` config: `kitcn dev --once` no longer logged `Bootstrapping local Convex...` and instead hit Convex's remote-login path
