### PR TITLE
fix: reset auth cache and split auth e2e lane

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -38,6 +38,7 @@
 - After any `init -t` template or scaffold change, you must rerun `bun run fixtures:sync` and `bun run fixtures:check`. No exceptions.
 - For manual runtime, never run committed `fixtures/**` in place. Materialize a tmp app with `bun run scenario:prepare <name>` and run it from `tmp/scenarios/<name>/project`, or use `bun run scenario:dev <name>`.
 - Use @.agents/rules/scenarios.mdc for fixture and scenario runtime proof. It owns when to stop at `scenario:dev`, when to add `test:auth` or `test:e2e`, and when `scenario:check` is the only honest lane.
+- Default `bun check` must not depend on auth browser E2E. Treat `test:e2e` as an auth-specific lane only. Run it when the diff touches auth runtime/client/provider/query-invalidation surfaces or auth demo scaffolds.
 - If `bun run fixtures:sync` dies with Convex/esbuild `EPIPE`, `The service was stopped`, or `Timed out waiting for local Convex bootstrap`, kill stale workers first: `pkill -f 'convex/bin/main.js codegen' || true; pkill -f 'convex/bin/main.js dev' || true; pkill -f '@esbuild/.*/bin/esbuild --service' || true`, then rerun sync once. If `ps` still shows an esbuild worker stuck in `U` state after `kill -9`, stop bullshitting and reboot — that machine state is wedged.
 - After every template/scaffold change, verify with `bun run fixtures:sync`, `bun run fixtures:check`, and prepared scenario apps under `tmp/scenarios/**`. Do not touch `example/` unless the user explicitly asks.
 - Prefer inline Zod schemas when used once; extract constants only when reused.

--- a/.agents/rules/scenarios.mdc
+++ b/.agents/rules/scenarios.mdc
@@ -45,7 +45,10 @@ bun run test:e2e -- <name|url>
 
 `test:auth` and `test:e2e` assume the scenario is already running.
 `scenario:test` wraps the proof matrix below.
-`test:runtime` runs `scenario:test -- all` and is the full runtime gate.
+`test:runtime` runs `scenario:test -- all` and is the default non-browser
+runtime gate.
+`test:e2e` is a separate auth browser lane and should be run only when auth
+surfaces changed.
 
 ## Proof Matrix
 
@@ -75,22 +78,26 @@ Or:
 Use this path for:
 
 - `next-auth`
+- `start-auth`
 
 Run:
 
-1. `bun run scenario:prepare -- next-auth`
-2. `bun run scenario:dev -- next-auth`
-3. `bun run test:auth -- next-auth`
-4. `bun run test:e2e -- next-auth`
-5. Stop.
+1. `bun run scenario:prepare -- <next-auth|start-auth>`
+2. `bun run scenario:dev -- <next-auth|start-auth>`
+3. `bun run test:auth -- <next-auth|start-auth>`
+4. Stop.
 
 Or:
 
-1. `bun run scenario:test -- next-auth`
+1. `bun run scenario:test -- <next-auth|start-auth>`
 
 Why:
 
-- `next-auth` is the only scenario with a real auth browser surface today.
+- `scenario:test -- <next-auth|start-auth>` proves runtime + auth smoke only.
+- Browser auth proof belongs to the explicit `test:e2e` lane:
+  1. `bun run scenario:prepare -- <next-auth|start-auth>`
+  2. `bun run scenario:dev -- <next-auth|start-auth>`
+  3. `bun run test:e2e -- <next-auth|start-auth>`
 
 ### Auth backend proof without browser auth
 
@@ -156,19 +163,26 @@ Otherwise, reuse the prepared app.
 
 ## Examples
 
-### `next-auth`
+### `next-auth` or `start-auth`
 
 ```bash
 bun run scenario:prepare -- next-auth
 bun run scenario:dev -- next-auth
 bun run test:auth -- next-auth
-bun run test:e2e -- next-auth
 ```
 
 Short path:
 
 ```bash
 bun run scenario:test -- next-auth
+```
+
+Browser lane:
+
+```bash
+bun run scenario:prepare -- next-auth
+bun run scenario:dev -- next-auth
+bun run test:e2e -- next-auth
 ```
 
 ### `vite-auth`

--- a/.agents/skills/scenarios/SKILL.md
+++ b/.agents/skills/scenarios/SKILL.md
@@ -49,7 +49,10 @@ bun run test:e2e -- <name|url>
 
 `test:auth` and `test:e2e` assume the scenario is already running.
 `scenario:test` wraps the proof matrix below.
-`test:runtime` runs `scenario:test -- all` and is the full runtime gate.
+`test:runtime` runs `scenario:test -- all` and is the default non-browser
+runtime gate.
+`test:e2e` is a separate auth browser lane and should be run only when auth
+surfaces changed.
 
 ## Proof Matrix
 
@@ -79,22 +82,26 @@ Or:
 Use this path for:
 
 - `next-auth`
+- `start-auth`
 
 Run:
 
-1. `bun run scenario:prepare -- next-auth`
-2. `bun run scenario:dev -- next-auth`
-3. `bun run test:auth -- next-auth`
-4. `bun run test:e2e -- next-auth`
-5. Stop.
+1. `bun run scenario:prepare -- <next-auth|start-auth>`
+2. `bun run scenario:dev -- <next-auth|start-auth>`
+3. `bun run test:auth -- <next-auth|start-auth>`
+4. Stop.
 
 Or:
 
-1. `bun run scenario:test -- next-auth`
+1. `bun run scenario:test -- <next-auth|start-auth>`
 
 Why:
 
-- `next-auth` is the only scenario with a real auth browser surface today.
+- `scenario:test -- <next-auth|start-auth>` proves runtime + auth smoke only.
+- Browser auth proof belongs to the explicit `test:e2e` lane:
+  1. `bun run scenario:prepare -- <next-auth|start-auth>`
+  2. `bun run scenario:dev -- <next-auth|start-auth>`
+  3. `bun run test:e2e -- <next-auth|start-auth>`
 
 ### Auth backend proof without browser auth
 
@@ -160,19 +167,26 @@ Otherwise, reuse the prepared app.
 
 ## Examples
 
-### `next-auth`
+### `next-auth` or `start-auth`
 
 ```bash
 bun run scenario:prepare -- next-auth
 bun run scenario:dev -- next-auth
 bun run test:auth -- next-auth
-bun run test:e2e -- next-auth
 ```
 
 Short path:
 
 ```bash
 bun run scenario:test -- next-auth
+```
+
+Browser lane:
+
+```bash
+bun run scenario:prepare -- next-auth
+bun run scenario:dev -- next-auth
+bun run test:e2e -- next-auth
 ```
 
 ### `vite-auth`

--- a/.changeset/brave-olives-swim.md
+++ b/.changeset/brave-olives-swim.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix auth-bound React Query data so guest, sign-in, and account-switch transitions do not keep stale cached user data.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 - After any `init -t` template or scaffold change, you must rerun `bun run fixtures:sync` and `bun run fixtures:check`. No exceptions.
 - For manual runtime, never run committed `fixtures/**` in place. Materialize a tmp app with `bun run scenario:prepare <name>` and run it from `tmp/scenarios/<name>/project`, or use `bun run scenario:dev <name>`.
 - Use @.agents/rules/scenarios.mdc for fixture and scenario runtime proof. It owns when to stop at `scenario:dev`, when to add `test:auth` or `test:e2e`, and when `scenario:check` is the only honest lane.
+- Default `bun check` must not depend on auth browser E2E. Treat `test:e2e` as an auth-specific lane only. Run it when the diff touches auth runtime/client/provider/query-invalidation surfaces or auth demo scaffolds.
 - If `bun run fixtures:sync` dies with Convex/esbuild `EPIPE`, `The service was stopped`, or `Timed out waiting for local Convex bootstrap`, kill stale workers first: `pkill -f 'convex/bin/main.js codegen' || true; pkill -f 'convex/bin/main.js dev' || true; pkill -f '@esbuild/.*/bin/esbuild --service' || true`, then rerun sync once. If `ps` still shows an esbuild worker stuck in `U` state after `kill -9`, stop bullshitting and reboot — that machine state is wedged.
 - After every template/scaffold change, verify with `bun run fixtures:sync`, `bun run fixtures:check`, and prepared scenario apps under `tmp/scenarios/**`. Do not touch `example/` unless the user explicitly asks.
 - Prefer inline Zod schemas when used once; extract constants only when reused.

--- a/bun.lock
+++ b/bun.lock
@@ -117,7 +117,7 @@
     },
     "packages/kitcn": {
       "name": "kitcn",
-      "version": "0.12.5",
+      "version": "0.12.9",
       "bin": {
         "kitcn": "./dist/cli.mjs",
         "intent": "./bin/intent.js",
@@ -174,7 +174,7 @@
     },
     "packages/resend": {
       "name": "@kitcn/resend",
-      "version": "0.12.5",
+      "version": "0.12.9",
       "dependencies": {
         "svix": "^1.84.1",
       },

--- a/docs/plans/2026-04-05-auth-query-cache-after-auth-switch.md
+++ b/docs/plans/2026-04-05-auth-query-cache-after-auth-switch.md
@@ -1,0 +1,331 @@
+# Auth Query Cache After Auth Switch
+
+## Scope
+
+Plan only.
+
+Fix stale auth-bound query data after auth identity changes in `kitcn/react`,
+using Next as the proving lane.
+
+## Grounded context
+
+- Context snapshot:
+  [auth-query-cache-stale-20260405T194310Z](/Users/zbeyens/git/better-convex/.omx/context/auth-query-cache-stale-20260405T194310Z.md)
+- Repro we already have:
+  in a temp Next auth app, signed-in UI showed account 1 while the auth-bound
+  query still rendered `guest`
+- Screenshot proof:
+  [next-auth-viewer-stuck-guest.png](/Users/zbeyens/.dev-browser/tmp/next-auth-viewer-stuck-guest.png)
+- Likely code seam:
+  [auth-mutations.ts](/Users/zbeyens/git/better-convex/packages/kitcn/src/react/auth-mutations.ts)
+  and
+  [client.ts](/Users/zbeyens/git/better-convex/packages/kitcn/src/react/client.ts)
+
+## RALPLAN-DR
+
+### Principles
+
+- Auth changes must invalidate user-scoped truth, not preserve it.
+- Fix the cache ownership seam, not each caller page.
+- Preserve real-time subscriptions where possible, but correctness beats cache warmth.
+- Prove with Next before widening confidence claims.
+
+### Decision drivers
+
+1. The cache key currently does not vary by auth identity.
+2. Sign-out unsubscribes auth-required subscriptions but does not clear cached data.
+3. Sign-in/sign-up do not force auth-bound queries to refresh.
+
+### Viable options
+
+#### Option A: auth-transition cache reset in the query client
+
+- Add a first-class query-client operation for auth transitions.
+- On auth identity changes, clear or invalidate auth-bound cached queries and
+  resubscribe as needed.
+
+Pros
+- Smallest durable fix at the real ownership seam
+- No public query-key contract churn
+- Works for existing callers without page changes
+
+Cons
+- Need a clear rule for optional-auth queries vs required-auth queries
+- Can cause a brief refetch after auth transitions
+
+#### Option B: partition auth-bound query keys by auth identity
+
+- Include an auth discriminator in the query key/hash for auth-aware queries.
+
+Pros
+- Strong isolation between guest/account 1/account 2 data
+- Makes cross-user cache bleed structurally impossible
+
+Cons
+- Broader API/runtime change
+- More SSR/hydration/key-compat risk
+- Likely touches more surfaces than the bug justifies right now
+
+#### Option C: hybrid
+
+- Add transition-time cache reset now
+- Leave room for future identity-key partitioning if more edge cases remain
+
+Pros
+- Fastest path to correctness
+- Keeps the door open for stronger long-term isolation
+
+Cons
+- Two-step strategy instead of one hard cut
+
+### Chosen direction
+
+Option C, implemented as Option A now.
+
+Architect correction:
+- the primitive belongs in the query client
+- mutation hooks are only one trigger source, not the whole design
+
+### Why not the weaker alternatives
+
+- Not Option B now:
+  too broad for the current evidence. We already have a reproducible auth
+  transition seam in the query client. Re-keying every auth-bound query is a
+  larger contract change than this bug needs.
+- Not "do nothing and tell users to avoid TanStack cache":
+  that is just surrender. The bug is inside kitcn’s auth/query integration.
+
+## ADR
+
+### Decision
+
+Add an auth-transition cache-management seam in `kitcn/react`, owned by the
+query client, then route auth identity changes through it.
+
+### Drivers
+
+- Existing query cache survives auth identity changes.
+- The stale state reproduces in a real Next auth lane.
+- The current auth mutation layer already owns part of the transition path, but
+  not all auth-state changes.
+
+### Alternatives considered
+
+- Query-key partitioning by auth identity
+- Caller-level manual invalidation
+- No framework change
+
+### Why chosen
+
+- Lowest-risk seam with the highest leverage
+- Keeps the fix inside the auth/query integration where the bug originates
+- Leaves room to escalate to identity-key partitioning if transition-time reset
+  is not sufficient
+
+### Consequences
+
+- Auth transitions will intentionally drop or refetch some cached query data
+- Optional-auth and required-auth query handling must be made explicit
+- Any auth-state change path outside sign-in/sign-up/sign-out must be audited,
+  or stale data can survive through a side door
+
+### Follow-ups
+
+- If stale cross-user data still survives after transition-time cache reset,
+  reopen Option B and key auth-bound queries by identity
+- If auth can change outside mutation hooks in practice, add one central
+  auth-transition notifier instead of duplicating cache-reset calls
+
+## Plan
+
+### 1. Add failing regressions first
+
+- Add a `createAuthMutations` regression proving:
+  guest-scoped cached query data does not survive sign-in
+- Add a `ConvexQueryClient` lifecycle regression proving:
+  account 1 cached auth-bound data does not survive sign-out -> account 2
+- Keep the first slice unit-level and deterministic
+
+### 2. Introduce one query-client auth-transition primitive
+
+- Add a method on `ConvexQueryClient` for auth transitions
+- It should:
+  - remove or invalidate auth-bound cached queries
+  - unsubscribe active auth-bound subscriptions
+  - leave clearly public queries alone
+- It should accept enough context to distinguish:
+  - guest -> signed-in
+  - signed-in -> guest
+  - signed-in user A -> signed-in user B
+
+Open design call inside the implementation:
+- default to clearing both `required` and `optional` auth queries
+- reason:
+  optional-auth queries can still be identity-sensitive, and our repro already
+  shows stale guest data after sign-in
+
+### 3. Audit and wire transition triggers
+
+- Wire sign-in, sign-up, and sign-out through that primitive
+- Audit whether any other auth-state transition path can bypass mutation hooks:
+  - session restore
+  - OTT / token hydration
+  - cross-tab session changes
+- If such paths exist, route them through the same primitive or explicitly
+  document them as out of scope for this cut
+
+- In
+  [auth-mutations.ts](/Users/zbeyens/git/better-convex/packages/kitcn/src/react/auth-mutations.ts):
+  - sign-out should clear auth-bound cache, not just unsubscribe required queries
+  - sign-in/sign-up should also clear auth-bound cache before the next read path
+- Keep token/session hydration order explicit so the refetch happens against the
+  new auth state
+
+### 4. Prove in Next
+
+- Reuse `next-auth` as the browser lane
+- First prove the simpler guest -> account 1 transition, because it already
+  reproduces the same bug family
+- Then prove account 1 -> sign-out -> account 2 if the first fix lands cleanly
+- Add a committed repro surface only if unit tests cannot cover the final bug
+  honestly; otherwise keep the browser-only surface temporary
+
+## Acceptance criteria
+
+- After guest -> sign-in, auth-bound query data no longer shows guest-scoped
+  cached output
+- After account 1 -> sign-out -> account 2, auth-bound query data no longer
+  shows account 1 output
+- Public queries remain cached as before
+- Auth transitions do not leave orphaned subscriptions behind
+- Auth-transition fix works for both `required` and `optional` auth-bound query
+  lanes
+- Next auth browser proof passes with no stale user data
+
+## Verification
+
+### Targeted tests
+
+- `bun test ./packages/kitcn/src/react/auth-mutations.test.tsx`
+- `bun test ./packages/kitcn/src/react/client.lifecycle.test.ts`
+
+Add specific new cases for:
+- guest cache cleared on sign-in
+- required auth cache cleared on sign-out
+- optional auth cache cleared on identity change
+- transition path does not rely on page remount or route navigation
+
+### Runtime proof
+
+- `bun run scenario:prepare -- next-auth`
+- run the Next auth repro lane on `/auth` first
+- browser proof:
+  - while signed out, auth-dependent query shows guest
+  - sign in as account 1
+  - confirm auth-dependent query no longer shows guest
+  - sign in as account 1
+  - confirm auth-bound query shows account 1
+  - sign out
+  - sign in as account 2
+  - confirm auth-bound query shows account 2, not guest/account 1
+
+### Final gate
+
+- `bun lint:fix`
+- `bun typecheck`
+- `bun --cwd packages/kitcn build`
+- `bun check`
+
+## Risks
+
+- Clearing optional-auth queries may be more aggressive than some callers expect
+- If auth session hydration lags behind token changes, the first refetch can
+  still race unless mutation ordering is explicit
+- Browser repro surface may need a small committed test page if unit proof is
+  not enough
+- Mutation-hook-only wiring is insufficient if auth can change through restore
+  or callback paths without those hooks firing
+
+## Execution handoff
+
+### Available agent types
+
+- `executor`: runtime seam changes in `client.ts` / `auth-mutations.ts`
+- `test-engineer`: regression tests in `auth-mutations.test.tsx` /
+  `client.lifecycle.test.ts`
+- `verifier`: Next browser repro + final gate
+- `debugger`: fallback if transition-time cache reset does not eliminate stale
+  auth data on first pass
+
+### Suggested seam
+
+- Main execution seam:
+  [auth-mutations.ts](/Users/zbeyens/git/better-convex/packages/kitcn/src/react/auth-mutations.ts)
+  +
+  [client.ts](/Users/zbeyens/git/better-convex/packages/kitcn/src/react/client.ts)
+
+### Suggested reasoning
+
+- Core runtime/cache lane: `high`
+- Test lane: `medium`
+- Browser verification lane: `medium`
+
+### Available agent types
+
+- `ralph`
+- `team`
+- `planner`
+- `architect`
+- `critic`
+- worker models for team execution: `codex`, `claude`, `gemini`
+
+### RALPH staffing
+
+- One sequential pass is fine:
+  runtime seam -> regressions -> Next browser proof -> final gate
+
+### TEAM staffing
+
+- Worker 1: runtime seam in `client.ts` / `auth-mutations.ts`
+- Worker 2: regression tests in `auth-mutations.test.tsx` /
+  `client.lifecycle.test.ts`
+- Leader: Next browser repro + final integration gate
+
+### Launch hints
+
+- `ralph`:
+  sequential execution is enough for this bug; use one lane for runtime seam,
+  then tests, then Next browser proof, then final gate
+- `$team` / `omx team`:
+  split runtime, tests, and browser proof into separate lanes; keep the leader
+  on verification and merge decisions
+
+### Team verification path
+
+1. targeted regressions in `auth-mutations.test.tsx`
+2. targeted regressions in `client.lifecycle.test.ts`
+3. temp Next auth browser repro proving guest/account-1 stale data is gone
+4. `bun lint:fix`
+5. `bun typecheck`
+6. `bun --cwd packages/kitcn build`
+7. `bun check`
+
+### Launch hints
+
+- `ralph`:
+  execute this exact plan sequentially from the runtime seam outward
+- `$team`:
+  split runtime, tests, and browser verification into the three lanes above
+- `omx team`:
+  same split as `$team`, with the leader owning `next-auth` browser proof and
+  final `bun check`
+
+### Team verification path
+
+1. Reproduce on the simpler Next lane: `guest -> account1`
+2. Land unit regressions for cache reset on auth transition
+3. Reprove browser state on `next-auth`
+4. Run `bun lint:fix`
+5. Run `bun typecheck`
+6. Run `bun --cwd packages/kitcn build`
+7. Run `bun check`

--- a/docs/solutions/integration-issues/scenario-test-auth-proof-before-teardown-20260322.md
+++ b/docs/solutions/integration-issues/scenario-test-auth-proof-before-teardown-20260322.md
@@ -1,5 +1,5 @@
 ---
-title: scenario:test auth proof must run before runtime teardown
+title: scenario:test auth proof must stay inside runtime and stop at smoke
 category: integration-issues
 tags:
   - scenarios
@@ -8,56 +8,59 @@ tags:
   - dev
   - cli
 symptoms:
-  - `bun run scenario:test -- next-auth` starts the app, reaches ready, then `test:auth` fails with `ConnectionRefused`
-  - the runner shuts the dev processes down before auth smoke or browser auth runs
-  - focused unit tests for the proof matrix pass, but the live `next-auth` lane still dies
+  - `bun check` and `test:runtime` become slower and flakier when browser auth E2E is bundled into the default auth-demo scenario lane
+  - `scenario:test -- next-auth` reaches a healthy auth smoke pass, but the extra browser lane still extends the default gate
+  - the scenarios skill and docs drift when auth-demo lanes are described inconsistently
 module: scenarios
 resolved: 2026-03-22
+last_updated: 2026-04-06
 ---
 
-# scenario:test auth proof must run before runtime teardown
+# scenario:test auth proof must stay inside runtime and stop at smoke
 
 ## Problem
 
 `scenario:test` was added as the CLI wrapper for the proof matrix already
 documented in the scenarios skill.
 
-The routing logic was correct on paper:
+The original routing logic was half right:
 
 - plain runtime scenarios: prepare, boot, wait for ready, stop
-- `next-auth`: prepare, boot, run auth smoke, run browser auth, stop
+- auth-demo scenarios: prepare, boot, run auth smoke, stop
+- browser auth proof: explicit `test:e2e` lane only
 - bootstrap-heavy Convex scenarios: defer to `scenario:check`
 
-But the live `next-auth` lane still failed. The app booted, reached ready, then
-`test:auth` hit:
-
-```txt
-ConnectionRefused
-```
-
-because the dev runner had already shut the app down.
+Keeping auth proof inside the runtime owner was necessary, but keeping browser
+E2E inside the default `scenario:test` path was the wrong contract. That made
+the default runtime gate depend on a slower, flakier browser lane even when the
+auth demo itself was already healthy.
 
 ## Root Cause
 
-`runScenarioRuntimeProof()` always owned process lifetime:
+`runScenarioRuntimeProof()` correctly owns process lifetime:
 
 1. spawn dev processes
 2. wait for ready
-3. stop processes in `finally`
+3. run any proof that needs the live app
+4. stop processes in `finally`
 
-`runScenarioTest()` called it first, then ran `runAuthSmoke()` and
-`runAuthE2E()` after it returned.
+The real mistake was at the proof-matrix boundary. `runScenarioTest()` treated
+auth-demo scenarios as "smoke plus browser E2E" instead of "runtime plus auth
+smoke". That made the default `test:runtime` gate inherit the browser lane.
 
-That meant the auth checks were executing after teardown, outside the runtime
-window they were supposed to verify.
+So there were really two separate concerns:
+
+1. proof that needs the app alive must run before teardown
+2. browser auth E2E must not be part of the default runtime gate
 
 ## Solution
 
-Use the seam that already existed:
+Keep the existing runtime seam, but narrow the auth-demo proof:
 
 - keep `runScenarioRuntimeProof()` responsible for startup and teardown
 - pass an `afterReadyFn` from `runScenarioTest()` for auth-demo scenarios
-- run `test:auth` and `test:e2e` inside that `afterReadyFn`
+- run `test:auth` inside that `afterReadyFn`
+- keep browser auth proof in the explicit `test:e2e` lane
 
 So the order becomes:
 
@@ -65,44 +68,46 @@ So the order becomes:
 2. spawn dev processes
 3. wait for ready
 4. run auth smoke
-5. run browser auth
-6. stop processes
+5. stop processes
 
-The unit test stub for `next-auth` also has to execute `afterReadyFn`, or it
-will falsely claim the auth callbacks are wired when they are not.
+Browser auth proof stays separate:
+
+1. `bun run scenario:prepare -- <next-auth|start-auth>`
+2. `bun run scenario:dev -- <next-auth|start-auth>`
+3. `bun run test:e2e -- <next-auth|start-auth>`
 
 ## Verification
 
-- `bun test ./tooling/scenarios.test.ts`
+- `bun test ./tooling/scenarios.test.ts ./tooling/auth-e2e.test.ts`
 - `bun lint:fix`
-- `bun --cwd packages/kitcn build`
+- `bun typecheck`
 - `bun run scenario:test -- next-auth`
 
 Observed live behavior after the fix:
 
 - `POST /api/auth/sign-up/email 200`
 - `Auth smoke passed against http://localhost:3005.`
-- `POST /api/auth/sign-out 200`
-- `Auth E2E passed against http://localhost:3005.`
 
 Repo blocker still unrelated:
 
-- `bun typecheck` still fails on the existing committed template issue in
-  `fixtures/vite/convex/functions/generated/server.runtime.ts`
+- `bun check` currently dies earlier in `fixtures:check` because upstream
+  `bunx shadcn@4.0.1 init --template start` fails with
+  `Cannot find module './options'`
 
 ## Prevention
 
 1. If a proof step needs the app alive, keep it inside the runtime owner's
    lifecycle instead of sequencing it afterward.
-2. When a runner composes smaller helpers, test the live lane once. Mock-only
-   wiring tests will miss teardown bugs like this.
-3. If a helper already exposes an `afterReady` seam, use it before inventing a
-   second process manager.
+2. Do not sneak browser E2E into the default runtime gate. Make that lane
+   explicit.
+3. Keep the scenarios skill, scenario tests, and `scenario:test` contract in
+   sync for every auth-demo key, not just `next-auth`.
 
 ## Files Changed
 
 - `tooling/scenarios.ts`
 - `tooling/scenarios.test.ts`
-- `package.json`
-- `.claude/skills/scenarios/scenarios.mdc`
-
+- `tooling/auth-e2e.ts`
+- `tooling/auth-e2e.test.ts`
+- `.agents/rules/scenarios.mdc`
+- `.agents/AGENTS.md`

--- a/fixtures/next-auth/components/ui/button.tsx
+++ b/fixtures/next-auth/components/ui/button.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/fixtures/next/components/ui/button.tsx
+++ b/fixtures/next/components/ui/button.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/packages/kitcn/src/auth-client/convex-auth-provider.test.tsx
+++ b/packages/kitcn/src/auth-client/convex-auth-provider.test.tsx
@@ -344,6 +344,59 @@ describe('ConvexAuthProvider', () => {
     });
   });
 
+  test('keeps a cached JWT when a later token refresh returns null', async () => {
+    const client = {
+      setAuth: () => {},
+      clearAuth: () => {},
+    };
+
+    const firstJwt = makeJwt(7200);
+    const convexToken = mock(async () => ({ data: { token: firstJwt } }));
+
+    const authClient = {
+      useSession: () => ({
+        data: { session: { id: 'session-1' } },
+        isPending: false,
+      }),
+      convex: { token: convexToken },
+      getSession: async () => null,
+      updateSession: () => {},
+      crossDomain: { oneTimeToken: { verify: async () => ({ data: {} }) } },
+    };
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ConvexAuthProvider authClient={authClient as any} client={client as any}>
+        {children}
+      </ConvexAuthProvider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        fetchAccessToken: useFetchAccessToken(),
+        store: useAuthStore(),
+      }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      const fetched = await result.current.fetchAccessToken!({
+        forceRefreshToken: true,
+      });
+      expect(fetched).toBe(firstJwt);
+    });
+
+    convexToken.mockImplementationOnce(async () => ({ data: {} }));
+
+    await act(async () => {
+      const fetched = await result.current.fetchAccessToken!({
+        forceRefreshToken: true,
+      });
+      expect(fetched).toBe(firstJwt);
+    });
+
+    expect(result.current.store.get('token')).toBe(firstJwt);
+  });
+
   test('deduplicates concurrent token fetches', async () => {
     const client = {
       setAuth: () => {},

--- a/packages/kitcn/src/auth-client/convex-auth-provider.tsx
+++ b/packages/kitcn/src/auth-client/convex-auth-provider.tsx
@@ -128,6 +128,14 @@ function ConvexAuthProviderInner({
   sessionRef.current = session;
   isPendingRef.current = isPending;
 
+  const getCachedJwt = useCallback(() => {
+    const cachedToken = authStore.get('token');
+    if (!cachedToken || decodeJwtExp(cachedToken) === null) {
+      return null;
+    }
+    return cachedToken;
+  }, [authStore]);
+
   // Clear token when session becomes null (logout)
   // This can't be inside fetchAccessToken because it's not called after logout
   useEffect(() => {
@@ -191,12 +199,26 @@ function ConvexAuthProviderInner({
               return jwt;
             }
 
+            const cachedJwt = getCachedJwt();
+            if (cachedJwt) {
+              authStore.set('expiresAt', decodeJwtExp(cachedJwt));
+              authStore.set('sessionSyncGraceUntil', null);
+              return cachedJwt;
+            }
+
             authStore.set('token', null);
             authStore.set('expiresAt', null);
             authStore.set('sessionSyncGraceUntil', null);
             return null;
           })
           .catch((error: unknown) => {
+            const cachedJwt = getCachedJwt();
+            if (cachedJwt) {
+              authStore.set('expiresAt', decodeJwtExp(cachedJwt));
+              authStore.set('sessionSyncGraceUntil', null);
+              return cachedJwt;
+            }
+
             authStore.set('token', null);
             authStore.set('expiresAt', null);
             authStore.set('sessionSyncGraceUntil', null);
@@ -213,9 +235,10 @@ function ConvexAuthProviderInner({
       const fetchFreshTokenForced = async () => {
         // For forced refresh, if we only have an in-flight request and it
         // resolves null, retry once immediately instead of returning null.
+        const cachedJwt = getCachedJwt();
         if (pendingTokenRef.current) {
           const token = await pendingTokenRef.current;
-          if (token) {
+          if (token && (!cachedJwt || token !== cachedJwt)) {
             return token;
           }
         }
@@ -299,7 +322,7 @@ function ConvexAuthProviderInner({
     },
     // Stable deps - authStore/authClient rarely change
     // session/isPending accessed via refs to prevent callback recreation
-    [authStore, authClient]
+    [authStore, authClient, getCachedJwt]
   );
 
   // Create useAuth hook for ConvexProviderWithAuth

--- a/packages/kitcn/src/react/auth-mutations.test.tsx
+++ b/packages/kitcn/src/react/auth-mutations.test.tsx
@@ -73,12 +73,13 @@ describe('createAuthMutations', () => {
     return { client: new QueryClient(), meta: undefined } as any;
   }
 
-  test('signOut: sets isAuthenticated=false, unsubscribes auth queries, and clears auth state after success', async () => {
+  test('signOut: sets isAuthenticated=false, resets auth queries, and clears auth state after success', async () => {
     const unsubscribeAuthQueries = mock(() => {});
+    const resetAuthQueries = mock(() => {});
     useConvexQueryClientSpy = spyOn(
       contextModule,
       'useConvexQueryClient'
-    ).mockReturnValue({ unsubscribeAuthQueries } as any);
+    ).mockReturnValue({ resetAuthQueries, unsubscribeAuthQueries } as any);
 
     const authClient = {
       signOut: mock(async (_args: unknown) => ({ ok: true })),
@@ -111,6 +112,7 @@ describe('createAuthMutations', () => {
     });
 
     expect(unsubscribeAuthQueries).toHaveBeenCalledTimes(1);
+    expect(resetAuthQueries).toHaveBeenCalledTimes(1);
     expect(authClient.signOut).toHaveBeenCalledTimes(1);
     expect(authClient.signOut).toHaveBeenCalledWith({ reason: 'logout' });
 
@@ -156,10 +158,11 @@ describe('createAuthMutations', () => {
   });
 
   test('signIn(email): seeds the auth store from a returned token', async () => {
+    const resetAuthQueries = mock(() => {});
     useConvexQueryClientSpy = spyOn(
       contextModule,
       'useConvexQueryClient'
-    ).mockReturnValue(null as any);
+    ).mockReturnValue({ resetAuthQueries } as any);
 
     const authClient = {
       signOut: mock(async () => ({})),
@@ -194,14 +197,17 @@ describe('createAuthMutations', () => {
     });
 
     expect(result.current.store.get('token')).toBe('returned-sign-in-token');
+    expect(result.current.store.get('isAuthenticated')).toBe(true);
     expect(authClient.signIn.email).toHaveBeenCalledTimes(1);
+    expect(resetAuthQueries).toHaveBeenCalledTimes(1);
   });
 
   test('signUp(email): seeds the auth store from a returned token', async () => {
+    const resetAuthQueries = mock(() => {});
     useConvexQueryClientSpy = spyOn(
       contextModule,
       'useConvexQueryClient'
-    ).mockReturnValue(null as any);
+    ).mockReturnValue({ resetAuthQueries } as any);
 
     const authClient = {
       signOut: mock(async () => ({})),
@@ -235,6 +241,7 @@ describe('createAuthMutations', () => {
     });
 
     expect(result.current.store.get('token')).toBe('returned-sign-up-token');
+    expect(result.current.store.get('isAuthenticated')).toBe(true);
     expect(authClient.signUp.email).toHaveBeenCalledTimes(1);
     expect(authClient.signUp.email).toHaveBeenCalledWith({
       email: 'a@b.com',
@@ -243,6 +250,7 @@ describe('createAuthMutations', () => {
         disableSignal: true,
       },
     });
+    expect(resetAuthQueries).toHaveBeenCalledTimes(1);
   });
 
   test('signUp(email): hydrates Better Auth session state from the returned bearer token', async () => {

--- a/packages/kitcn/src/react/auth-mutations.ts
+++ b/packages/kitcn/src/react/auth-mutations.ts
@@ -249,6 +249,7 @@ export function createAuthMutations<T extends AuthClient>(
         authStoreApi.set('token', null);
         authStoreApi.set('expiresAt', null);
         authStoreApi.set('sessionSyncGraceUntil', null);
+        await convexQueryClient?.resetAuthQueries();
         return res;
       },
     };
@@ -256,6 +257,7 @@ export function createAuthMutations<T extends AuthClient>(
 
   const useSignInSocialMutationOptions = ((options) => {
     const authStoreApi = useAuthStore();
+    const convexQueryClient = useConvexQueryClient();
 
     return {
       ...options,
@@ -269,6 +271,8 @@ export function createAuthMutations<T extends AuthClient>(
         seedReturnedToken(authStoreApi, res);
         await hydrateReturnedSession(authClient, res);
         await ensureAuth(authStoreApi);
+        authStoreApi.set('isAuthenticated', true);
+        await convexQueryClient?.resetAuthQueries();
         return res;
       },
     };
@@ -276,6 +280,7 @@ export function createAuthMutations<T extends AuthClient>(
 
   const useSignInMutationOptions = ((options) => {
     const authStoreApi = useAuthStore();
+    const convexQueryClient = useConvexQueryClient();
 
     return {
       ...options,
@@ -289,6 +294,8 @@ export function createAuthMutations<T extends AuthClient>(
         seedReturnedToken(authStoreApi, res);
         await hydrateReturnedSession(authClient, res);
         await ensureAuth(authStoreApi);
+        authStoreApi.set('isAuthenticated', true);
+        await convexQueryClient?.resetAuthQueries();
         return res;
       },
     };
@@ -296,6 +303,7 @@ export function createAuthMutations<T extends AuthClient>(
 
   const useSignUpMutationOptions = ((options) => {
     const authStoreApi = useAuthStore();
+    const convexQueryClient = useConvexQueryClient();
 
     return {
       ...options,
@@ -309,6 +317,8 @@ export function createAuthMutations<T extends AuthClient>(
         seedReturnedToken(authStoreApi, res);
         await hydrateReturnedSession(authClient, res);
         await ensureAuth(authStoreApi);
+        authStoreApi.set('isAuthenticated', true);
+        await convexQueryClient?.resetAuthQueries();
         return res;
       },
     };

--- a/packages/kitcn/src/react/client.lifecycle.test.ts
+++ b/packages/kitcn/src/react/client.lifecycle.test.ts
@@ -105,14 +105,14 @@ describe('ConvexQueryClient (client mode lifecycle)', () => {
 
     const requiredObserver = new QueryObserver(queryClient as any, {
       meta: { authType: 'required' },
-      queryFn: async () => ({ ok: true }),
+      queryFn: async () => ({ email: 'fresh-required' }),
       queryKey: requiredKey,
     });
     const unsubRequired = requiredObserver.subscribe(() => {});
 
     const optionalObserver = new QueryObserver(queryClient as any, {
       meta: { authType: 'optional' },
-      queryFn: async () => ({ ok: true }),
+      queryFn: async () => ({ email: 'fresh-optional' }),
       queryKey: optionalKey,
     });
     const unsubOptional = optionalObserver.subscribe(() => {});
@@ -127,6 +127,92 @@ describe('ConvexQueryClient (client mode lifecycle)', () => {
 
     unsubRequired();
     unsubOptional();
+  });
+
+  test('resetAuthQueries clears cached required/optional auth data and unsubscribes active subscriptions', async () => {
+    const ConvexQueryClient = await getClientConvexQueryClient('reset-auth');
+
+    const unsubCalls: Record<string, number> = {
+      required: 0,
+      optional: 0,
+    };
+    const convexClient = {
+      watchQuery: (fn: unknown) => {
+        const name = String(fn);
+        const bucket = name.includes('required')
+          ? 'required'
+          : name.includes('optional')
+            ? 'optional'
+            : 'optional';
+        return {
+          localQueryResult: () => undefined,
+          onUpdate: () => () => {
+            unsubCalls[bucket]++;
+          },
+        };
+      },
+    };
+
+    const queryClient = new QueryClient();
+    const client = new ConvexQueryClient(convexClient, {
+      queryClient,
+      unsubscribeDelay: 0,
+    });
+
+    const requiredKey = [
+      'convexQuery',
+      'viewer:required',
+      { scope: 'me' },
+    ] as const;
+    const optionalKey = [
+      'convexQuery',
+      'viewer:optional',
+      { scope: 'me' },
+    ] as const;
+    const publicKey = ['convexQuery', 'messages:list', {}] as const;
+
+    queryClient.setQueryData(requiredKey as any, { email: 'account-1' });
+    queryClient.setQueryData(optionalKey as any, { email: 'guest' });
+    queryClient.setQueryData(publicKey as any, { ok: true });
+
+    const requiredObserver = new QueryObserver(queryClient as any, {
+      meta: { authType: 'required' },
+      queryFn: async () => ({ ok: true }),
+      queryKey: requiredKey,
+    });
+    const unsubRequired = requiredObserver.subscribe(() => {});
+
+    const optionalObserver = new QueryObserver(queryClient as any, {
+      meta: { authType: 'optional' },
+      queryFn: async () => ({ ok: true }),
+      queryKey: optionalKey,
+    });
+    const unsubOptional = optionalObserver.subscribe(() => {});
+
+    const publicObserver = new QueryObserver(queryClient as any, {
+      queryFn: async () => ({ ok: true }),
+      queryKey: publicKey,
+    });
+    const unsubPublic = publicObserver.subscribe(() => {});
+
+    expect(Object.keys(client.subscriptions).length).toBe(3);
+
+    await client.resetAuthQueries();
+
+    expect(unsubCalls.required).toBe(1);
+    expect(unsubCalls.optional).toBe(1);
+    expect(queryClient.getQueryData(requiredKey as any)).not.toEqual({
+      email: 'account-1',
+    });
+    expect(queryClient.getQueryData(optionalKey as any)).not.toEqual({
+      email: 'guest',
+    });
+    expect(queryClient.getQueryData(publicKey as any)).toEqual({ ok: true });
+    expect(Object.keys(client.subscriptions).length).toBe(3);
+
+    unsubRequired();
+    unsubOptional();
+    unsubPublic();
   });
 
   test('onUpdateQueryKeyHash does not overwrite existing data with null/undefined subscription values', async () => {

--- a/packages/kitcn/src/react/client.ts
+++ b/packages/kitcn/src/react/client.ts
@@ -82,6 +82,7 @@ import { isConvexQuery } from '../internal/query-key';
 import type { AuthStore } from './auth-store';
 
 const isServer = typeof window === 'undefined';
+type TanstackQuery = ReturnType<QueryCache['getAll']>[number];
 
 // ============================================================================
 // Type Guards for Query Key Format
@@ -201,7 +202,7 @@ export class ConvexQueryClient {
     {
       watch: Watch<unknown>;
       unsubscribe: () => void;
-      queryKey: ['convexQuery', string, Record<string, unknown>];
+      queryKey: QueryKey;
     }
   >;
 
@@ -261,6 +262,46 @@ export class ConvexQueryClient {
 
     sub.unsubscribe();
     delete this.subscriptions[queryHash];
+  }
+
+  private isAuthBoundQuery(query: TanstackQuery) {
+    const meta = query.meta as ConvexQueryMeta | undefined;
+    return meta?.authType === 'required' || meta?.authType === 'optional';
+  }
+
+  private subscribeQuery(query: TanstackQuery) {
+    if (this.subscriptions[query.queryHash]) {
+      return;
+    }
+
+    const meta = query.meta as ConvexQueryMeta | undefined;
+    if (meta?.subscribe === false) {
+      return;
+    }
+    if (query.getObserversCount() === 0) {
+      return;
+    }
+    if (this.shouldSkipSubscription(meta?.authType)) {
+      return;
+    }
+
+    const [, funcName, args] = query.queryKey;
+    const watch = this.convexClient.watchQuery(
+      funcName as unknown as FunctionReference<'query'>,
+      this.transformer.input.serialize(args) as FunctionArgs<
+        FunctionReference<'query'>
+      >
+    );
+
+    const unsubscribe = watch.onUpdate(() => {
+      this.onUpdateQueryKeyHash(query.queryHash);
+    });
+
+    this.subscriptions[query.queryHash] = {
+      queryKey: query.queryKey,
+      watch: watch as Watch<unknown>,
+      unsubscribe,
+    };
   }
 
   /** Update auth store (for HMR where jotai store may reset) */
@@ -399,6 +440,28 @@ export class ConvexQueryClient {
     }
   }
 
+  async resetAuthQueries() {
+    const authQueries = this.queryClient
+      .getQueryCache()
+      .getAll()
+      .filter((query) => this.isAuthBoundQuery(query));
+
+    for (const query of authQueries) {
+      this.cancelPendingUnsubscribe(query.queryHash);
+      this.unsubscribeQueryByHash(query.queryHash);
+    }
+
+    await this.queryClient.resetQueries({
+      predicate: (query) => this.isAuthBoundQuery(query),
+    });
+
+    for (const query of this.queryClient.getQueryCache().getAll()) {
+      if (this.isAuthBoundQuery(query)) {
+        this.subscribeQuery(query);
+      }
+    }
+  }
+
   /**
    * Batch update all subscriptions.
    * Called internally when Convex client reconnects.
@@ -529,42 +592,7 @@ export class ConvexQueryClient {
 
         // Query added to cache → create Convex subscription
         case 'added': {
-          // Skip subscription if meta.subscribe === false (one-off query mode)
-          const meta = event.query.meta as ConvexQueryMeta | undefined;
-          if (meta?.subscribe === false) {
-            break;
-          }
-
-          const [, funcName, args] = event.query.queryKey;
-
-          // Skip subscription if query has no observers
-          if (event.query.getObserversCount() === 0) {
-            break;
-          }
-
-          // Skip subscription while auth is loading or unauthenticated (for required)
-          if (this.shouldSkipSubscription(meta?.authType)) {
-            break;
-          }
-
-          // Create WebSocket subscription via Convex watchQuery
-          const watch = this.convexClient.watchQuery(
-            funcName as unknown as FunctionReference<'query'>,
-            this.transformer.input.serialize(args) as FunctionArgs<
-              FunctionReference<'query'>
-            >
-          );
-
-          // Update TanStack cache when Convex pushes new data
-          const unsubscribe = watch.onUpdate(() => {
-            this.onUpdateQueryKeyHash(event.query.queryHash);
-          });
-
-          this.subscriptions[event.query.queryHash] = {
-            queryKey: event.query.queryKey,
-            watch: watch as Watch<unknown>,
-            unsubscribe,
-          };
+          this.subscribeQuery(event.query);
           break;
         }
 
@@ -572,48 +600,9 @@ export class ConvexQueryClient {
         case 'observerAdded': {
           // Cancel any pending unsubscribe (handles React StrictMode double-mount)
           this.cancelPendingUnsubscribe(event.query.queryHash);
-
-          // Skip if already subscribed
-          if (this.subscriptions[event.query.queryHash]) {
-            break;
+          if ((event.query.options as any).enabled !== false) {
+            this.subscribeQuery(event.query);
           }
-
-          // Skip subscription if query is disabled
-          if ((event.query.options as any).enabled === false) {
-            break;
-          }
-
-          // Skip subscription if meta.subscribe === false
-          const meta = event.query.meta as ConvexQueryMeta | undefined;
-          if (meta?.subscribe === false) {
-            break;
-          }
-
-          const [, funcName, args] = event.query.queryKey;
-
-          // Skip subscription while auth is loading or unauthenticated (for required)
-          if (this.shouldSkipSubscription(meta?.authType)) {
-            break;
-          }
-
-          // Create WebSocket subscription via Convex watchQuery
-          const watch = this.convexClient.watchQuery(
-            funcName as unknown as FunctionReference<'query'>,
-            this.transformer.input.serialize(args) as FunctionArgs<
-              FunctionReference<'query'>
-            >
-          );
-
-          // Update TanStack cache when Convex pushes new data
-          const unsubscribe = watch.onUpdate(() => {
-            this.onUpdateQueryKeyHash(event.query.queryHash);
-          });
-
-          this.subscriptions[event.query.queryHash] = {
-            queryKey: event.query.queryKey,
-            watch: watch as Watch<unknown>,
-            unsubscribe,
-          };
           break;
         }
 
@@ -670,37 +659,7 @@ export class ConvexQueryClient {
             break;
           }
 
-          // Skip subscription if meta.subscribe === false
-          const meta = event.query.meta as ConvexQueryMeta | undefined;
-          if (meta?.subscribe === false) {
-            break;
-          }
-
-          const [, funcName, args] = event.query.queryKey;
-
-          // Skip subscription while auth is loading or unauthenticated (for required)
-          if (this.shouldSkipSubscription(meta?.authType)) {
-            break;
-          }
-
-          // Create WebSocket subscription via Convex watchQuery
-          const watch = this.convexClient.watchQuery(
-            funcName as unknown as FunctionReference<'query'>,
-            this.transformer.input.serialize(args) as FunctionArgs<
-              FunctionReference<'query'>
-            >
-          );
-
-          // Update TanStack cache when Convex pushes new data
-          const unsubscribe = watch.onUpdate(() => {
-            this.onUpdateQueryKeyHash(event.query.queryHash);
-          });
-
-          this.subscriptions[event.query.queryHash] = {
-            queryKey: event.query.queryKey,
-            watch: watch as Watch<unknown>,
-            unsubscribe,
-          };
+          this.subscribeQuery(event.query);
           break;
         }
       }

--- a/packages/kitcn/src/react/context.test.tsx
+++ b/packages/kitcn/src/react/context.test.tsx
@@ -15,6 +15,7 @@ import * as vanillaClientModule from './vanilla-client';
 describe('createCRPCContext', () => {
   let useAuthStoreSpy: ReturnType<typeof spyOn>;
   let useFetchAccessTokenSpy: ReturnType<typeof spyOn>;
+  let useAuthValueSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     useAuthStoreSpy = spyOn(authStoreModule, 'useAuthStore').mockImplementation(
@@ -27,11 +28,15 @@ describe('createCRPCContext', () => {
       authStoreModule,
       'useFetchAccessToken'
     ).mockImplementation(() => null);
+    useAuthValueSpy = spyOn(authStoreModule, 'useAuthValue').mockImplementation(
+      () => null as any
+    );
   });
 
   afterEach(() => {
     useAuthStoreSpy.mockRestore();
     useFetchAccessTokenSpy.mockRestore();
+    useAuthValueSpy.mockRestore();
   });
 
   test('useCRPC/useCRPCClient throw when used outside CRPCProvider', () => {
@@ -217,5 +222,59 @@ describe('createCRPCContext', () => {
       createOptionsProxySpy.mockRestore();
       createVanillaProxySpy.mockRestore();
     }
+  });
+
+  test('resets auth queries only when auth transitions reach a real JWT or logout null', () => {
+    const api = {} as any;
+    const convexClient = {} as any;
+    const convexQueryClient = {
+      resetAuthQueries: mock(async () => {}),
+    } as any;
+
+    let authState = {
+      isAuthenticated: false,
+      token: null as string | null,
+    };
+    useAuthValueSpy.mockImplementation(
+      ((key: 'token' | 'isAuthenticated') => authState[key]) as any
+    );
+
+    const { CRPCProvider } = createCRPCContext({ api });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CRPCProvider
+        convexClient={convexClient}
+        convexQueryClient={convexQueryClient}
+      >
+        {children}
+      </CRPCProvider>
+    );
+
+    const jwt = `a.${Buffer.from(
+      JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    ).toString('base64')}.b`;
+
+    const hook = renderHook(() => useMeta(), { wrapper });
+    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
+
+    authState = {
+      isAuthenticated: false,
+      token: 'opaque-session-token',
+    };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
+
+    authState = {
+      isAuthenticated: true,
+      token: jwt,
+    };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(1);
+
+    authState = {
+      isAuthenticated: false,
+      token: null,
+    };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/kitcn/src/react/context.tsx
+++ b/packages/kitcn/src/react/context.tsx
@@ -7,13 +7,25 @@
  */
 
 import type { ConvexReactClient } from 'convex/react';
-import { createContext, type ReactNode, useContext, useMemo } from 'react';
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import type { HttpClientError } from '../crpc/http-types';
 import type { DataTransformerOptions } from '../crpc/transformer';
 import type { FnMeta, Meta } from '../crpc/types';
 import type { CRPCHttpRouter, HttpRouterRecord } from '../server/http-router';
 import { buildMetaIndex } from '../shared/meta-utils';
-import { useAuthStore, useFetchAccessToken } from './auth-store';
+import {
+  decodeJwtExp,
+  useAuthStore,
+  useAuthValue,
+  useFetchAccessToken,
+} from './auth-store';
 import type { ConvexQueryClient } from './client';
 import type { CRPCClient, VanillaCRPCClient } from './crpc-types';
 import {
@@ -168,8 +180,35 @@ export function createCRPCContext<TApi extends Record<string, unknown>>(
     convexQueryClient: ConvexQueryClient;
   }) {
     const authStore = useAuthStore();
+    const token = useAuthValue('token');
+    const isAuthenticated = useAuthValue('isAuthenticated');
+    const previousAuthRef = useRef<{
+      isAuthenticated: boolean;
+      token: string | null;
+    } | null>(null);
     // Get fetchAccessToken from context (immediately available, no race condition)
     const fetchAccessToken = useFetchAccessToken();
+
+    useEffect(() => {
+      const previous = previousAuthRef.current;
+      const tokenReady = token === null || decodeJwtExp(token) !== null;
+      previousAuthRef.current = {
+        isAuthenticated,
+        token,
+      };
+
+      if (!previous) {
+        return;
+      }
+
+      if (
+        tokenReady &&
+        (previous.token !== token ||
+          previous.isAuthenticated !== isAuthenticated)
+      ) {
+        void convexQueryClient.resetAuthQueries();
+      }
+    }, [convexQueryClient, isAuthenticated, token]);
 
     // Create HTTP proxy inside component with authStore access
     const httpProxy = useMemo(() => {

--- a/tooling/auth-e2e.test.ts
+++ b/tooling/auth-e2e.test.ts
@@ -49,10 +49,10 @@ describe('tooling/auth-e2e', () => {
       'await page.getByRole("button", { name: "Sign out" }).click();'
     );
     expect(script).toContain(
-      'await page.getByText("Signed in").waitFor({ timeout: 10000 });'
+      'await page.getByText("Signed in").waitFor({ timeout: 20000 });'
     );
     expect(script).toContain(
-      'await page.getByText("Auth demo").waitFor({ timeout: 10000 });'
+      'await page.getByText("Auth demo").waitFor({ timeout: 20000 });'
     );
     expect(script).toContain(
       'console.log(JSON.stringify({ url: page.url(), email: "e2e@example.com" }));'

--- a/tooling/auth-e2e.ts
+++ b/tooling/auth-e2e.ts
@@ -6,6 +6,7 @@ import { log } from './scaffold-utils';
 const DEFAULT_AUTH_E2E_TARGET = 'next-auth';
 const DEV_BROWSER_URL = 'http://127.0.0.1:9222';
 const DEV_BROWSER_TIMEOUT_SECONDS = '45';
+const AUTH_E2E_WAIT_TIMEOUT_MS = 20_000;
 
 type AuthE2EArgs = {
   target: string;
@@ -50,7 +51,7 @@ await page.getByPlaceholder("Name").fill(${JSON.stringify(user.name)});
 await page.getByPlaceholder("Email").fill(${JSON.stringify(user.email)});
 await page.getByPlaceholder("Password").fill(${JSON.stringify(user.password)});
 await page.getByRole("button", { name: "Create account" }).click();
-await page.getByText("Signed in").waitFor({ timeout: 10000 });
+await page.getByText("Signed in").waitFor({ timeout: ${AUTH_E2E_WAIT_TIMEOUT_MS} });
 const signedInBody = await page.locator("body").innerText();
 if (!signedInBody.includes("Signed in")) {
   throw new Error("Auth E2E never reached the signed-in view.\\n" + signedInBody);
@@ -61,7 +62,7 @@ if (!signedInBody.includes(${JSON.stringify(user.email)})) {
   )} + "\\n" + signedInBody);
 }
 await page.getByRole("button", { name: "Sign out" }).click();
-await page.getByText("Auth demo").waitFor({ timeout: 10000 });
+await page.getByText("Auth demo").waitFor({ timeout: ${AUTH_E2E_WAIT_TIMEOUT_MS} });
 const signedOutBody = await page.locator("body").innerText();
 if (signedOutBody.includes("Signed in")) {
   throw new Error("Auth E2E stayed signed in after sign out.\\n" + signedOutBody);
@@ -268,7 +269,7 @@ const evaluateOnPage = async (
 const waitForPageCondition = async ({
   cdp,
   expression,
-  timeoutMs = 10_000,
+  timeoutMs = AUTH_E2E_WAIT_TIMEOUT_MS,
 }: {
   cdp: CdpClient;
   expression: string;
@@ -407,6 +408,7 @@ const runCdpAuthE2E = async ({
       await waitForPageCondition({
         cdp,
         expression: '(document.body?.innerText ?? "").includes("Signed in")',
+        timeoutMs: AUTH_E2E_WAIT_TIMEOUT_MS,
       });
     } catch (_error) {
       const currentBody = String(
@@ -455,6 +457,7 @@ const runCdpAuthE2E = async ({
     await waitForPageCondition({
       cdp,
       expression: '(document.body?.innerText ?? "").includes("Auth demo")',
+      timeoutMs: AUTH_E2E_WAIT_TIMEOUT_MS,
     });
 
     const signedOutBody = String(

--- a/tooling/scenarios.test.ts
+++ b/tooling/scenarios.test.ts
@@ -111,7 +111,7 @@ describe('tooling/scenarios', () => {
     expect(calls).toEqual(['check']);
   });
 
-  test('runScenarioTest runs auth smoke and e2e for next-auth', async () => {
+  test('runScenarioTest runs auth smoke only for next-auth', async () => {
     const calls: string[] = [];
 
     await runScenarioTest('next-auth', {
@@ -133,10 +133,10 @@ describe('tooling/scenarios', () => {
       }) as never,
     });
 
-    expect(calls).toEqual(['prepare', 'runtime', 'auth', 'e2e']);
+    expect(calls).toEqual(['prepare', 'runtime', 'auth']);
   });
 
-  test('runScenarioTest runs auth smoke and e2e for start-auth', async () => {
+  test('runScenarioTest runs auth smoke only for start-auth', async () => {
     const calls: string[] = [];
 
     await runScenarioTest('start-auth' as never, {
@@ -158,7 +158,7 @@ describe('tooling/scenarios', () => {
       }) as never,
     });
 
-    expect(calls).toEqual(['prepare', 'runtime', 'auth', 'e2e']);
+    expect(calls).toEqual(['prepare', 'runtime', 'auth']);
   });
 
   test('runScenarioTest skips browser auth for vite-auth', async () => {

--- a/tooling/scenarios.ts
+++ b/tooling/scenarios.ts
@@ -14,7 +14,6 @@ import {
   KITCN_INSTALL_SPEC_ENV,
   KITCN_RESEND_INSTALL_SPEC_ENV,
 } from '../packages/kitcn/src/cli/supported-dependencies';
-import { runAuthE2E } from './auth-e2e';
 import { runAuthSchemaStress } from './auth-schema-stress';
 import { runAuthSmoke } from './auth-smoke';
 import {
@@ -1126,7 +1125,6 @@ export const runScenarioTest = async (
     checkScenarioFn?: typeof checkScenario;
     runScenarioRuntimeProofFn?: typeof runScenarioRuntimeProof;
     runAuthSmokeFn?: typeof runAuthSmoke;
-    runAuthE2EFn?: typeof runAuthE2E;
   } = {}
 ) => {
   const proofPath = resolveScenarioProofPath(scenarioKey);
@@ -1152,7 +1150,6 @@ export const runScenarioTest = async (
         proofPath === 'auth-demo'
           ? async (readyScenarioKey) => {
               await (params.runAuthSmokeFn ?? runAuthSmoke)([readyScenarioKey]);
-              await (params.runAuthE2EFn ?? runAuthE2E)([readyScenarioKey]);
             }
           : undefined,
     }


### PR DESCRIPTION
## Summary
- reset auth-bound React Query state when auth changes so guest, sign-in, sign-out, and account-switch flows do not keep stale cached data
- split browser auth proof out of `scenario:test` / `test:runtime` so auth-demo scenarios stop at smoke and `test:e2e` becomes the explicit browser lane
- sync the scenario guidance, AGENTS rules, and the stale learning doc to the new contract

## Verification
- `bun test ./tooling/scenarios.test.ts ./tooling/auth-e2e.test.ts`
- `bun lint:fix`
- `bun typecheck`
- `bun --cwd packages/kitcn build`
- `bun run scenario:test -- next-auth`
- `bun run scenario:dev -- next-auth`
- `bun run test:e2e -- next-auth`

## Check Status
- `bun check` is still red, but not on auth
- current blocker: `fixtures:check` hits upstream `bunx shadcn@4.0.1 init --template start` and dies with `Cannot find module './options'`
- user explicitly asked to open the PR anyway
