### PR TITLE
fix: rerun concave codegen on schema watch

### DIFF
--- a/.changeset/smooth-cows-invite.md
+++ b/.changeset/smooth-cows-invite.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix Concave local `kitcn dev` schema watches so `schema.ts` edits rerun fresh codegen and refresh generated schema outputs without a manual `kitcn codegen`.

--- a/docs/solutions/integration-issues/concave-schema-watch-must-run-fresh-codegen-20260406.md
+++ b/docs/solutions/integration-issues/concave-schema-watch-must-run-fresh-codegen-20260406.md
@@ -1,0 +1,75 @@
+---
+title: Concave schema watch must run fresh codegen and ignore generated outputs
+category: integration-issues
+tags:
+  - concave
+  - dev
+  - watcher
+  - codegen
+  - schema
+symptoms:
+  - editing `convex/functions/schema.ts` during `kitcn dev --backend concave` logs watch activity, but `_generated/dataModel.d.ts` stays stale
+  - manual `kitcn codegen` immediately fixes the stale schema output
+  - generated output folders can trigger noisy watch churn if the watcher treats backend-owned files as source inputs
+module: concave-dev
+resolved: 2026-04-06
+---
+
+# Concave schema watch must run fresh codegen and ignore generated outputs
+
+## Problem
+
+Concave local dev was reacting to `schema.ts` edits, but not honestly finishing
+the job.
+
+After a schema edit, the watcher logged success and the app reloaded, yet the
+actual Concave-generated schema types under `_generated/` still reflected the
+old schema until a manual `kitcn codegen`.
+
+## Root Cause
+
+The watcher only ran `generateMeta(...)`.
+
+That updates kitcn-owned generated files, but Concave schema output is owned by
+the backend codegen pass. So the watch lane was doing half a codegen and then
+claiming success.
+
+There was a second trap waiting behind the fix: once the watcher starts
+refreshing backend-owned outputs too, `_generated/**` must be ignored or the
+watcher can start reacting to its own codegen artifacts.
+
+## Solution
+
+Split the watch behavior by backend:
+
+1. keep the old in-process `generateMeta(...)` path for Convex
+2. for Concave, run a fresh `kitcn codegen` child process from the watcher
+3. treat both `generated/**` and `_generated/**` as watcher-owned outputs
+4. pass the resolved backend into the watcher child so `kitcn dev --backend concave`
+   does not silently fall back to Convex behavior
+
+The key detail is the fresh child process. Manual `kitcn codegen` already
+worked, so the watcher should reuse that exact behavior instead of trying to
+fake Concave codegen inline.
+
+## Verification
+
+- `bun test ./packages/kitcn/src/cli/watcher.test.ts ./packages/kitcn/src/cli/commands/dev.test.ts`
+- `bun lint:fix`
+- `bun typecheck`
+- `bun --cwd packages/kitcn build`
+- fresh temp app:
+  - `bun run scenario:prepare -- next`
+  - `cd tmp/scenarios/next/project`
+  - `./node_modules/.bin/kitcn dev`
+  - edit `convex/functions/schema.ts`
+  - confirm `_generated/dataModel.d.ts` updates without manual `kitcn codegen`
+
+## Prevention
+
+1. Concave watcher fixes must verify the real backend-owned `_generated/**`
+   output, not only kitcn-owned `generated/**`.
+2. If a manual CLI command works but the watch lane does not, prefer reusing
+   the real CLI behavior over rebuilding the flow from partial helpers.
+3. Never watch backend-generated output directories as if they were source
+   files.

--- a/packages/kitcn/src/cli/commands/dev.test.ts
+++ b/packages/kitcn/src/cli/commands/dev.test.ts
@@ -899,6 +899,16 @@ describe('cli/commands/dev', () => {
         targetOrigin: 'http://127.0.0.1:3210',
       });
       expect(calls).toHaveLength(2);
+      expect(calls[0]).toEqual(
+        expect.objectContaining({
+          cmd: 'bun',
+          opts: expect.objectContaining({
+            env: expect.objectContaining({
+              KITCN_BACKEND: 'concave',
+            }),
+          }),
+        })
+      );
       expect(calls[1]).toEqual(
         expect.objectContaining({
           cmd: 'bun',

--- a/packages/kitcn/src/cli/commands/dev.ts
+++ b/packages/kitcn/src/cli/commands/dev.ts
@@ -1239,7 +1239,9 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
     cwd: process.cwd(),
     env: {
       ...createCommandEnv(localNodeEnvOverrides),
+      KITCN_BACKEND: backend,
       KITCN_API_OUTPUT_DIR: sharedDir || '',
+      ...(parsed.configPath ? { KITCN_CONFIG_PATH: parsed.configPath } : {}),
       KITCN_DEBUG: debug ? '1' : '',
       KITCN_CODEGEN_SCOPE: 'all',
       KITCN_CODEGEN_TRIM_SEGMENTS: JSON.stringify(trimSegments),

--- a/packages/kitcn/src/cli/watcher.test.ts
+++ b/packages/kitcn/src/cli/watcher.test.ts
@@ -2,7 +2,14 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { getWatchRoots, shouldIgnoreWatchPath, startWatcher } from './watcher';
+import {
+  getWatchRoots,
+  runWatcherCodegen,
+  shouldIgnoreWatchPath,
+  startWatcher,
+} from './watcher';
+
+const CLI_TS_RE = /\/cli\.ts$/;
 
 describe('cli/watcher', () => {
   test('getWatchRoots includes the functions dir and sibling routers dir', () => {
@@ -20,6 +27,13 @@ describe('cli/watcher', () => {
     expect(
       shouldIgnoreWatchPath(
         '/repo/convex/generated/auth.ts',
+        functionsDir,
+        outputFile
+      )
+    ).toBe(true);
+    expect(
+      shouldIgnoreWatchPath(
+        '/repo/convex/_generated/api.d.ts',
         functionsDir,
         outputFile
       )
@@ -48,6 +62,158 @@ describe('cli/watcher', () => {
         outputFile
       )
     ).toBe(false);
+  });
+
+  test('runWatcherCodegen uses full codegen flow for concave backend', async () => {
+    const generateMetaStub = mock(async () => {});
+    const execaStub = mock(async () => ({
+      exitCode: 0,
+      stderr: '',
+      stdout: '',
+    }));
+    const loadCliConfigStub = mock(() => ({
+      backend: 'concave' as const,
+      codegen: {
+        args: ['--typecheck'],
+        debug: false,
+        scope: 'all' as const,
+        trimSegments: ['plugins'],
+      },
+    }));
+
+    await runWatcherCodegen(
+      {
+        backendArg: 'concave',
+        configPath: 'custom.json',
+        debug: true,
+        scope: 'orm',
+        sharedDir: 'out',
+        trimSegments: ['plugins', 'generated'],
+      },
+      {
+        resolveRunDeps: () =>
+          ({
+            execa: execaStub as never,
+            generateMeta: generateMetaStub as never,
+            loadCliConfig: loadCliConfigStub as never,
+            syncEnv: mock(async () => {}) as never,
+          }) as never,
+        resolveConfiguredBackendFn: (() => 'concave') as never,
+      }
+    );
+
+    expect(loadCliConfigStub).toHaveBeenCalledWith('custom.json');
+    expect(generateMetaStub).not.toHaveBeenCalled();
+    expect(execaStub).toHaveBeenCalledWith(
+      'bun',
+      [
+        expect.stringMatching(CLI_TS_RE),
+        'codegen',
+        '--backend',
+        'concave',
+        '--scope',
+        'orm',
+        '--api',
+        'out',
+        '--config',
+        'custom.json',
+        '--debug',
+      ],
+      expect.objectContaining({
+        cwd: process.cwd(),
+        reject: false,
+        stdio: 'pipe',
+      })
+    );
+  });
+
+  test('runWatcherCodegen keeps generateMeta-only flow for convex backend', async () => {
+    const generateMetaStub = mock(async () => {});
+    const execaStub = mock(async () => ({
+      exitCode: 0,
+      stderr: '',
+      stdout: '',
+    }));
+    const loadCliConfigStub = mock(() => ({
+      backend: 'convex' as const,
+      codegen: {
+        args: [],
+        debug: false,
+        scope: 'all' as const,
+        trimSegments: ['plugins'],
+      },
+    }));
+
+    await runWatcherCodegen(
+      {
+        backendArg: 'convex',
+        debug: true,
+        scope: 'orm',
+        sharedDir: 'out',
+        trimSegments: ['plugins', 'generated'],
+      },
+      {
+        resolveRunDeps: () =>
+          ({
+            execa: execaStub as never,
+            generateMeta: generateMetaStub as never,
+            loadCliConfig: loadCliConfigStub as never,
+            syncEnv: mock(async () => {}) as never,
+          }) as never,
+        resolveConfiguredBackendFn: (() => 'convex') as never,
+      }
+    );
+
+    expect(generateMetaStub).toHaveBeenCalledWith('out', {
+      debug: true,
+      scope: 'orm',
+      silent: true,
+      trimSegments: ['plugins', 'generated'],
+    });
+    expect(execaStub).not.toHaveBeenCalled();
+  });
+
+  test('startWatcher uses watcher codegen flow when backend env is concave', async () => {
+    const previousBackend = process.env.KITCN_BACKEND;
+    process.env.KITCN_BACKEND = 'concave';
+
+    const generateMetaStub = mock(async () => {});
+    const runWatcherCodegenStub = mock(async () => {});
+    const handlers: Record<string, (...args: unknown[]) => void> = {};
+    const watcher = {
+      on(event: string, cb: (...args: unknown[]) => void) {
+        handlers[event] = cb;
+        return watcher;
+      },
+    };
+
+    try {
+      await startWatcher({
+        debounceMs: 10,
+        watch: () => watcher,
+        generateMeta: generateMetaStub as never,
+        getConvexConfig: (() => ({
+          functionsDir: '/repo/convex',
+          outputFile: '/repo/out/api.ts',
+        })) as never,
+        runWatcherCodegen: runWatcherCodegenStub as never,
+      });
+
+      handlers.change?.();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(runWatcherCodegenStub).toHaveBeenCalledWith({
+        backendArg: 'concave',
+        configPath: undefined,
+        debug: false,
+        scope: 'all',
+        sharedDir: undefined,
+        trimSegments: undefined,
+      });
+      expect(generateMetaStub).not.toHaveBeenCalled();
+    } finally {
+      process.env.KITCN_BACKEND = previousBackend;
+    }
   });
 
   test('startWatcher debounces add/change/unlink events and calls generateMeta', async () => {

--- a/packages/kitcn/src/cli/watcher.ts
+++ b/packages/kitcn/src/cli/watcher.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveConfiguredBackend, resolveRunDeps } from './backend-core.js';
 import { generateMeta, getConvexConfig } from './codegen.js';
+import type { CliBackend } from './config.js';
 import { logger } from './utils/logger.js';
 
 type WatcherLike = {
@@ -13,10 +15,47 @@ type WatchOptions = {
   ignored: (watchedPath: string) => boolean;
 };
 
+type WatcherCodegenParams = {
+  backendArg?: CliBackend;
+  configPath?: string;
+  debug: boolean;
+  scope: 'all' | 'auth' | 'orm';
+  sharedDir?: string;
+  trimSegments?: string[];
+};
+
+type WatcherCodegenDeps = {
+  resolveConfiguredBackendFn?: typeof resolveConfiguredBackend;
+  resolveRunDeps?: typeof resolveRunDeps;
+};
+
 export function getWatchRoots(functionsDir: string): string[] {
   // Watch the real roots. chokidar v5 dropped glob support.
   const convexDir = path.dirname(functionsDir);
   return [functionsDir, path.join(convexDir, 'routers')];
+}
+
+function parseWatcherBackendEnv(
+  value: string | undefined
+): CliBackend | undefined {
+  if (value === 'convex' || value === 'concave') {
+    return value;
+  }
+  return undefined;
+}
+
+function resolveWatcherCliCommand(
+  currentFilename = fileURLToPath(import.meta.url)
+) {
+  const currentDir = path.dirname(currentFilename);
+  const isTs = currentFilename.endsWith('.ts');
+
+  return {
+    cliPath: isTs
+      ? path.join(currentDir, 'cli.ts')
+      : path.join(currentDir, 'cli.mjs'),
+    runtime: isTs ? 'bun' : 'node',
+  };
 }
 
 function parseTrimSegmentsEnv(value: string | undefined): string[] | undefined {
@@ -63,6 +102,7 @@ export function shouldIgnoreWatchPath(
   const normalizedPath = path.resolve(watchedPath);
   const normalizedFunctionsDir = path.resolve(functionsDir);
   const normalizedOutputFile = path.resolve(outputFile);
+  const convexGeneratedDir = path.join(normalizedFunctionsDir, '_generated');
   const generatedDir = path.join(normalizedFunctionsDir, 'generated');
   const generatedFile = path.join(normalizedFunctionsDir, 'generated.ts');
 
@@ -71,6 +111,13 @@ export function shouldIgnoreWatchPath(
   }
 
   if (normalizedPath === generatedFile) {
+    return true;
+  }
+
+  if (
+    normalizedPath === convexGeneratedDir ||
+    normalizedPath.startsWith(`${convexGeneratedDir}${path.sep}`)
+  ) {
     return true;
   }
 
@@ -84,7 +131,68 @@ export function shouldIgnoreWatchPath(
   return normalizedPath.endsWith('.runtime.ts');
 }
 
+export async function runWatcherCodegen(
+  params: WatcherCodegenParams,
+  deps: WatcherCodegenDeps = {}
+) {
+  const resolveRunDepsFn = deps.resolveRunDeps ?? resolveRunDeps;
+  const resolveConfiguredBackendFn =
+    deps.resolveConfiguredBackendFn ?? resolveConfiguredBackend;
+  const {
+    execa: execaFn,
+    generateMeta: generateMetaFn,
+    loadCliConfig: loadCliConfigFn,
+  } = resolveRunDepsFn();
+  const config = loadCliConfigFn(params.configPath);
+  const backend = resolveConfiguredBackendFn({
+    backendArg: params.backendArg,
+    config,
+  });
+
+  if (backend !== 'concave') {
+    await generateMetaFn(params.sharedDir, {
+      debug: params.debug,
+      silent: true,
+      scope: params.scope,
+      trimSegments: params.trimSegments,
+    });
+    return;
+  }
+
+  const { cliPath, runtime } = resolveWatcherCliCommand();
+  const args = [
+    cliPath,
+    'codegen',
+    '--backend',
+    'concave',
+    '--scope',
+    params.scope,
+  ];
+  if (params.sharedDir) {
+    args.push('--api', params.sharedDir);
+  }
+  if (params.configPath) {
+    args.push('--config', params.configPath);
+  }
+  if (params.debug) {
+    args.push('--debug');
+  }
+
+  const result = await execaFn(runtime, args, {
+    cwd: process.cwd(),
+    reject: false,
+    stdio: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Watcher codegen failed with exit code ${result.exitCode}.\n${`${result.stdout ?? ''}\n${result.stderr ?? ''}`.trim()}`
+    );
+  }
+}
+
 export async function startWatcher(opts?: {
+  backend?: CliBackend;
+  configPath?: string;
   sharedDir?: string;
   debug?: boolean;
   scope?: 'all' | 'auth' | 'orm';
@@ -93,7 +201,11 @@ export async function startWatcher(opts?: {
   watch?: (patterns: string[], options: WatchOptions) => WatcherLike;
   generateMeta?: typeof generateMeta;
   getConvexConfig?: typeof getConvexConfig;
+  runWatcherCodegen?: typeof runWatcherCodegen;
 }): Promise<WatcherLike> {
+  const backendArg =
+    opts?.backend ?? parseWatcherBackendEnv(process.env.KITCN_BACKEND);
+  const configPath = opts?.configPath ?? process.env.KITCN_CONFIG_PATH;
   const sharedDir =
     opts?.sharedDir ?? (process.env.KITCN_API_OUTPUT_DIR || undefined);
   const debug = opts?.debug ?? process.env.KITCN_DEBUG === '1';
@@ -107,6 +219,7 @@ export async function startWatcher(opts?: {
   const debounceMs = opts?.debounceMs ?? 100;
   const resolveConfig = opts?.getConvexConfig ?? getConvexConfig;
   const runGenerateMeta = opts?.generateMeta ?? generateMeta;
+  const runWatchCodegen = opts?.runWatcherCodegen ?? runWatcherCodegen;
 
   const { functionsDir, outputFile } = resolveConfig(sharedDir);
   const watchRoots = getWatchRoots(functionsDir);
@@ -149,7 +262,18 @@ export async function startWatcher(opts?: {
 
     generateMetaInFlight = true;
     try {
-      await runGenerateMeta(sharedDir, createGenerateOptions());
+      if (backendArg || configPath) {
+        await runWatchCodegen({
+          backendArg,
+          configPath,
+          debug,
+          scope,
+          sharedDir,
+          trimSegments,
+        });
+      } else {
+        await runGenerateMeta(sharedDir, createGenerateOptions());
+      }
       logger.success('Convex api updated');
     } catch (error) {
       logger.error('Watch codegen error:', error);


### PR DESCRIPTION
| Check | Result |
| --- | --- |
| PR | [#163](https://github.com/udecode/kitcn/pull/163) |
| Issue | [#159](https://github.com/udecode/kitcn/issues/159) |
| Confidence | 🟢 97% |

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | ✅ Direct prepared Concave app repro showed stale `_generated/dataModel.d.ts` after `schema.ts` edits until manual `kitcn codegen` | ➖ N/A |
| Verified | 🟢 `watcher` + `dev` suites green; `lint:fix`; `typecheck`; `packages/kitcn build`; `bun check`; live Concave repro green | ➖ N/A |

**✅ Outcome**
- `schema.ts` edits under Concave local `kitcn dev` now rerun fresh codegen, so `_generated/dataModel.d.ts` updates without a manual `kitcn codegen`
- watcher ignores backend-owned `generated/**` and `_generated/**` outputs, so it stops treating generated files as source inputs
- `kitcn dev --backend concave` now passes the resolved backend into the watcher child, so the watch lane stays on the Concave path

**⚠️ Caveat**
- live proof used the direct prepared app command `./node_modules/.bin/kitcn dev` in `tmp/scenarios/next/project`
- I did not reproduce the exact Windows once-per-second loop on macOS, but this closes the self-trigger watch path that could cause that class of churn

**🏗️ Design**
- Chosen seam: `packages/kitcn/src/cli/watcher.ts` plus watcher child env in `packages/kitcn/src/cli/commands/dev.ts`
- Why not quick patch: rerunning `generateMeta` harder still leaves Concave-owned `_generated` schema output stale
- Why not broader change: the bug lived in the watcher/codegen seam, not in the whole dev orchestrator

**🧪 Verified**
- `bun test ./packages/kitcn/src/cli/watcher.test.ts ./packages/kitcn/src/cli/commands/dev.test.ts`
- `bun lint:fix`
- `bun typecheck`
- `bun --cwd packages/kitcn build`
- `bun check`
- live repro:
  - `bun run scenario:prepare -- next`
  - `cd tmp/scenarios/next/project`
  - `./node_modules/.bin/kitcn dev`
  - edit `convex/functions/schema.ts` to add `author: text()`
  - confirm `convex/functions/_generated/dataModel.d.ts` updates without manual codegen
