### PR TITLE
docs: surface jwks sync commands earlier

### DIFF
--- a/packages/kitcn/skills/convex/references/setup/auth.md
+++ b/packages/kitcn/skills/convex/references/setup/auth.md
@@ -272,7 +272,15 @@ Repair / remote sync:
 bunx kitcn env push
 ```
 
-Use this for `--prod` or explicit repair against an already active deployment.
+Use this to sync static `JWKS` onto the target deployment too.
+
+```bash
+bunx kitcn env push --prod
+bunx kitcn env push --rotate
+```
+
+Use `--prod` for production and `--rotate` when you want fresh keys plus fresh
+`JWKS`. See `/docs/cli/backend#env` for the full env command surface.
 
 Rotate later:
 

--- a/www/content/docs/auth/server.mdx
+++ b/www/content/docs/auth/server.mdx
@@ -474,6 +474,21 @@ convex({
 })
 ```
 
+Use `kitcn env push` to sync the static `JWKS` value:
+
+```bash
+# Sync local deployment env, including JWKS
+npx kitcn env push
+
+# Sync production deployment env, including JWKS
+npx kitcn env push --prod
+
+# Rotate auth keys, then push fresh JWKS
+npx kitcn env push --rotate
+```
+
+See [CLI env commands](/docs/cli/backend#env) for the full target/repair flow.
+
 See [Authentication Flow](/docs/auth#authentication-flow) to understand why this matters.
 
 #### Custom Base Path


### PR DESCRIPTION
| Check | Result |
| --- | --- |
| PR | [#164](https://github.com/udecode/kitcn/pull/164) |
| Issue | [#162](https://github.com/udecode/kitcn/issues/162) |
| Confidence | 🟢 96% |

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | ✅ Issue text matched current docs split: static JWKS explained in auth docs, sync command buried in CLI env docs | ➖ N/A |
| Verified | ✅ Docs updated in `www` and synced skill ref; `bun check` started and stayed green through lint/typecheck/tests/fixtures while running the long scenario tail | ➖ N/A |

**✅ Outcome**
- surfaced `kitcn env push` directly in the first static JWKS section of the auth server docs
- added the exact local / prod / rotate commands there
- synced the compressed auth setup skill reference so agents tell the same story

**⚠️ Caveat**
- `bun check` is very long in this repo; it stayed green through the heavy gate phases in this turn, but I did not wait for every final scenario log line before opening this docs-only PR

**🏗️ Design**
- Chosen seam: `www/content/docs/auth/server.mdx` plus the synced skill ref at `packages/kitcn/skills/convex/references/setup/auth.md`
- Why not quick patch: changing only the skill or only the site docs would keep the other surface drifting

**🧪 Verified**
- issue repro against current docs copy
- `bun check` kicked off and stayed green through lint, typecheck, test suites, fixtures, and scenario gate progress in this turn
