### PR TITLE
fix: normalize aggregate timestamp range filters

### DIFF
--- a/.changeset/smooth-cows-invite.md
+++ b/.changeset/smooth-cows-invite.md
@@ -5,3 +5,6 @@
 ## Patches
 
 - Fix Concave local `kitcn dev` schema watches so `schema.ts` edits rerun fresh codegen and refresh generated schema outputs without a manual `kitcn codegen`.
+- Fix `count()` and aggregate range filters on `timestamp({ mode: "string" })`
+  aggregateIndex suffix fields so stored millis buckets match ISO-string
+  filters instead of silently returning zero.

--- a/docs/plans/2026-04-06-issue-156-count-range-plan.md
+++ b/docs/plans/2026-04-06-issue-156-count-range-plan.md
@@ -1,0 +1,12 @@
+# Issue 156 plan
+
+- Source: GitHub issue #156 `count() with range query on composite aggregateIndex suffix silently returns 0`
+- Type: bug, package code, non-trivial
+- Repro seam: aggregate/count planner emits string-mode timestamp range values as ISO strings; aggregate buckets store numeric millis
+- Chosen seam: normalize aggregate/count comparable values inside `packages/kitcn/src/orm/aggregate-index/runtime.ts`
+- Why not quick patch: fixing only `count()` would leave `aggregate()` and OR-collapse paths inconsistent
+- Verification:
+  - targeted Vitest regression for string-mode timestamp range count
+  - `bun --cwd packages/kitcn typecheck`
+  - `bun --cwd packages/kitcn build`
+- Release artifact: update existing unreleased `.changeset/smooth-cows-invite.md`

--- a/docs/solutions/logic-errors/aggregate-range-filters-must-normalize-string-mode-timestamps-20260406.md
+++ b/docs/solutions/logic-errors/aggregate-range-filters-must-normalize-string-mode-timestamps-20260406.md
@@ -1,0 +1,120 @@
+---
+title: Aggregate range filters must normalize string-mode timestamps before bucket reads
+date: 2026-04-06
+category: logic-errors
+module: orm
+problem_type: logic_error
+component: database
+symptoms:
+  - count() on a composite aggregateIndex returns 0 for eq-prefix plus range-suffix filters on timestamp({ mode: "string" })
+  - findMany() over the matching normal index returns rows for the same where clause
+  - no COUNT_NOT_INDEXED or COUNT_FILTER_UNSUPPORTED error is raised
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - aggregate
+  - count
+  - orm
+  - timestamp
+  - range
+  - aggregate-index
+  - string-mode
+---
+
+# Aggregate range filters must normalize string-mode timestamps before bucket reads
+
+## Problem
+
+`count()` and aggregate reads over a composite `aggregateIndex` could silently
+return `0` when the suffix range field used `timestamp({ mode: "string" })`.
+
+The planner matched the right aggregate index, but the final bucket filter
+compared stored numeric millis against unnormalized ISO-string bounds.
+
+## Symptoms
+
+- `count({ where: { status: "completed", updatedAt: { gte, lte } } })`
+  returns `0`
+- the same `where` via `findMany()` returns the expected rows
+- planner output shows the correct aggregate index and range field, so the bug
+  hides below index selection
+
+## What Didn't Work
+
+- chasing `pickRangeAggregateIndex(...)` first; the range plan was already
+  correct
+- blaming key-hash prefix scans; synthetic string-key buckets matched fine
+- checking `matchesRangeComparisons(...)` in isolation with string inputs; the
+  real failure only appears when bucket key parts are numeric millis
+
+## Solution
+
+Normalize aggregate/count comparable values through the same temporal write-path
+used by normal query filters.
+
+```ts
+const normalizeAggregateComparableValue = (
+  tableConfig: TableRelationalConfig,
+  fieldName: string,
+  value: unknown
+): unknown => {
+  if (fieldName === INTERNAL_CREATION_TIME_FIELD) {
+    if (value instanceof Date) {
+      return value.getTime();
+    }
+    if (Array.isArray(value)) {
+      return value.map((entry) =>
+        entry instanceof Date ? entry.getTime() : entry
+      );
+    }
+    return value;
+  }
+
+  return normalizeTemporalComparableValue(
+    tableConfig.table as any,
+    fieldName,
+    value
+  );
+};
+```
+
+Use that normalization inside aggregate filter parsing for:
+
+- scalar equality values
+- `in` arrays
+- `gt` / `gte` / `lt` / `lte` range bounds
+
+Add a regression proving `readCountFromBuckets(...)` matches a numeric
+aggregate bucket when the public where-clause uses ISO-string timestamp bounds.
+
+## Why This Works
+
+`timestamp({ mode: "string" })` is a public API shape, not the storage shape.
+Writes normalize those values to millis before they reach Convex, and aggregate
+bucket keys are built from the stored document shape.
+
+Before this fix, aggregate/count planning preserved ISO strings in
+`rangeConstraint.comparisons`, so bucket reads compared:
+
+- stored key part: `number`
+- filter bound: `string`
+
+That type mismatch never threw. It just made every range comparison fail, which
+collapsed the result to zero.
+
+Normalizing planner values at parse time fixes the whole aggregate path instead
+of patching only `count()`.
+
+## Prevention
+
+- Any aggregate/count planner path that parses public filters must normalize
+  temporal values to storage shape before constraint matching
+- When aggregate planner output looks correct but results are empty, test with a
+  synthetic bucket row that uses stored values, not hydrated public values
+- Keep regression coverage at the bucket-read seam, not just planner selection
+
+## Related Issues
+
+- [GitHub issue #156](https://github.com/udecode/kitcn/issues/156)
+- [Aggregate cursor planners must treat createdAt as the implicit _creationTime index suffix](./aggregate-created-at-cursor-alias-must-map-to-implicit-creationtime-index-20260325.md)

--- a/packages/kitcn/src/orm/aggregate-index/runtime.ts
+++ b/packages/kitcn/src/orm/aggregate-index/runtime.ts
@@ -3,6 +3,7 @@ import type {
   GenericDatabaseWriter,
 } from 'convex/server';
 import type { GenericId, Value } from 'convex/values';
+import { normalizeTemporalComparableValue } from '../mutation-utils';
 import { Columns } from '../symbols';
 import {
   INTERNAL_CREATION_TIME_FIELD,
@@ -307,6 +308,30 @@ const withFieldConstraint = (
   return next;
 };
 
+const normalizeAggregateComparableValue = (
+  tableConfig: TableRelationalConfig,
+  fieldName: string,
+  value: unknown
+): unknown => {
+  if (fieldName === INTERNAL_CREATION_TIME_FIELD) {
+    if (value instanceof Date) {
+      return value.getTime();
+    }
+    if (Array.isArray(value)) {
+      return value.map((entry) =>
+        entry instanceof Date ? entry.getTime() : entry
+      );
+    }
+    return value;
+  }
+
+  return normalizeTemporalComparableValue(
+    tableConfig.table as any,
+    fieldName,
+    value
+  );
+};
+
 const pushConstraint = (
   target: ConstraintMap,
   fieldName: string,
@@ -401,6 +426,7 @@ const normalizeConstraints = (
 };
 
 const parseFieldFilter = (
+  tableConfig: TableRelationalConfig,
   fieldName: string,
   value: unknown,
   target: ConstraintMap,
@@ -408,7 +434,9 @@ const parseFieldFilter = (
   methodName: string
 ): void => {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    pushConstraint(target, fieldName, [value]);
+    pushConstraint(target, fieldName, [
+      normalizeAggregateComparableValue(tableConfig, fieldName, value),
+    ]);
     return;
   }
 
@@ -431,7 +459,14 @@ const parseFieldFilter = (
       );
     }
     for (const entry of andEntries) {
-      parseFieldFilter(fieldName, entry, target, codes, methodName);
+      parseFieldFilter(
+        tableConfig,
+        fieldName,
+        entry,
+        target,
+        codes,
+        methodName
+      );
     }
   }
 
@@ -439,7 +474,9 @@ const parseFieldFilter = (
 
   if (Object.hasOwn(filter, 'eq')) {
     hasRecognizedOperator = true;
-    pushConstraint(target, fieldName, [filter.eq]);
+    pushConstraint(target, fieldName, [
+      normalizeAggregateComparableValue(tableConfig, fieldName, filter.eq),
+    ]);
   }
 
   if (Object.hasOwn(filter, 'in')) {
@@ -452,7 +489,15 @@ const parseFieldFilter = (
         `field '${fieldName}'.in must be an array.`
       );
     }
-    pushConstraint(target, fieldName, inValues);
+    pushConstraint(
+      target,
+      fieldName,
+      normalizeAggregateComparableValue(
+        tableConfig,
+        fieldName,
+        inValues
+      ) as unknown[]
+    );
   }
 
   if (Object.hasOwn(filter, 'isNull')) {
@@ -489,7 +534,11 @@ const parseFieldFilter = (
     }
     pushRangeComparison(target, fieldName, {
       operator,
-      value: boundValue,
+      value: normalizeAggregateComparableValue(
+        tableConfig,
+        fieldName,
+        boundValue
+      ),
     });
   }
 
@@ -583,7 +632,14 @@ const parseFiniteOrBranch = (options: {
         `filter field '${key}' is not recognized.`
       );
     }
-    parseFieldFilter(normalizedKey, value, constraints, codes, methodName);
+    parseFieldFilter(
+      tableConfig,
+      normalizedKey,
+      value,
+      constraints,
+      codes,
+      methodName
+    );
   }
 
   normalizeConstraints(constraints, codes, methodName);
@@ -838,7 +894,14 @@ const parseWhereObject = (
 
     const normalizedKey = normalizeFilterFieldName(tableConfig, key);
     if (columnNames.has(normalizedKey)) {
-      parseFieldFilter(normalizedKey, value, target, codes, methodName);
+      parseFieldFilter(
+        tableConfig,
+        normalizedKey,
+        value,
+        target,
+        codes,
+        methodName
+      );
       continue;
     }
 

--- a/packages/kitcn/src/orm/query.is-nullish.test.ts
+++ b/packages/kitcn/src/orm/query.is-nullish.test.ts
@@ -1,9 +1,13 @@
 import {
   compileAggregateQueryPlan,
   compileCountQueryPlan,
+  readCountFromBuckets,
+  serializeCountKeyParts,
 } from './aggregate-index/runtime';
 import { integer } from './builders/number';
 import { text } from './builders/text';
+import { textEnum } from './builders/text-enum';
+import { timestamp } from './builders/timestamp';
 import { fieldRef, isNotNull, isNull } from './filter-expression';
 import { aggregateIndex } from './indexes';
 import { GelRelationalQuery } from './query';
@@ -32,6 +36,22 @@ describe('GelRelationalQuery nullish filter compilation', () => {
         .sum(t.dueDate),
     ]
   );
+  const workflowRuns = convexTable(
+    'workflow_runs_query_mode_test',
+    {
+      status: textEnum([
+        'queued',
+        'running',
+        'completed',
+        'failed',
+        'canceled',
+      ]).notNull(),
+      updatedAt: timestamp({ mode: 'string' }).notNull(),
+    },
+    (t) => [
+      aggregateIndex('all_runs_by_status_updated').on(t.status, t.updatedAt),
+    ]
+  );
 
   const createQuery = (table: any = users) =>
     new (GelRelationalQuery as any)(
@@ -42,6 +62,48 @@ describe('GelRelationalQuery nullish filter compilation', () => {
       {},
       'many'
     );
+
+  const createBucketDb = (rows: Array<Record<string, unknown>>) => ({
+    query() {
+      return {
+        withIndex(_name: string, apply: (q: any) => any) {
+          const filters: Array<{
+            field: string;
+            operator: 'eq' | 'gte' | 'lt';
+            value: unknown;
+          }> = [];
+          const query = {
+            eq(field: string, value: unknown) {
+              filters.push({ field, operator: 'eq', value });
+              return query;
+            },
+            gte(field: string, value: unknown) {
+              filters.push({ field, operator: 'gte', value });
+              return query;
+            },
+            lt(field: string, value: unknown) {
+              filters.push({ field, operator: 'lt', value });
+              return query;
+            },
+            collect: async () =>
+              rows.filter((row) =>
+                filters.every((filter) => {
+                  const rowValue = row[filter.field];
+                  if (filter.operator === 'eq') {
+                    return rowValue === filter.value;
+                  }
+                  if (filter.operator === 'gte') {
+                    return rowValue >= filter.value;
+                  }
+                  return rowValue < filter.value;
+                })
+              ),
+          };
+          return apply(query);
+        },
+      };
+    },
+  });
 
   it('compiles isNull() to (field == null OR field == undefined)', () => {
     const expr = isNull(fieldRef<any>('deletedAt') as any) as any;
@@ -275,5 +337,36 @@ describe('GelRelationalQuery nullish filter compilation', () => {
       fieldName: '_creationTime',
       prefixFields: ['userId', 'deletionTime'],
     });
+  });
+
+  it('normalizes string-mode timestamp ranges before reading aggregate buckets', async () => {
+    const from = '2026-03-06T00:00:00.000Z';
+    const to = '2026-04-06T00:00:00.000Z';
+    const matchingUpdatedAt = Date.parse('2026-03-15T00:00:00.000Z');
+    const plan = compileCountQueryPlan(
+      { table: workflowRuns, name: workflowRuns.tableName, relations: {} },
+      {
+        status: 'completed',
+        updatedAt: { gte: from, lte: to },
+      }
+    );
+    const db = createBucketDb([
+      {
+        _id: 'bucket-1',
+        tableKey: 'workflow_runs_query_mode_test',
+        indexName: 'all_runs_by_status_updated',
+        keyHash: serializeCountKeyParts(['completed', matchingUpdatedAt]),
+        keyParts: ['completed', matchingUpdatedAt],
+        count: 4,
+        sumValues: {},
+        nonNullCountValues: {},
+      },
+    ]);
+
+    await expect(readCountFromBuckets(db as any, plan)).resolves.toBe(4);
+    expect(plan.rangeConstraint?.comparisons).toEqual([
+      { operator: 'gte', value: Date.parse(from) },
+      { operator: 'lte', value: Date.parse(to) },
+    ]);
   });
 });


### PR DESCRIPTION
🐛 Fixes #156
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 | ➖ N/A |
| Verified | 🟢 | ➖ N/A |

**✅ Outcome**
- Fixed aggregate/count range planning so string-mode timestamp filters normalize to storage-shape millis before bucket reads.
- Added a regression that reproduces the silent-zero bug against numeric aggregate buckets.
- Updated the unreleased changeset.
- Captured the learning in `docs/solutions/logic-errors/aggregate-range-filters-must-normalize-string-mode-timestamps-20260406.md`.

**⚠️ Caveat**
- No browser surface.

**🏗️ Design**
- Chosen seam: normalize aggregate/count comparable values during aggregate filter parsing, not later in `count()`.
- Why not quick patch: patching only `count()` would leave `aggregate()` and OR-collapse paths with the same storage-vs-public timestamp mismatch.
- Why not broader change: no need to redesign aggregate bucket storage; the bug was planner input normalization.

**🧪 Verified**
- `bun test packages/kitcn/src/orm/query.is-nullish.test.ts`
- `bun run lint:fix`
- `bun run typecheck`
- `bun --cwd packages/kitcn build`
- `bun run check`
