### PR TITLE
fix: support middleware in parse stubs

### DIFF
--- a/packages/kitcn/src/cli/backend-core.ts
+++ b/packages/kitcn/src/cli/backend-core.ts
@@ -180,6 +180,13 @@ export type MutationCtx = GenericMutationCtx<GenericDataModel>;
 export type ActionCtx = GenericActionCtx<GenericDataModel>;
 export type GenericCtx = QueryCtx | MutationCtx | ActionCtx;
 
+const createMiddleware = (handler?: unknown) => ({
+  _handler: handler,
+  pipe(nextHandler?: unknown) {
+    return createMiddleware(nextHandler);
+  },
+});
+
 const createProcedureBuilder = () => {
   const builder = {
     internal() {
@@ -206,6 +213,9 @@ const createProcedureBuilder = () => {
     action(handler?: unknown) {
       return handler ?? builder;
     },
+    middleware(handler?: unknown) {
+      return createMiddleware(handler);
+    },
   };
 
   return builder;
@@ -221,12 +231,16 @@ export const initCRPC = {
   context() {
     return this;
   },
+  middleware(handler?: unknown) {
+    return createMiddleware(handler);
+  },
   create() {
     return {
       query: createProcedureBuilder(),
       mutation: createProcedureBuilder(),
       action: createProcedureBuilder(),
       httpAction: createProcedureBuilder(),
+      middleware: createMiddleware,
       router: (record = {}) => record,
     };
   },

--- a/packages/kitcn/src/cli/codegen.test.ts
+++ b/packages/kitcn/src/cli/codegen.test.ts
@@ -3346,6 +3346,114 @@ export default createHttpRouter({}, router({}));
     }
   });
 
+  test('generateMeta resolves auth-style c.middleware().pipe() scaffold chains under a bun-style cache path', async () => {
+    const dir = mkTempDir();
+    try {
+      writeFile(
+        path.join(dir, 'convex.json'),
+        `${JSON.stringify({ functions: 'convex/functions' }, null, 2)}\n`
+      );
+      writeFile(
+        path.join(dir, 'node_modules', 'convex', 'package.json'),
+        JSON.stringify({
+          name: 'convex',
+          type: 'module',
+          exports: {
+            './server': './server.js',
+          },
+        })
+      );
+      writeFile(
+        path.join(dir, 'node_modules', 'convex', 'server.js'),
+        `export const queryGeneric = () => ({})
+export const mutationGeneric = () => ({})
+export const actionGeneric = () => ({})
+export const internalQueryGeneric = () => ({})
+export const internalMutationGeneric = () => ({})
+export const internalActionGeneric = () => ({})
+export const GenericActionCtx = {};
+export const GenericDataModel = {};
+export const GenericMutationCtx = {};
+export const GenericQueryCtx = {};
+`.trim()
+      );
+
+      const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kitcn-cache-'));
+      writeFile(
+        path.join(cacheDir, 'package.json'),
+        JSON.stringify({
+          name: 'kitcn',
+          type: 'module',
+          exports: {
+            './server': './dist/server/index.js',
+          },
+        })
+      );
+      writeFile(
+        path.join(cacheDir, 'dist', 'server', 'index.js'),
+        `
+        export { queryGeneric as initCRPC } from 'convex/server';
+        export const createHttpRouter = (_app, httpRouter) => httpRouter ?? {};
+        export const CRPCError = class extends Error {};
+        export const createEnv = ({ schema }) => () => schema?.parse?.(process.env) ?? process.env;
+        `.trim()
+      );
+      fs.mkdirSync(path.join(dir, 'node_modules'), { recursive: true });
+      fs.symlinkSync(cacheDir, path.join(dir, 'node_modules', 'kitcn'));
+
+      writeFile(
+        path.join(dir, 'convex', 'functions', 'schema.ts'),
+        'export default {};'
+      );
+      writeFile(
+        path.join(dir, 'convex', 'functions', 'http.ts'),
+        `
+        import { CRPCError } from 'kitcn/server';
+        import type { QueryCtx } from './generated/server';
+        import { initCRPC } from './generated/server';
+
+        const c = initCRPC
+          .meta<{ auth?: 'required' }>()
+          .create();
+
+        const requireAuth = c.middleware(async ({ ctx, next }) => {
+          if (!(ctx as QueryCtx)) {
+            throw new CRPCError({ code: 'UNAUTHORIZED', message: 'No ctx' });
+          }
+
+          return next({ ctx });
+        });
+
+        export const authRoute = c.httpAction.use(requireAuth.pipe(({ next }) => next({})));
+        export default authRoute;
+        `.trim()
+      );
+
+      const result = Bun.spawnSync(
+        [
+          'bun',
+          '--cwd',
+          path.join(process.cwd(), 'packages', 'kitcn'),
+          '-e',
+          'import { generateMeta } from "./src/cli/codegen.ts"; process.chdir(process.argv[1]); await generateMeta(undefined, { silent: true }); console.log("OK");',
+          dir,
+        ],
+        {
+          cwd: process.cwd(),
+          stderr: 'pipe',
+          stdout: 'pipe',
+        }
+      );
+
+      expect(result.exitCode).toBe(0);
+    } finally {
+      fs.rmSync(path.join(dir, 'node_modules', 'kitcn'), {
+        force: true,
+        recursive: true,
+      });
+    }
+  });
+
   test('generateMeta still logs unexpected http.ts parse failures', async () => {
     const dir = mkTempDir();
     const oldCwd = process.cwd();

--- a/packages/kitcn/src/cli/codegen.ts
+++ b/packages/kitcn/src/cli/codegen.ts
@@ -503,6 +503,13 @@ export type MutationCtx = ServerMutationCtx;
 export type ActionCtx = ServerActionCtx;
 export type GenericCtx = QueryCtx | MutationCtx | ActionCtx;
 
+const createMiddleware = (handler?: unknown) => ({
+  _handler: handler,
+  pipe(nextHandler?: unknown) {
+    return createMiddleware(nextHandler);
+  },
+});
+
 const createProcedureBuilder = () => {
   const builder = {
     internal() {
@@ -529,6 +536,9 @@ const createProcedureBuilder = () => {
     action(handler?: unknown) {
       return handler ?? builder;
     },
+    middleware(handler?: unknown) {
+      return createMiddleware(handler);
+    },
   };
 
   return builder;
@@ -544,12 +554,16 @@ export const initCRPC = {
   context() {
     return this;
   },
+  middleware(handler?: unknown) {
+    return createMiddleware(handler);
+  },
   create() {
     return {
       query: createProcedureBuilder(),
       mutation: createProcedureBuilder(),
       action: createProcedureBuilder(),
       httpAction: createProcedureBuilder(),
+      middleware: createMiddleware,
       router: (record = {}) => record,
     };
   },


### PR DESCRIPTION
🐛 Fixes bunx auth-style bootstrap parse failure
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 | ➖ N/A |
| Verified | 🟢 | ➖ N/A |

**✅ Outcome**
- Fixes the remaining `c.middleware is not a function` bootstrap failure in published `0.12.14`.
- Extends the generated server placeholder / parser stubs to support `middleware()` and `.pipe()` for auth-style scaffold chains.
- Adds a regression for the real auth-style `c.middleware().pipe()` Bun cache path.

**⚠️ Caveat**
- This is the follow-up after the earlier bunx bootstrap fixes. Release `0.12.14` still misses this exact placeholder-side behavior.

**🏗️ Design**
- Chosen seam: generated server placeholder and parser shim, not more parse-failure suppression.
- Why not quick patch: suppressing `http.ts` would just hide another broken bootstrap path.
- Why not broader change: the runtime is fine; only first-pass codegen placeholders were too weak.

**🧪 Verified**
- `bun test ./packages/kitcn/src/cli/codegen.test.ts --test-name-pattern 'symlinked into a bun-style cache path|nested scaffold chain|auth-style c.middleware'`
