### PR TITLE
fix(auth): keep react auth loading during token sync

### DIFF
--- a/.changeset/tidy-auth-flash.md
+++ b/.changeset/tidy-auth-flash.md
@@ -1,0 +1,9 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix React auth hooks so `useAuth()` and `useSafeConvexAuth()` stay loading
+  while a cached session token is still syncing to Convex, which prevents a
+  brief signed-out flash before the signed-in state settles.

--- a/docs/plans/2026-04-10-fix-auth-state-flash.md
+++ b/docs/plans/2026-04-10-fix-auth-state-flash.md
@@ -1,0 +1,34 @@
+## Task
+
+Fix the React auth startup race where `useAuth()` can report
+`{ isLoading: false, isAuthenticated: false }` for a beat even though a cached
+session/token exists and the UI is about to settle to signed-in.
+
+## Source
+
+- User report: spinner disappears, `Logged out` flashes, then `Logged in`
+- Repro clue: browser console shows `GET /api/auth/convex/token 401`
+
+## Findings
+
+- `packages/kitcn/src/auth-client/convex-auth-provider.tsx` already computes a
+  defensive loading state in `AuthStateSync` for `token && !isAuthenticated`.
+- `packages/kitcn/src/react/auth-store.tsx` ignores that synced store state and
+  returns raw `useConvexAuth()` values from both `useAuth()` and
+  `useSafeConvexAuth()`.
+- Solid already reads the synced store state, so React/Solid parity drifted.
+- Auth templates already worked around this with `hasSession || Boolean(user)`,
+  which is evidence the public hook contract was flaky.
+
+## Plan
+
+1. Add failing React tests for the token-present / Convex-not-ready state.
+2. Change the React auth hooks to read the synced store state for kitcn auth.
+3. Verify the change against query skip logic, auth guard, and auth display
+   hooks.
+4. Run targeted tests, `typecheck`, `lint:fix`, and `bun --cwd packages/kitcn build`.
+
+## Release Note
+
+- `packages/kitcn` is published package code.
+- If code changes land, update the active unreleased changeset before handoff.

--- a/docs/solutions/integration-issues/react-auth-hooks-must-read-synced-store-state-during-token-catch-up-20260410.md
+++ b/docs/solutions/integration-issues/react-auth-hooks-must-read-synced-store-state-during-token-catch-up-20260410.md
@@ -1,0 +1,114 @@
+---
+title: React auth hooks must read synced store state during token catch-up
+date: 2026-04-10
+category: integration-issues
+module: react-auth-hooks
+problem_type: integration_issue
+component: authentication
+symptoms:
+  - `useAuth()` can flip from `{ isLoading: true }` to `{ isLoading: false, isAuthenticated: false }` before settling to signed in
+  - auth UIs can briefly render signed-out content even though a cached token or session still exists
+  - `useSafeConvexAuth()` can stop skipping auth-gated queries too early during startup
+  - `/api/auth/convex/token` can transiently return `401` while session sync is still catching up
+root_cause: async_timing
+resolution_type: code_fix
+severity: high
+tags: [auth, react, convex, better-auth, useauth, loading-state]
+---
+
+# React auth hooks must read synced store state during token catch-up
+
+## Problem
+
+The React auth surface had a split brain during startup.
+
+`ConvexAuthProvider` already computed a defensive loading window for
+`token && !isAuthenticated`, but `useAuth()` and `useSafeConvexAuth()` ignored
+that synced state and returned raw `useConvexAuth()` values instead. That let
+the UI briefly render "logged out" before the signed-in state caught up.
+
+## Symptoms
+
+- `useAuth()` shows a spinner, then briefly reports signed out, then flips to
+  signed in
+- auth pages need caller-side workarounds like `hasSession || Boolean(user)` to
+  avoid flicker
+- auth-gated query helpers can treat startup as settled too early
+- the browser can show a transient `401` on `/api/auth/convex/token` during the
+  same window
+
+## What Didn't Work
+
+- treating the page-level workaround as the fix; it hides one caller but leaves
+  the public hook contract wrong
+- assuming `isLoading === false` from raw `useConvexAuth()` means auth is fully
+  settled for kitcn consumers
+
+## Solution
+
+Make the React auth hooks read the synced auth store, not the raw Convex hook,
+when kitcn's `AuthProvider` is active.
+
+Before:
+
+```tsx
+export function useSafeConvexAuth(): ConvexAuthResult {
+  const authStore = useAuthStore();
+
+  if (authStore.store) {
+    return useConvexAuth();
+  }
+
+  return { isAuthenticated: false, isLoading: false };
+}
+```
+
+After:
+
+```tsx
+export function useSafeConvexAuth(): ConvexAuthResult {
+  const authStore = useAuthStore();
+
+  if (authStore.store) {
+    const isAuthenticated = useAuthValue("isAuthenticated");
+    const isLoading = useAuthValue("isLoading");
+    return { isAuthenticated, isLoading };
+  }
+
+  return { isAuthenticated: false, isLoading: false };
+}
+```
+
+Do the same in `useAuth()`:
+
+- keep `hasSession` derived from the cached token
+- read `isAuthenticated` and `isLoading` from `useAuthValue(...)`
+- stop exposing raw `useConvexAuth()` state directly for kitcn auth
+
+## Why This Works
+
+`AuthStateSync` is the owning seam for the startup race. It already knows when
+kitcn should stay loading even though raw Convex auth has not caught up yet.
+
+Once the public React hooks read that synced store state, every caller sees one
+consistent contract:
+
+- token present + Convex still catching up => loading
+- confirmed auth => authenticated
+- confirmed no session => signed out
+
+That matches the Solid implementation too, so React and Solid stop drifting.
+
+## Prevention
+
+- If a provider computes a defensive derived auth state, public hooks must read
+  that derived state instead of bypassing it
+- Keep React and Solid auth hooks behaviorally aligned; parity drift here is
+  expensive
+- Add a regression test for `token present + synced store loading + raw Convex
+  false` so the flash does not come back
+
+## Related Issues
+
+- `docs/solutions/integration-issues/auth-browser-lanes-and-stale-signout-20260321.md`
+- `docs/solutions/integration-issues/start-auth-reload-must-rehydrate-from-persisted-session-token-20260408.md`

--- a/packages/kitcn/src/react/auth-store.test.tsx
+++ b/packages/kitcn/src/react/auth-store.test.tsx
@@ -88,20 +88,47 @@ describe('useSafeConvexAuth / useAuth', () => {
     }
   });
 
-  test('useAuth (kitcn AuthProvider): hasSession reflects token and reads auth state from Convex', () => {
+  test('useAuth (kitcn AuthProvider): hasSession reflects token and reads auth state from the synced store', () => {
+    const wrapper = makeAuthWrapper({
+      token: 'tok',
+      isAuthenticated: false,
+      isLoading: true,
+    });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current).toEqual({
+      hasSession: true,
+      isAuthenticated: false,
+      isLoading: true,
+    });
+  });
+
+  test('kitcn AuthProvider keeps loading while store says token is still syncing', () => {
     const useConvexAuthSpy = spyOn(
       convexReact,
       'useConvexAuth'
     ).mockReturnValue({
       isAuthenticated: false,
-      isLoading: true,
+      isLoading: false,
     } as any);
 
     try {
-      const wrapper = makeAuthWrapper({ token: 'tok' });
-      const { result } = renderHook(() => useAuth(), { wrapper });
+      const wrapper = makeAuthWrapper({
+        token: 'tok',
+        isAuthenticated: false,
+        isLoading: true,
+      });
 
-      expect(result.current).toEqual({
+      const { result: safeAuth } = renderHook(() => useSafeConvexAuth(), {
+        wrapper,
+      });
+      expect(safeAuth.current).toEqual({
+        isAuthenticated: false,
+        isLoading: true,
+      });
+
+      const { result: auth } = renderHook(() => useAuth(), { wrapper });
+      expect(auth.current).toEqual({
         hasSession: true,
         isAuthenticated: false,
         isLoading: true,
@@ -122,48 +149,33 @@ describe('useAuthGuard', () => {
   }
 
   test('calls onMutationUnauthorized and returns true when unauthenticated', () => {
-    const useConvexAuthSpy = spyOn(
-      convexReact,
-      'useConvexAuth'
-    ).mockReturnValue({
+    const onMutationUnauthorized = mock(() => {});
+    const wrapper = makeAuthWrapper({
+      token: 'tok',
       isAuthenticated: false,
       isLoading: false,
-    } as any);
+      onMutationUnauthorized,
+    });
 
-    try {
-      const onMutationUnauthorized = mock(() => {});
-      const wrapper = makeAuthWrapper({ token: 'tok', onMutationUnauthorized });
+    const { result } = renderHook(() => useAuthGuard(), { wrapper });
 
-      const { result } = renderHook(() => useAuthGuard(), { wrapper });
-
-      expect(result.current()).toBe(true);
-      expect(onMutationUnauthorized).toHaveBeenCalledTimes(1);
-    } finally {
-      useConvexAuthSpy.mockRestore();
-    }
+    expect(result.current()).toBe(true);
+    expect(onMutationUnauthorized).toHaveBeenCalledTimes(1);
   });
 
   test('runs callback and returns false/undefined when authenticated', () => {
-    const useConvexAuthSpy = spyOn(
-      convexReact,
-      'useConvexAuth'
-    ).mockReturnValue({
+    const wrapper = makeAuthWrapper({
+      token: 'tok',
       isAuthenticated: true,
       isLoading: false,
-    } as any);
+    });
+    const callback = mock(() => {});
 
-    try {
-      const wrapper = makeAuthWrapper({ token: 'tok' });
-      const callback = mock(() => {});
+    const { result } = renderHook(() => useAuthGuard(), { wrapper });
 
-      const { result } = renderHook(() => useAuthGuard(), { wrapper });
-
-      expect(result.current()).toBe(false);
-      expect(result.current(callback as any)).toBeUndefined();
-      expect(callback).toHaveBeenCalledTimes(1);
-    } finally {
-      useConvexAuthSpy.mockRestore();
-    }
+    expect(result.current()).toBe(false);
+    expect(result.current(callback as any)).toBeUndefined();
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -223,48 +235,36 @@ describe('Auth Components', () => {
   });
 
   test('Authenticated renders children only when authenticated', () => {
-    const useConvexAuthSpy = spyOn(
-      convexReact,
-      'useConvexAuth'
-    ).mockReturnValue({
-      isAuthenticated: true,
-      isLoading: false,
-    } as any);
+    const { queryByTestId } = render(
+      <Authenticated>
+        <div data-testid="x">X</div>
+      </Authenticated>,
+      {
+        wrapper: makeAuthWrapper({
+          token: 'tok',
+          isAuthenticated: true,
+          isLoading: false,
+        }),
+      }
+    );
 
-    try {
-      const { queryByTestId } = render(
-        <Authenticated>
-          <div data-testid="x">X</div>
-        </Authenticated>,
-        { wrapper: makeAuthWrapper({ token: 'tok' }) }
-      );
-
-      expect(queryByTestId('x')).not.toBeNull();
-    } finally {
-      useConvexAuthSpy.mockRestore();
-    }
+    expect(queryByTestId('x')).not.toBeNull();
   });
 
   test('Unauthenticated renders children only when not loading and not authenticated', () => {
-    const useConvexAuthSpy = spyOn(
-      convexReact,
-      'useConvexAuth'
-    ).mockReturnValue({
-      isAuthenticated: false,
-      isLoading: false,
-    } as any);
+    const { queryByTestId } = render(
+      <Unauthenticated>
+        <div data-testid="x">X</div>
+      </Unauthenticated>,
+      {
+        wrapper: makeAuthWrapper({
+          token: 'tok',
+          isAuthenticated: false,
+          isLoading: false,
+        }),
+      }
+    );
 
-    try {
-      const { queryByTestId } = render(
-        <Unauthenticated>
-          <div data-testid="x">X</div>
-        </Unauthenticated>,
-        { wrapper: makeAuthWrapper({ token: 'tok' }) }
-      );
-
-      expect(queryByTestId('x')).not.toBeNull();
-    } finally {
-      useConvexAuthSpy.mockRestore();
-    }
+    expect(queryByTestId('x')).not.toBeNull();
   });
 });

--- a/packages/kitcn/src/react/auth-store.tsx
+++ b/packages/kitcn/src/react/auth-store.tsx
@@ -124,7 +124,11 @@ export function useSafeConvexAuth(): ConvexAuthResult {
   // Check kitcn AuthProvider first
   if (authStore.store) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useConvexAuth();
+    const isAuthenticated = useAuthValue('isAuthenticated');
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const isLoading = useAuthValue('isLoading');
+
+    return { isAuthenticated, isLoading };
   }
 
   // Check ConvexAuthBridge (provides value directly - no conditional hook needed)
@@ -192,11 +196,12 @@ export const useAuth = () => {
       };
     }
 
-    // Use Convex SDK's auth state directly
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { isLoading, isAuthenticated } = useConvexAuth();
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const token = useAuthValue('token');
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const isAuthenticated = useAuthValue('isAuthenticated');
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const isLoading = useAuthValue('isLoading');
 
     return {
       hasSession: !!token,


### PR DESCRIPTION
## Summary
- fix the React auth hook contract so `useAuth()` and `useSafeConvexAuth()` read the synced auth-store state during token/session catch-up
- add a regression test for the `token present + store loading + raw Convex false` startup window that caused the signed-out flash
- document the auth-state race and add a patch changeset for `kitcn`

## Verification
- `bun check`
- `bun test packages/kitcn/src/react/auth-store.test.tsx`
- `bun test packages/kitcn/src/internal/auth.test.tsx`
- `bun test packages/kitcn/src/auth-client/convex-auth-provider.test.tsx`
- `bun typecheck`
- `bun lint:fix`
- `bun --cwd packages/kitcn build`
