### PR TITLE
fix(cli): support raw start auth adoption

### DIFF
--- a/.changeset/raw-start-auth-adoption.md
+++ b/.changeset/raw-start-auth-adoption.md
@@ -1,0 +1,8 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Support `kitcn add auth --preset convex --yes` on TanStack Start apps
+  without falling through the Vite `main.tsx` patch path.

--- a/docs/plans/2026-04-10-support-raw-convex-auth-preset-on-tanstack-start.md
+++ b/docs/plans/2026-04-10-support-raw-convex-auth-preset-on-tanstack-start.md
@@ -1,0 +1,40 @@
+## Goal
+
+Support `kitcn add auth --preset convex --yes` on TanStack Start.
+
+## Why
+
+- raw Convex auth preset already supports Next and Vite
+- TanStack Start is already a detected shell
+- current raw preset falls into generic React/Vite provider patching
+- that path expects `main.tsx`, which Start does not have
+
+## Acceptance
+
+- raw preset succeeds on a TanStack Start shell
+- it keeps raw Convex auth behavior:
+  - no `kitcn.json`
+  - no cRPC scaffold churn
+  - no richer kitcn auth client surface
+  - rerun full preset for schema refresh
+- Start-specific files are scaffolded/patched:
+  - `src/lib/convex/auth-client.ts`
+  - `src/lib/convex/auth-server.ts`
+  - `src/lib/convex/convex-provider.tsx`
+  - `src/routes/api/auth/$.ts`
+- provider patch does not require `main.tsx`
+- CLI coverage proves the Start raw preset path
+
+## Plan
+
+1. Add a failing CLI test for raw Convex auth adoption on TanStack Start.
+2. Add a raw Start fixture/helper if needed.
+3. Patch raw preset plan selection so TanStack Start uses Start-specific auth files.
+4. Run targeted CLI tests.
+5. Run required repo gates for package/scaffold work:
+   - `bun --cwd packages/kitcn build`
+   - `bun lint:fix`
+   - `bun typecheck`
+   - `bun run fixtures:sync`
+   - `bun run fixtures:check`
+6. Update the active unreleased changeset.

--- a/docs/solutions/integration-issues/raw-convex-start-auth-adoption-must-patch-start-provider-and-react-client-20260410.md
+++ b/docs/solutions/integration-issues/raw-convex-start-auth-adoption-must-patch-start-provider-and-react-client-20260410.md
@@ -1,0 +1,89 @@
+---
+title: Raw Convex Start auth adoption must patch Start provider and React client
+category: integration-issues
+tags:
+  - convex
+  - auth
+  - tanstack-start
+  - better-auth
+  - cli
+  - scaffolding
+symptoms:
+  - `kitcn add auth --preset convex --yes` fails on TanStack Start with `Auth preset "convex" requires a Vite-style client entry file (main.tsx/main.jsx).`
+  - raw Convex Start auth adoption writes `process.env.NEXT_PUBLIC_CONVEX_SITE_URL!` into `src/lib/convex/auth-client.ts`
+  - TanStack Start is detected as a supported shell, but raw auth adoption still behaves like plain Vite
+module: auth-adoption
+resolved: 2026-04-10
+---
+
+# Raw Convex Start auth adoption must patch Start provider and React client
+
+## Problem
+
+Raw Convex auth adoption already worked for Next and plain Vite, but
+TanStack Start still fell through the generic React/Vite raw preset path.
+
+That made `kitcn add auth --preset convex --yes` fail on real Start apps even
+though the CLI already detected `tanstack-start` as a supported framework.
+
+## Root Cause
+
+Two raw-preset branches were missing for TanStack Start:
+
+1. provider patch planning only handled Next or plain React/Vite entry files,
+   so Start tried to patch `main.tsx` and failed
+2. template resolution only swapped the default Start auth client template, not
+   the raw Convex auth client template, so Start inherited the Next
+   `NEXT_PUBLIC_CONVEX_SITE_URL` variant
+
+The bug was not in auth bootstrap itself. It was in scaffold selection.
+
+## Solution
+
+Keep the raw Convex preset minimal on TanStack Start.
+
+Do not route Start through the richer kitcn auth scaffold. Instead:
+
+1. patch `src/lib/convex/convex-provider.tsx` in place, the same way raw Next
+   patches its provider shell
+2. keep the raw auth client shape with no `createAuthMutations()`
+3. use the React/Vite raw auth client template for Start so it reads
+   `import.meta.env.VITE_CONVEX_SITE_URL!`
+
+That preserves the raw Convex contract:
+
+- no `kitcn.json`
+- no cRPC scaffold churn
+- no generated `/auth` page
+- no Start auth proxy route
+
+## Verification
+
+- `bun test ./packages/kitcn/src/cli/cli.commands.ts --test-name-pattern 'raw start convex app|raw vite convex app|raw next convex app'`
+- `bun test ./tooling/scenarios.test.ts`
+- `bun --cwd packages/kitcn build`
+- `bun lint:fix`
+- `bun typecheck`
+- `bun run fixtures:sync`
+- `bun run fixtures:check`
+- `bun run scenario:check -- raw-start-auth-adoption`
+
+## Prevention
+
+1. Treat `tanstack-start` as its own raw preset shell, not as a Vite app with
+   a missing `main.tsx`
+2. When a framework gets a shell-specific default auth template, check the raw
+   auth template branch too
+3. For raw preset adoption, patch the narrowest existing provider shell instead
+   of replacing it with the full managed auth baseline
+4. Keep a dedicated bootstrap-heavy raw Start scenario so raw auth adoption
+   drift fails in scenario validation, not in user migration threads
+
+## Files Changed
+
+- `packages/kitcn/src/cli/registry/items/auth/auth-item.ts`
+- `packages/kitcn/src/cli/cli.commands.ts`
+
+## Related
+
+- `docs/solutions/integration-issues/raw-convex-auth-adoption-bootstrap-20260318.md`

--- a/packages/kitcn/src/cli/cli.commands.ts
+++ b/packages/kitcn/src/cli/cli.commands.ts
@@ -311,6 +311,172 @@ export default defineSchema({
   );
 }
 
+function writeRawConvexStartApp(dir: string) {
+  fs.mkdirSync(path.join(dir, 'src', 'components'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'src', 'lib', 'convex'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'src', 'routes'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'convex'), { recursive: true });
+
+  writePackageJson(dir, {
+    name: 'raw-start-convex-app',
+    private: true,
+    type: 'module',
+    dependencies: {
+      '@tanstack/react-router': '^1.132.0',
+      '@tanstack/react-start': '^1.132.0',
+      convex: '^1.33.0',
+      react: '^19.2.4',
+      'react-dom': '^19.2.4',
+    },
+    devDependencies: {
+      '@vitejs/plugin-react': '^5.0.4',
+      vite: '^7.2.4',
+      'vite-tsconfig-paths': '^5.1.4',
+    },
+  });
+
+  fs.writeFileSync(
+    path.join(dir, 'tsconfig.json'),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          baseUrl: '.',
+          jsx: 'react-jsx',
+          paths: {
+            '@/*': ['./src/*'],
+          },
+        },
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'components.json'),
+    `${JSON.stringify(
+      {
+        tailwind: {
+          css: 'src/styles.css',
+        },
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'vite.config.ts'),
+    `import path from 'node:path';
+import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+import tsConfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsConfigPaths(), tanstackStart(), react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});
+`
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'src', 'router.tsx'),
+    `import { createRouter as createTanStackRouter } from '@tanstack/react-router';
+import { routeTree } from './routeTree.gen';
+
+export function getRouter() {
+  return createTanStackRouter({
+    routeTree,
+  });
+}
+`
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'src', 'components', 'providers.tsx'),
+    `import type { ReactNode } from 'react';
+
+import { AppConvexProvider } from '@/lib/convex/convex-provider';
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <AppConvexProvider>{children}</AppConvexProvider>;
+}
+`
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'src', 'lib', 'convex', 'convex-provider.tsx'),
+    `'use client';
+
+import { ConvexProvider, ConvexReactClient } from 'convex/react';
+import type { ReactNode } from 'react';
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
+
+export function AppConvexProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <ConvexProvider client={convex}>{children}</ConvexProvider>;
+}
+`
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'src', 'routes', '__root.tsx'),
+    `import { Outlet, createRootRoute } from '@tanstack/react-router';
+
+import { Providers } from '@/components/providers';
+
+export const Route = createRootRoute({
+  component: RootComponent,
+});
+
+function RootComponent() {
+  return (
+    <Providers>
+      <Outlet />
+    </Providers>
+  );
+}
+`
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'src', 'routes', 'index.tsx'),
+    `import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/' as never)({
+  component: HomePage,
+});
+
+function HomePage() {
+  return <main>raw start convex</main>;
+}
+`
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'convex', 'schema.ts'),
+    `import { defineSchema, defineTable } from 'convex/server';
+import { v } from 'convex/values';
+
+export default defineSchema({
+  messages: defineTable({
+    author: v.string(),
+    body: v.string(),
+  }),
+});
+`
+  );
+}
+
 async function withCiTty<T>(callback: () => Promise<T>): Promise<T> {
   const stdinDescriptor = Object.getOwnPropertyDescriptor(
     process.stdin,
@@ -2312,6 +2478,117 @@ describe('cli/cli', () => {
         'import.meta.env.VITE_CONVEX_SITE_URL!'
       );
       expect(authClientSource).not.toContain('createAuthMutations');
+      expect(
+        execaStub.mock.calls.some((call) => {
+          const [, args] = call as unknown as [string, string[]];
+          return args[0] === '/fake/convex/main.js' && args[1] === 'codegen';
+        })
+      ).toBe(true);
+      expect(syncEnvStub).toHaveBeenCalledWith({
+        authSyncMode: 'auto',
+        force: true,
+        sharedDir: 'convex/shared',
+        targetArgs: [],
+      });
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
+  test('run(add auth --preset convex --yes) adopts a raw start convex app without kitcn baseline churn', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-cli-add-auth-convex-start-')
+    );
+    const oldCwd = process.cwd();
+    writeRawConvexStartApp(dir);
+    fs.writeFileSync(
+      path.join(dir, '.env.local'),
+      'CONVEX_DEPLOYMENT=local:demo\nVITE_CONVEX_URL=http://127.0.0.1:3210\n'
+    );
+    process.chdir(dir);
+
+    try {
+      const execaStub = mock(async (_cmd: string, args: string[]) => {
+        if (args[0] === '/fake/convex/main.js' && args[1] === 'codegen') {
+          return { exitCode: 0, stdout: '', stderr: '' } as any;
+        }
+
+        return { exitCode: 0 } as any;
+      });
+      const generateMetaStub = mock(async () => {});
+      const syncEnvStub = mock(async () => {});
+      const loadConfigStub = mock(() => createDefaultConfig());
+
+      const exitCode = await run(
+        ['add', 'auth', '--preset', 'convex', '--yes'],
+        {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          generateMeta: generateMetaStub as any,
+          syncEnv: syncEnvStub as any,
+          loadCliConfig: loadConfigStub as any,
+        }
+      );
+
+      expect(exitCode).toBe(0);
+      expect(fs.existsSync(path.join(dir, 'kitcn.json'))).toBe(false);
+      expect(
+        fs.existsSync(path.join(dir, 'src', 'lib', 'convex', 'crpc.tsx'))
+      ).toBe(false);
+      expect(
+        fs.existsSync(path.join(dir, 'src', 'lib', 'convex', 'auth-client.ts'))
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(dir, 'src', 'lib', 'convex', 'auth-server.ts'))
+      ).toBe(false);
+      expect(
+        fs.existsSync(path.join(dir, 'src', 'lib', 'convex', 'server.ts'))
+      ).toBe(false);
+      expect(
+        fs.existsSync(path.join(dir, 'src', 'routes', 'api', 'auth', '$.ts'))
+      ).toBe(false);
+      expect(fs.existsSync(path.join(dir, 'src', 'routes', 'auth.tsx'))).toBe(
+        false
+      );
+
+      const providerSource = fs.readFileSync(
+        path.join(dir, 'src', 'lib', 'convex', 'convex-provider.tsx'),
+        'utf8'
+      );
+      expect(providerSource).toContain('ConvexAuthProvider');
+      expect(providerSource).toContain(
+        "import { authClient } from '@/lib/convex/auth-client';"
+      );
+      expect(providerSource).not.toContain('QueryClientProvider');
+      expect(providerSource).not.toContain('CRPCProvider');
+
+      const authClientSource = fs.readFileSync(
+        path.join(dir, 'src', 'lib', 'convex', 'auth-client.ts'),
+        'utf8'
+      );
+      expect(authClientSource).toContain(
+        'import.meta.env.VITE_CONVEX_SITE_URL!'
+      );
+      expect(authClientSource).not.toContain('createAuthMutations');
+
+      const httpSource = fs.readFileSync(
+        path.join(dir, 'convex', 'http.ts'),
+        'utf8'
+      );
+      expect(httpSource).toContain('registerRoutes(http, getAuth, {');
+      expect(httpSource).toContain('allowedOrigins: [process.env.SITE_URL!]');
+      expect(httpSource).not.toContain('authMiddleware');
+      expect(httpSource).not.toContain('createHttpRouter');
+
+      const schemaSource = fs.readFileSync(
+        path.join(dir, 'convex', 'schema.ts'),
+        'utf8'
+      );
+      expect(schemaSource).toContain(
+        "import { authSchema } from './authSchema';"
+      );
+      expect(schemaSource).toContain('...authSchema,');
+      expect(schemaSource).not.toContain('authExtension()');
       expect(
         execaStub.mock.calls.some((call) => {
           const [, args] = call as unknown as [string, string[]];

--- a/packages/kitcn/src/cli/registry/items/auth/auth-item.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-item.ts
@@ -61,8 +61,10 @@ const AUTH_CONVEX_HTTP_CALL_RE = /registerRoutes\(http,\s*getAuth,\s*\{/;
 const AUTH_CONVEX_HTTP_ROUTER_RE = /const\s+http\s*=\s*httpRouter\(\);?/;
 const AUTH_CONVEX_SCHEMA_CALL_RE = /defineSchema\(\s*\{/;
 const AUTH_CONVEX_APP_IMPORT_RE = /import App from ['"][^'"]+['"];?/;
-const AUTH_CONVEX_NEXT_PROVIDER_IMPORT_RE =
-  /import\s+\{\s*ConvexProvider,\s*ConvexReactClient\s*\}\s+from\s+'convex\/react';/;
+const AUTH_CONVEX_PROVIDER_IMPORT_RE =
+  /import\s+\{\s*ConvexProvider,\s*ConvexReactClient\s*\}\s+from\s+['"]convex\/react['"];?/;
+const AUTH_PROVIDER_REACT_NODE_IMPORT_RE =
+  /import\s+type\s+\{\s*ReactNode\s*\}\s+from\s+['"]react['"];?/;
 const AUTH_CONVEX_NEXT_PROVIDER_RETURN_RE =
   /<ConvexProvider client=\{convex\}>[\s\S]*?<\/ConvexProvider>/;
 const AUTH_CONVEX_REACT_PROVIDER_OPEN_RE = /<ConvexProvider client=\{convex\}>/;
@@ -590,6 +592,35 @@ function buildAuthConvexSchemaPlanFile(
   });
 }
 
+function patchAuthConvexProviderSource(source: string) {
+  let nextSource = source;
+
+  if (!nextSource.includes("from 'kitcn/auth/client'")) {
+    nextSource = nextSource.replace(
+      AUTH_CONVEX_PROVIDER_IMPORT_RE,
+      "import { ConvexAuthProvider } from 'kitcn/auth/client';\nimport { ConvexReactClient } from 'convex/react';"
+    );
+  }
+  if (
+    !nextSource.includes(
+      "import { authClient } from '@/lib/convex/auth-client';"
+    )
+  ) {
+    nextSource = nextSource.replace(
+      AUTH_PROVIDER_REACT_NODE_IMPORT_RE,
+      "import type { ReactNode } from 'react';\nimport { authClient } from '@/lib/convex/auth-client';"
+    );
+  }
+  if (!nextSource.includes('<ConvexAuthProvider')) {
+    nextSource = nextSource.replace(
+      AUTH_CONVEX_NEXT_PROVIDER_RETURN_RE,
+      '<ConvexAuthProvider authClient={authClient} client={convex}>{children}</ConvexAuthProvider>'
+    );
+  }
+
+  return nextSource;
+}
+
 function buildAuthConvexNextProviderPlanFile(
   params: PluginRegistryBuildPlanFilesParams
 ) {
@@ -612,26 +643,7 @@ function buildAuthConvexNextProviderPlanFile(
   }
 
   let source = fs.readFileSync(providerPath, 'utf8');
-  if (!source.includes("from 'kitcn/auth/client'")) {
-    source = source.replace(
-      AUTH_CONVEX_NEXT_PROVIDER_IMPORT_RE,
-      "import { ConvexAuthProvider } from 'kitcn/auth/client';\nimport { ConvexReactClient } from 'convex/react';"
-    );
-  }
-  if (
-    !source.includes("import { authClient } from '@/lib/convex/auth-client';")
-  ) {
-    source = source.replace(
-      "import type { ReactNode } from 'react';",
-      "import type { ReactNode } from 'react';\nimport { authClient } from '@/lib/convex/auth-client';"
-    );
-  }
-  if (!source.includes('<ConvexAuthProvider')) {
-    source = source.replace(
-      AUTH_CONVEX_NEXT_PROVIDER_RETURN_RE,
-      '<ConvexAuthProvider authClient={authClient} client={convex}>{children}</ConvexAuthProvider>'
-    );
-  }
+  source = patchAuthConvexProviderSource(source);
 
   return createPlanFile({
     kind: 'scaffold',
@@ -640,6 +652,41 @@ function buildAuthConvexNextProviderPlanFile(
     createReason: 'Create auth-aware Convex client provider.',
     updateReason: 'Update Convex client provider with auth.',
     skipReason: 'Convex client provider already includes auth.',
+  });
+}
+
+function buildAuthConvexStartProviderPlanFile(
+  params: PluginRegistryBuildPlanFilesParams
+) {
+  const projectContext = params.roots.projectContext;
+  if (!projectContext || projectContext.framework !== 'tanstack-start') {
+    throw new Error(
+      'Auth preset "convex" requires a supported TanStack Start app shell.'
+    );
+  }
+
+  const providerPath = resolve(
+    process.cwd(),
+    projectContext.convexClientDir,
+    'convex-provider.tsx'
+  );
+  if (!fs.existsSync(providerPath)) {
+    throw new Error(
+      'Auth preset "convex" for TanStack Start expects src/lib/convex/convex-provider.tsx.'
+    );
+  }
+
+  const source = patchAuthConvexProviderSource(
+    fs.readFileSync(providerPath, 'utf8')
+  );
+
+  return createPlanFile({
+    kind: 'scaffold',
+    filePath: providerPath,
+    content: source,
+    createReason: 'Create auth-aware Start provider.',
+    updateReason: 'Update Start provider with auth.',
+    skipReason: 'Start provider already includes auth.',
   });
 }
 
@@ -698,9 +745,15 @@ function buildAuthConvexReactEntryPlanFile(
 function buildAuthConvexProviderPlanFile(
   params: PluginRegistryBuildPlanFilesParams
 ) {
-  return params.roots.projectContext?.mode === 'next-app'
-    ? buildAuthConvexNextProviderPlanFile(params)
-    : buildAuthConvexReactEntryPlanFile(params);
+  const projectContext = params.roots.projectContext;
+  if (projectContext?.mode === 'next-app') {
+    return buildAuthConvexNextProviderPlanFile(params);
+  }
+  if (projectContext?.framework === 'tanstack-start') {
+    return buildAuthConvexStartProviderPlanFile(params);
+  }
+
+  return buildAuthConvexReactEntryPlanFile(params);
 }
 
 export const authRegistryItem = defineInternalRegistryItem({
@@ -770,6 +823,12 @@ export const authRegistryItem = defineInternalRegistryItem({
                 return {
                   ...template,
                   content: AUTH_START_CLIENT_TEMPLATE,
+                };
+              }
+              if (template.id === 'auth-client-convex') {
+                return {
+                  ...template,
+                  content: AUTH_CONVEX_REACT_CLIENT_TEMPLATE,
                 };
               }
 

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/.gitignore
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env.local
+.convex
+dist

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/README.md
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/README.md
@@ -1,0 +1,3 @@
+# Raw TanStack Start auth adoption fixture
+
+Minimal TanStack Start shell for raw Convex auth adoption scenarios.

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/components.json
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/convex/README.md
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/convex/README.md
@@ -1,0 +1,1 @@
+# Convex functions

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/convex/schema.ts
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/convex/schema.ts
@@ -1,0 +1,9 @@
+import { defineSchema, defineTable } from 'convex/server';
+import { v } from 'convex/values';
+
+export default defineSchema({
+  messages: defineTable({
+    author: v.string(),
+    body: v.string(),
+  }),
+});

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/convex/tsconfig.json
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2021", "dom"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext"
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/package.json
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit && bun run typecheck:convex",
+    "typecheck:convex": "tsc --noEmit --project convex/tsconfig.json"
+  },
+  "dependencies": {
+    "@tanstack/react-router": "^1.132.0",
+    "@tanstack/react-start": "^1.132.0",
+    "convex": "^1.33.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^5.0.4",
+    "typescript": "^5.7.2",
+    "vite": "^7.1.7",
+    "vite-tsconfig-paths": "^5.1.4"
+  }
+}

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/src/components/providers.tsx
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/src/components/providers.tsx
@@ -1,0 +1,7 @@
+import type { ReactNode } from 'react';
+
+import { AppConvexProvider } from '@/lib/convex/convex-provider';
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <AppConvexProvider>{children}</AppConvexProvider>;
+}

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/src/lib/convex/convex-provider.tsx
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/src/lib/convex/convex-provider.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { ConvexProvider, ConvexReactClient } from 'convex/react';
+import type { ReactNode } from 'react';
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
+
+export function AppConvexProvider({ children }: { children: ReactNode }) {
+  return <ConvexProvider client={convex}>{children}</ConvexProvider>;
+}

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/src/routes/__root.tsx
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/src/routes/__root.tsx
@@ -1,0 +1,15 @@
+import { createRootRoute, Outlet } from '@tanstack/react-router';
+
+import { Providers } from '@/components/providers';
+
+export const Route = createRootRoute({
+  component: RootComponent,
+});
+
+function RootComponent() {
+  return (
+    <Providers>
+      <Outlet />
+    </Providers>
+  );
+}

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/src/routes/index.tsx
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/src/routes/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/' as never)({
+  component: HomePage,
+});
+
+function HomePage() {
+  return <main>raw start auth adoption</main>;
+}

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/src/styles.css
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/src/styles.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/src/vite-env.d.ts
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/tsconfig.json
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext"
+  },
+  "include": ["src/**/*"]
+}

--- a/tooling/scenario-fixtures/raw-start-auth-adoption/vite.config.ts
+++ b/tooling/scenario-fixtures/raw-start-auth-adoption/vite.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+import tsConfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsConfigPaths(), tanstackStart(), react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});

--- a/tooling/scenario.config.ts
+++ b/tooling/scenario.config.ts
@@ -11,6 +11,7 @@ export const SCENARIO_KEYS = [
   'convex-vite-auth-bootstrap',
   'convex-next-all',
   'create-convex-nextjs-shadcn-auth',
+  'raw-start-auth-adoption',
   'create-convex-bare',
   'create-convex-nextjs-shadcn',
   'create-convex-react-vite-shadcn',
@@ -29,6 +30,7 @@ export const FULL_CONVEX_SCENARIO_KEYS = [
   'convex-vite-auth-bootstrap',
   'convex-next-all',
   'create-convex-nextjs-shadcn-auth',
+  'raw-start-auth-adoption',
 ] as const;
 
 export type ScenarioKey = (typeof SCENARIO_KEYS)[number];
@@ -211,6 +213,26 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
     source: {
       kind: 'fixture',
       fixture: 'create-convex-nextjs-shadcn',
+    },
+  },
+  'raw-start-auth-adoption': {
+    backend: 'convex',
+    check: false,
+    env: {
+      CONVEX_AGENT_MODE: 'anonymous',
+    },
+    label: 'raw start auth adoption',
+    setup: [],
+    validation: {
+      beforeCheck: [
+        ['convex', 'init'],
+        ['kitcn', 'add', 'auth', '--preset', 'convex', '--yes'],
+      ],
+      lint: false,
+    },
+    source: {
+      kind: 'fixture',
+      fixture: 'raw-start-auth-adoption',
     },
   },
   'create-convex-bare': {

--- a/tooling/scenarios.test.ts
+++ b/tooling/scenarios.test.ts
@@ -85,6 +85,7 @@ describe('tooling/scenarios', () => {
     expect(resolveScenarioProofPath('create-convex-nextjs-shadcn-auth')).toBe(
       'check'
     );
+    expect(resolveScenarioProofPath('raw-start-auth-adoption')).toBe('check');
   });
 
   test('runScenarioTest uses check for bootstrap-heavy convex scenarios', async () => {
@@ -469,6 +470,7 @@ describe('tooling/scenarios', () => {
       'convex-vite-auth-bootstrap',
       'convex-next-all',
       'create-convex-nextjs-shadcn-auth',
+      'raw-start-auth-adoption',
     ]);
     expect(SCENARIO_DEFINITIONS['convex-next-all']).toMatchObject({
       backend: 'convex',
@@ -499,6 +501,26 @@ describe('tooling/scenarios', () => {
       source: {
         kind: 'fixture',
         fixture: 'create-convex-nextjs-shadcn',
+      },
+      validation: {
+        beforeCheck: [
+          ['convex', 'init'],
+          ['kitcn', 'add', 'auth', '--preset', 'convex', '--yes'],
+        ],
+        lint: false,
+      },
+    });
+    expect(SCENARIO_DEFINITIONS['raw-start-auth-adoption']).toEqual({
+      backend: 'convex',
+      check: false,
+      env: {
+        CONVEX_AGENT_MODE: 'anonymous',
+      },
+      label: 'raw start auth adoption',
+      setup: [],
+      source: {
+        kind: 'fixture',
+        fixture: 'raw-start-auth-adoption',
       },
       validation: {
         beforeCheck: [

--- a/tooling/scenarios.ts
+++ b/tooling/scenarios.ts
@@ -98,6 +98,7 @@ const BOOTSTRAP_CHECK_SCENARIOS = new Set<ScenarioKey>([
   'convex-vite-auth-bootstrap',
   'convex-next-all',
   'create-convex-nextjs-shadcn-auth',
+  'raw-start-auth-adoption',
 ]);
 
 const isPortAvailable = (port: number) =>


### PR DESCRIPTION
## Summary
- support `kitcn add auth --preset convex --yes` on TanStack Start
- patch the raw preset to use the Start provider shell and the Vite-style raw auth client template
- add `raw-start-auth-adoption` as a bootstrap-heavy scenario for raw Start auth adoption
- update the active changeset and add a focused learning doc

## Why
Raw Convex auth adoption on TanStack Start was falling through the generic Vite entry patcher and failing on the missing `main.tsx` seam.

## Verification
- `bun check`
- `bun run scenario:check -- raw-start-auth-adoption`
