### PR TITLE
feat(cli): upgrade Convex agentic bootstrap

### DIFF
--- a/.agents/rules/convex-release-audit.mdc
+++ b/.agents/rules/convex-release-audit.mdc
@@ -1,0 +1,223 @@
+---
+description: Audit newer Convex npm releases against kitcn. Use when checking whether a newer `convex` version unlocks kitcn improvements, compatibility work, CLI/agent workflows, or cleanup of local Convex hacks. Reads `https://ship.convex.dev/`, the upstream Convex changelog, and GitHub diffs before delegating an implementation PR through `task`.
+---
+
+# Convex Release Audit
+
+Handle $ARGUMENTS.
+
+Goal: find newer Convex releases, extract work kitcn can actually use, then
+delegate one concrete implementation slice to
+[$task](/Users/zbeyens/git/better-convex/.agents/skills/task/SKILL.md) so it
+opens the PR.
+
+## Rules
+
+- Use evidence, not vibes. Read both changelog sources and a diff.
+- Prefer deleting kitcn glue over adding more glue when upstream fixed the real
+  problem.
+- Do not upgrade Convex just because a newer version exists. Ship only a
+  leverageable improvement.
+- Keep the PR slice coherent. One release opportunity per PR unless multiple
+  fixes share the same seam.
+- If no actionable opportunity exists, stop with the evidence. Do not open a
+  vanity PR.
+
+## 1. Establish Current And Target Versions
+
+Find the currently pinned Convex version:
+
+```bash
+rg -n '"convex":' package.json packages/**/package.json example/package.json
+```
+
+Find the latest published version:
+
+```bash
+npm view convex version --json
+```
+
+If $ARGUMENTS names a target version, use it as the upper bound. Otherwise use
+the latest npm version.
+
+Record:
+
+- current pinned version
+- target version
+- every version in the current-exclusive, target-inclusive range
+- exact package files that pin or constrain Convex
+
+## 2. Read Both Changelogs
+
+Read Ship:
+
+```bash
+curl -sL https://ship.convex.dev/
+```
+
+Read the upstream npm package changelog through `gh`, not browser scraping:
+
+```bash
+gh api \
+  -H "Accept: application/vnd.github.raw" \
+  repos/get-convex/convex-backend/contents/npm-packages/convex/CHANGELOG.md
+```
+
+Extract only the sections in range. Reconcile disagreements:
+
+- Ship is product-facing signal.
+- `npm-packages/convex/CHANGELOG.md` is package-facing signal.
+- If they disagree, keep both facts and investigate in the diff.
+
+## 3. Read The Upstream Diff With `gh`
+
+Use a local upstream clone for navigation, creating it only if missing:
+
+```bash
+test -d ../convex-backend/.git || gh repo clone get-convex/convex-backend ../convex-backend
+git -C ../convex-backend fetch origin main --tags
+```
+
+Find refs for the current and target versions. Prefer tags if they exist:
+
+```bash
+git -C ../convex-backend tag -l "*<version>*" | sort
+git -C ../convex-backend log --all --oneline -- npm-packages/convex/package.json
+```
+
+If tags are unclear, inspect version-bump commits in
+`npm-packages/convex/package.json` and use the commit before/after each version
+bump.
+
+Read the compare through `gh`:
+
+```bash
+gh api \
+  repos/get-convex/convex-backend/compare/<base-ref>...<target-ref> \
+  --jq '.files[] | select(.filename | test("npm-packages/convex|cli|agent|dev|auth|codegen|deployment|function|schema")) | {filename,status,patch}'
+```
+
+If the compare is too large, narrow locally after proving the refs:
+
+```bash
+git -C ../convex-backend diff <base-ref>..<target-ref> -- \
+  npm-packages/convex
+```
+
+## 4. Search Kitcn For Leverage
+
+Search for local Convex integration points and hacks:
+
+```bash
+rg -n "CONVEX_AGENT_MODE|local-force-upgrade|skip-push|typecheck disable|codegen disable|convex dev|convex init|convex run|CONVEX_|Convex" \
+  packages www .agents docs test
+```
+
+Also search institutional notes before proposing work:
+
+```bash
+rg -i --files-with-matches "convex|upgrade|agent|cli|dev|bootstrap|verify" docs/solutions
+```
+
+Read relevant hits, especially notes about:
+
+- local backend upgrade prompts
+- anonymous or non-interactive Convex setup
+- `kitcn dev`, `kitcn verify`, `kitcn init`
+- hidden Convex flags or leaked upstream plumbing
+- docs/skill sync for Convex setup guidance
+
+## 5. Classify Opportunities
+
+For each release item, classify it:
+
+- `feature`: new Convex API, CLI command, runtime behavior, or platform feature
+  kitcn can expose.
+- `compatibility`: required work to keep kitcn working with the new version.
+- `agentic`: upstream change that improves non-interactive, deterministic, or
+  machine-readable flows.
+- `cleanup`: upstream change that lets kitcn delete a workaround, hidden flag,
+  fake prompt handling, fallback path, or doc warning.
+- `no-op`: interesting upstream change with no kitcn action.
+
+For every non-`no-op`, include:
+
+- changelog evidence
+- diff evidence
+- kitcn file(s) affected
+- expected implementation seam
+- verification command(s)
+- confidence
+
+Bias toward `agentic` and `cleanup`; kitcn exists to make Convex sharper for
+humans and agents, not to mirror every upstream bullet.
+
+## 6. Choose One PR Slice
+
+Pick the highest-leverage slice using this order:
+
+1. compatibility breakage
+2. delete dirty hack made obsolete upstream
+3. agentic CLI unlock
+4. product feature kitcn can expose cleanly
+5. docs or skill-only update
+
+If the winning slice touches published package code, the delegated task must
+update the active changeset and run `bun --cwd packages/kitcn build`.
+
+If it touches scaffold templates, the delegated task must run
+`bun run fixtures:sync` and `bun run fixtures:check`.
+
+## 7. Delegate Through `task`
+
+Load
+[$task](/Users/zbeyens/git/better-convex/.agents/skills/task/SKILL.md) with a
+prompt in this exact shape:
+
+```md
+Implement this Convex release opportunity.
+
+Current Convex: <version>
+Target Convex: <version>
+
+Opportunity: <one-sentence selected slice>
+Class: <feature | compatibility | agentic | cleanup>
+
+Evidence:
+- Ship changelog: <short citation or summary>
+- Convex changelog: <short citation or summary>
+- Upstream diff: <refs and files>
+- Kitcn evidence: <local files and docs/solutions notes>
+
+Implementation:
+- <specific files or seams to inspect first>
+- <expected code/doc/test shape>
+
+Acceptance:
+- <tests/checks>
+- <package build if packages/kitcn changes>
+- <fixtures commands if scaffold output changes>
+- open the PR after verification
+
+Do not preserve obsolete Convex workarounds if the upstream release removes the
+need for them. Hard cut the hack.
+```
+
+Then follow `task` until the PR exists or a real blocker is proven.
+
+## Output
+
+Before delegation, keep the audit terse:
+
+```md
+Current: <version>
+Target: <version>
+
+| Class | Opportunity | Evidence | Decision |
+| --- | --- | --- | --- |
+| cleanup | ... | ... | selected |
+
+Delegating to task: <selected slice>
+```
+
+After `task` finishes, use its final handoff format.

--- a/.agents/rules/package-release-audit.mdc
+++ b/.agents/rules/package-release-audit.mdc
@@ -1,0 +1,248 @@
+---
+description: Audit newer npm package releases against kitcn. Use when checking whether a newer dependency version unlocks kitcn improvements, compatibility work, CLI/agent workflows, or cleanup of local package-specific hacks. Reads package changelogs, GitHub releases, upstream diffs, and local kitcn usage before delegating an implementation PR through `task`.
+---
+
+# Package Release Audit
+
+Handle $ARGUMENTS.
+
+Goal: find newer releases for a named package, extract work kitcn can actually
+use, then delegate one concrete implementation slice to
+[$task](/Users/zbeyens/git/better-convex/.agents/skills/task/SKILL.md) so it
+opens the PR.
+
+## Rules
+
+- Use evidence, not vibes. Read changelog/release sources and a diff.
+- Prefer deleting kitcn glue over adding more glue when upstream fixed the real
+  problem.
+- Do not upgrade a package just because a newer version exists. Ship only a
+  leverageable improvement.
+- Keep the PR slice coherent. One release opportunity per PR unless multiple
+  fixes share the same seam.
+- If no actionable opportunity exists, stop with the evidence. Do not open a
+  vanity PR.
+
+## 1. Establish Package, Current, And Target Versions
+
+Extract the package name from $ARGUMENTS. If the package name is ambiguous,
+stop and ask for the exact npm package name.
+
+Find the currently pinned package version:
+
+```bash
+rg -n '"<package-name>":' package.json packages/**/package.json example/package.json
+```
+
+Find the latest published version and package metadata:
+
+```bash
+npm view <package-name> version repository homepage dist-tags --json
+```
+
+If $ARGUMENTS names a target version, use it as the upper bound. Otherwise use
+the latest npm version.
+
+Record:
+
+- package name
+- current pinned version or range
+- target version
+- every version in the current-exclusive, target-inclusive range when discoverable
+- exact package files that pin or constrain the package
+- repository owner/name inferred from npm metadata
+
+## 2. Read Changelogs And Release Notes
+
+Prefer official sources in this order:
+
+1. package repository changelog files
+2. GitHub releases
+3. package docs/blog release pages from npm metadata
+4. npm package metadata only when no richer source exists
+
+Read the repository changelog through `gh`, not browser scraping, when a GitHub
+repo is available:
+
+```bash
+gh api \
+  -H "Accept: application/vnd.github.raw" \
+  repos/<owner>/<repo>/contents/CHANGELOG.md
+```
+
+If that path is missing, discover likely changelog paths:
+
+```bash
+gh api repos/<owner>/<repo>/git/trees/HEAD?recursive=1 \
+  --jq '.tree[].path | select(test("(^|/)(CHANGELOG|RELEASES|HISTORY|UPGRADING|MIGRATION|MIGRATIONS)\\\\.(md|mdx|txt)$"; "i"))'
+```
+
+Read GitHub releases:
+
+```bash
+gh release list --repo <owner>/<repo> --limit 20
+gh release view <tag-or-version> --repo <owner>/<repo>
+```
+
+Extract only the sections in range. Reconcile disagreements:
+
+- Changelog files are package-facing signal.
+- GitHub releases are release-manager signal.
+- Docs/blog pages are product-facing signal.
+- If they disagree, keep both facts and investigate in the diff.
+
+## 3. Read The Upstream Diff With `gh`
+
+Use a local upstream clone for navigation, creating it only if missing:
+
+```bash
+test -d ../<repo-name>/.git || gh repo clone <owner>/<repo> ../<repo-name>
+git -C ../<repo-name> fetch origin main --tags
+```
+
+Find refs for the current and target versions. Prefer tags if they exist:
+
+```bash
+git -C ../<repo-name> tag -l "*<version>*" | sort
+git -C ../<repo-name> log --all --oneline -- '*package.json' '*CHANGELOG*'
+```
+
+If tags are unclear, inspect version-bump commits in the package's
+`package.json` or changelog and use the commit before/after each version bump.
+
+Read the compare through `gh`:
+
+```bash
+gh api \
+  repos/<owner>/<repo>/compare/<base-ref>...<target-ref> \
+  --jq '.files[] | select(.filename | test("package|src|cli|server|client|auth|plugin|adapter|schema|migration|agent|mcp|codegen|docs|CHANGELOG"; "i")) | {filename,status,patch}'
+```
+
+If the compare is too large, narrow locally after proving the refs:
+
+```bash
+git -C ../<repo-name> diff <base-ref>..<target-ref> -- \
+  . ':!**/node_modules/**' ':!**/dist/**' ':!**/build/**'
+```
+
+## 4. Search Kitcn For Leverage
+
+Search for local package integration points and hacks:
+
+```bash
+rg -n "<package-name>|<package-import>|<package-domain-term>|TODO|workaround|hack|temporary|shim|compat|adapter|plugin|peer|version" \
+  packages www .agents docs test tooling
+```
+
+Also search institutional notes before proposing work:
+
+```bash
+rg -i --files-with-matches "<package-name>|<package-domain-term>|upgrade|compat|agent|cli|bootstrap|adapter|plugin|peer|version" docs/solutions
+```
+
+Read relevant hits, especially notes about:
+
+- package-specific wrappers, adapters, plugins, or generated code
+- peer dependency ranges and scaffold pins
+- CLI or agent workflow workarounds
+- non-interactive, deterministic, or machine-readable behavior
+- docs/skill sync for package guidance
+- dirty hacks that might be obsolete after the upstream release
+
+## 5. Classify Opportunities
+
+For each release item, classify it:
+
+- `feature`: new package API, CLI command, runtime behavior, integration, or
+  platform feature kitcn can expose.
+- `compatibility`: required work to keep kitcn working with the new version.
+- `agentic`: upstream change that improves non-interactive, deterministic,
+  machine-readable, MCP, CLI, or automation flows.
+- `cleanup`: upstream change that lets kitcn delete a workaround, shim, fallback,
+  prompt handling, wrapper, patch, or doc warning.
+- `docs`: upstream change that only affects user-facing docs, setup guidance, or
+  skills.
+- `no-op`: interesting upstream change with no kitcn action.
+
+For every non-`no-op`, include:
+
+- changelog or release evidence
+- diff evidence
+- kitcn file(s) affected
+- expected implementation seam
+- verification command(s)
+- confidence
+
+Bias toward `agentic` and `cleanup`; kitcn exists to make dependencies sharper
+for humans and agents, not to mirror every upstream bullet.
+
+## 6. Choose One PR Slice
+
+Pick the highest-leverage slice using this order:
+
+1. compatibility breakage
+2. delete dirty hack made obsolete upstream
+3. agentic CLI/tooling unlock
+4. product feature kitcn can expose cleanly
+5. docs or skill-only update
+
+If the winning slice touches published package code, the delegated task must
+update the active changeset and run `bun --cwd packages/kitcn build`.
+
+If it touches scaffold templates, the delegated task must run
+`bun run fixtures:sync` and `bun run fixtures:check`.
+
+## 7. Delegate Through `task`
+
+Load
+[$task](/Users/zbeyens/git/better-convex/.agents/skills/task/SKILL.md) with a
+prompt in this exact shape:
+
+```md
+Implement this package release opportunity.
+
+Package: <package-name>
+Current version/range: <version>
+Target version: <version>
+
+Opportunity: <one-sentence selected slice>
+Class: <feature | compatibility | agentic | cleanup | docs>
+
+Evidence:
+- Changelog/release notes: <short citation or summary>
+- Upstream diff: <refs and files>
+- Kitcn evidence: <local files and docs/solutions notes>
+
+Implementation:
+- <specific files or seams to inspect first>
+- <expected code/doc/test shape>
+
+Acceptance:
+- <tests/checks>
+- <package build if packages/kitcn changes>
+- <fixtures commands if scaffold output changes>
+- open the PR after verification
+
+Do not preserve obsolete package workarounds if the upstream release removes
+the need for them. Hard cut the hack.
+```
+
+Then follow `task` until the PR exists or a real blocker is proven.
+
+## Output
+
+Before delegation, keep the audit terse:
+
+```md
+Package: <package-name>
+Current: <version>
+Target: <version>
+
+| Class | Opportunity | Evidence | Decision |
+| --- | --- | --- | --- |
+| cleanup | ... | ... | selected |
+
+Delegating to task: <selected slice>
+```
+
+After `task` finishes, use its final handoff format.

--- a/.agents/rules/research-wiki.mdc
+++ b/.agents/rules/research-wiki.mdc
@@ -1,0 +1,200 @@
+---
+description: Operate the docs/research compiled layer in either full or maintain mode. Use for research-lane creation, research upkeep, authority-sensitive corpus work, source summaries, concepts, systems, decisions, and open-question pages.
+argument-hint: '[full|maintain] <goal or area>'
+disable-model-invocation: true
+---
+
+# Research Wiki
+
+Handle $ARGUMENTS. This is the reusable workflow for operating the
+`docs/research` compiled layer without turning research into one-off chat mush.
+
+<task>#$ARGUMENTS</task>
+
+## Purpose
+
+Turn the existing research command docs into one reusable skill entrypoint.
+
+This skill should decide whether the job is:
+
+- a **full** ingest-and-compile pass
+- a **maintain** pass over an existing research lane
+
+The support docs remain canonical detail:
+
+- [docs/research/commands/full-pipeline.md](docs/research/commands/full-pipeline.md)
+- [docs/research/commands/maintain.md](docs/research/commands/maintain.md)
+
+Use them as sub-workflows, not as dead docs.
+
+## Core Rules
+
+- `docs/research` is the compiled layer; `../raw` is the evidence layer.
+- Keep the workflow lossless relative to the support docs above.
+- Update the research layer itself, not just the chat answer.
+- If the topic is authority-sensitive and spans multiple likely corpora, do a
+  **full corpus-level ingest** across the relevant source families instead of a
+  narrow spot check.
+- In `full` mode, verify corpus completeness via an official-source discovery
+  step before declaring a corpus missing, thin, or only partially evidenced.
+- In `full` mode, once official-source discovery confirms that the relevant raw
+  family already exists locally, exhaust the strongest local raw hits before
+  calling `evidence gap` or `contradiction gap`.
+- In `full` mode, every scoped corpus must end in an explicit disposition:
+  - strongest evidence found
+  - raw gap
+  - compile gap
+  - synthesis gap
+  - freshness gap
+  - evidence gap
+  - contradiction gap
+  - structure gap
+    A full pass is not complete until every scoped corpus has one.
+- Do not confuse:
+  - raw evidence
+  - compiled source summaries
+  - synthesized decisions
+  - open questions
+- If evidence is thin or contradictory, say so explicitly and create an
+  `open-questions/` page instead of flattening uncertainty into fake law.
+
+## Read First
+
+Always read:
+
+1. [docs/research/README.md](docs/research/README.md)
+2. [docs/research/index.md](docs/research/index.md)
+3. [docs/research/log.md](docs/research/log.md)
+
+Then choose one support doc:
+
+- [docs/research/commands/full-pipeline.md](docs/research/commands/full-pipeline.md)
+  for `full`
+- [docs/research/commands/maintain.md](docs/research/commands/maintain.md)
+  for `maintain`
+
+## Mode Selection
+
+### Use `full` when:
+
+- the topic is broad or thinly covered
+- the authority question is large enough that trusting the visible local slice
+  would be reckless
+- raw evidence is missing, stale, or uneven
+- the surface spans multiple likely corpora
+- trigger behavior, input behavior, or product claims need a **full
+  corpus-level ingest**
+
+Examples:
+
+- compare Typora / Obsidian / Milkdown on one under-researched trigger surface
+- rebuild a weak authority lane
+- create a new research lane from scratch
+
+### Use `maintain` when:
+
+- the lane already exists in `docs/research`
+- the goal is contradiction cleanup, freshness, backlinks, or stronger compiled
+  synthesis
+- you need upkeep, not a new ingest push
+
+## Full-Mode Requirement
+
+When `full` is chosen for a surface that obviously touches multiple editors or
+source families, do **not** stop after finding one useful source.
+
+Do the full corpus-level pass:
+
+1. scope the relevant corpora
+2. inspect existing compiled coverage
+3. inspect raw coverage across the relevant corpora
+4. run an official-source discovery step per corpus
+5. exhaust the strongest local raw hits per corpus
+6. create a per-corpus evidence ledger
+7. classify gaps per corpus
+8. fill what is safe
+9. update `index.md` and `log.md`
+10. return the remaining gaps honestly
+
+For editor-behavior authority work, that often means some subset of:
+
+- Typora
+- Obsidian
+- Milkdown
+- Google Docs / GitHub Docs / Notion
+
+depending on the actual surface
+
+### Per-Corpus Evidence Ledger
+
+For `full` mode, explicitly close each scoped corpus with:
+
+- corpus name
+- compiled pages inspected
+- raw paths inspected
+- direct raw files actually read
+- official source entrypoints checked
+- strongest evidence found
+- disposition:
+  - `evidenced`
+  - `raw gap`
+  - `compile gap`
+  - `synthesis gap`
+  - `freshness gap`
+  - `evidence gap`
+  - `contradiction gap`
+  - `structure gap`
+- next action if still unresolved
+
+Do not end a full pass with silent corpora.
+
+If a likely corpus was scoped and produced no useful proof, say that directly.
+That is still a result.
+
+Before recording `raw gap`, use official-source discovery to confirm that the
+missing coverage is real and not just a stale or incomplete local raw mirror.
+
+Before recording `evidence gap`, read the strongest local raw hits that your
+searches surfaced for that corpus. Broad grep is routing, not proof.
+
+If raw evidence is missing for a scoped corpus after that discovery step,
+record a `raw gap` explicitly instead of quietly letting another corpus carry
+the whole answer.
+
+If compiled pages are missing but raw exists, record a `compile gap` and create
+the missing source summary when safe.
+
+If evidence exists but still does not answer the behavior question, record an
+`evidence gap` or `contradiction gap` instead of flattening it into a partial
+yes.
+
+If official discovery and local raw search already surfaced an obviously
+relevant file, you do not get to stop at "broad grep over corpus X". Read the
+file and cite it, or explain why it was not actually relevant.
+
+## Outputs
+
+A successful pass should leave behind durable artifacts such as:
+
+- source summaries
+- entity pages
+- concept pages
+- system pages
+- decision pages
+- open-question pages
+- updated index/log entrypoints
+
+## Blunt Rules
+
+- Do not do “research” that only rephrases the first source you found.
+- Do not call something `full` if you only spot-checked one corpus when the
+  topic obviously spans several.
+- Do not close `full` mode without an official-source discovery step for each
+  scoped corpus.
+- Do not treat grep hits as the same thing as inspected evidence.
+- Do not record a corpus as thin, partial, or unresolved when the likely
+  answer is already sitting in local raw unread.
+- Do not close `full` mode without a per-corpus evidence ledger.
+- Do not bypass the compiled layer and patch law straight from raw evidence
+  unless the task is tiny and the evidence is already obvious.
+- Do not leave `index.md` or `log.md` stale after adding research pages.

--- a/.agents/skills/convex-release-audit/SKILL.md
+++ b/.agents/skills/convex-release-audit/SKILL.md
@@ -1,0 +1,227 @@
+---
+description: Audit newer Convex npm releases against kitcn. Use when checking whether a newer `convex` version unlocks kitcn improvements, compatibility work, CLI/agent workflows, or cleanup of local Convex hacks. Reads `https://ship.convex.dev/`, the upstream Convex changelog, and GitHub diffs before delegating an implementation PR through `task`.
+name: convex-release-audit
+metadata:
+  skiller:
+    source: .agents/rules/convex-release-audit.mdc
+---
+
+# Convex Release Audit
+
+Handle $ARGUMENTS.
+
+Goal: find newer Convex releases, extract work kitcn can actually use, then
+delegate one concrete implementation slice to
+[$task](/Users/zbeyens/git/better-convex/.agents/skills/task/SKILL.md) so it
+opens the PR.
+
+## Rules
+
+- Use evidence, not vibes. Read both changelog sources and a diff.
+- Prefer deleting kitcn glue over adding more glue when upstream fixed the real
+  problem.
+- Do not upgrade Convex just because a newer version exists. Ship only a
+  leverageable improvement.
+- Keep the PR slice coherent. One release opportunity per PR unless multiple
+  fixes share the same seam.
+- If no actionable opportunity exists, stop with the evidence. Do not open a
+  vanity PR.
+
+## 1. Establish Current And Target Versions
+
+Find the currently pinned Convex version:
+
+```bash
+rg -n '"convex":' package.json packages/**/package.json example/package.json
+```
+
+Find the latest published version:
+
+```bash
+npm view convex version --json
+```
+
+If $ARGUMENTS names a target version, use it as the upper bound. Otherwise use
+the latest npm version.
+
+Record:
+
+- current pinned version
+- target version
+- every version in the current-exclusive, target-inclusive range
+- exact package files that pin or constrain Convex
+
+## 2. Read Both Changelogs
+
+Read Ship:
+
+```bash
+curl -sL https://ship.convex.dev/
+```
+
+Read the upstream npm package changelog through `gh`, not browser scraping:
+
+```bash
+gh api \
+  -H "Accept: application/vnd.github.raw" \
+  repos/get-convex/convex-backend/contents/npm-packages/convex/CHANGELOG.md
+```
+
+Extract only the sections in range. Reconcile disagreements:
+
+- Ship is product-facing signal.
+- `npm-packages/convex/CHANGELOG.md` is package-facing signal.
+- If they disagree, keep both facts and investigate in the diff.
+
+## 3. Read The Upstream Diff With `gh`
+
+Use a local upstream clone for navigation, creating it only if missing:
+
+```bash
+test -d ../convex-backend/.git || gh repo clone get-convex/convex-backend ../convex-backend
+git -C ../convex-backend fetch origin main --tags
+```
+
+Find refs for the current and target versions. Prefer tags if they exist:
+
+```bash
+git -C ../convex-backend tag -l "*<version>*" | sort
+git -C ../convex-backend log --all --oneline -- npm-packages/convex/package.json
+```
+
+If tags are unclear, inspect version-bump commits in
+`npm-packages/convex/package.json` and use the commit before/after each version
+bump.
+
+Read the compare through `gh`:
+
+```bash
+gh api \
+  repos/get-convex/convex-backend/compare/<base-ref>...<target-ref> \
+  --jq '.files[] | select(.filename | test("npm-packages/convex|cli|agent|dev|auth|codegen|deployment|function|schema")) | {filename,status,patch}'
+```
+
+If the compare is too large, narrow locally after proving the refs:
+
+```bash
+git -C ../convex-backend diff <base-ref>..<target-ref> -- \
+  npm-packages/convex
+```
+
+## 4. Search Kitcn For Leverage
+
+Search for local Convex integration points and hacks:
+
+```bash
+rg -n "CONVEX_AGENT_MODE|local-force-upgrade|skip-push|typecheck disable|codegen disable|convex dev|convex init|convex run|CONVEX_|Convex" \
+  packages www .agents docs test
+```
+
+Also search institutional notes before proposing work:
+
+```bash
+rg -i --files-with-matches "convex|upgrade|agent|cli|dev|bootstrap|verify" docs/solutions
+```
+
+Read relevant hits, especially notes about:
+
+- local backend upgrade prompts
+- anonymous or non-interactive Convex setup
+- `kitcn dev`, `kitcn verify`, `kitcn init`
+- hidden Convex flags or leaked upstream plumbing
+- docs/skill sync for Convex setup guidance
+
+## 5. Classify Opportunities
+
+For each release item, classify it:
+
+- `feature`: new Convex API, CLI command, runtime behavior, or platform feature
+  kitcn can expose.
+- `compatibility`: required work to keep kitcn working with the new version.
+- `agentic`: upstream change that improves non-interactive, deterministic, or
+  machine-readable flows.
+- `cleanup`: upstream change that lets kitcn delete a workaround, hidden flag,
+  fake prompt handling, fallback path, or doc warning.
+- `no-op`: interesting upstream change with no kitcn action.
+
+For every non-`no-op`, include:
+
+- changelog evidence
+- diff evidence
+- kitcn file(s) affected
+- expected implementation seam
+- verification command(s)
+- confidence
+
+Bias toward `agentic` and `cleanup`; kitcn exists to make Convex sharper for
+humans and agents, not to mirror every upstream bullet.
+
+## 6. Choose One PR Slice
+
+Pick the highest-leverage slice using this order:
+
+1. compatibility breakage
+2. delete dirty hack made obsolete upstream
+3. agentic CLI unlock
+4. product feature kitcn can expose cleanly
+5. docs or skill-only update
+
+If the winning slice touches published package code, the delegated task must
+update the active changeset and run `bun --cwd packages/kitcn build`.
+
+If it touches scaffold templates, the delegated task must run
+`bun run fixtures:sync` and `bun run fixtures:check`.
+
+## 7. Delegate Through `task`
+
+Load
+[$task](/Users/zbeyens/git/better-convex/.agents/skills/task/SKILL.md) with a
+prompt in this exact shape:
+
+```md
+Implement this Convex release opportunity.
+
+Current Convex: <version>
+Target Convex: <version>
+
+Opportunity: <one-sentence selected slice>
+Class: <feature | compatibility | agentic | cleanup>
+
+Evidence:
+- Ship changelog: <short citation or summary>
+- Convex changelog: <short citation or summary>
+- Upstream diff: <refs and files>
+- Kitcn evidence: <local files and docs/solutions notes>
+
+Implementation:
+- <specific files or seams to inspect first>
+- <expected code/doc/test shape>
+
+Acceptance:
+- <tests/checks>
+- <package build if packages/kitcn changes>
+- <fixtures commands if scaffold output changes>
+- open the PR after verification
+
+Do not preserve obsolete Convex workarounds if the upstream release removes the
+need for them. Hard cut the hack.
+```
+
+Then follow `task` until the PR exists or a real blocker is proven.
+
+## Output
+
+Before delegation, keep the audit terse:
+
+```md
+Current: <version>
+Target: <version>
+
+| Class | Opportunity | Evidence | Decision |
+| --- | --- | --- | --- |
+| cleanup | ... | ... | selected |
+
+Delegating to task: <selected slice>
+```
+
+After `task` finishes, use its final handoff format.

--- a/.agents/skills/package-release-audit/SKILL.md
+++ b/.agents/skills/package-release-audit/SKILL.md
@@ -1,0 +1,252 @@
+---
+description: Audit newer npm package releases against kitcn. Use when checking whether a newer dependency version unlocks kitcn improvements, compatibility work, CLI/agent workflows, or cleanup of local package-specific hacks. Reads package changelogs, GitHub releases, upstream diffs, and local kitcn usage before delegating an implementation PR through `task`.
+name: package-release-audit
+metadata:
+  skiller:
+    source: .agents/rules/package-release-audit.mdc
+---
+
+# Package Release Audit
+
+Handle $ARGUMENTS.
+
+Goal: find newer releases for a named package, extract work kitcn can actually
+use, then delegate one concrete implementation slice to
+[$task](/Users/zbeyens/git/better-convex/.agents/skills/task/SKILL.md) so it
+opens the PR.
+
+## Rules
+
+- Use evidence, not vibes. Read changelog/release sources and a diff.
+- Prefer deleting kitcn glue over adding more glue when upstream fixed the real
+  problem.
+- Do not upgrade a package just because a newer version exists. Ship only a
+  leverageable improvement.
+- Keep the PR slice coherent. One release opportunity per PR unless multiple
+  fixes share the same seam.
+- If no actionable opportunity exists, stop with the evidence. Do not open a
+  vanity PR.
+
+## 1. Establish Package, Current, And Target Versions
+
+Extract the package name from $ARGUMENTS. If the package name is ambiguous,
+stop and ask for the exact npm package name.
+
+Find the currently pinned package version:
+
+```bash
+rg -n '"<package-name>":' package.json packages/**/package.json example/package.json
+```
+
+Find the latest published version and package metadata:
+
+```bash
+npm view <package-name> version repository homepage dist-tags --json
+```
+
+If $ARGUMENTS names a target version, use it as the upper bound. Otherwise use
+the latest npm version.
+
+Record:
+
+- package name
+- current pinned version or range
+- target version
+- every version in the current-exclusive, target-inclusive range when discoverable
+- exact package files that pin or constrain the package
+- repository owner/name inferred from npm metadata
+
+## 2. Read Changelogs And Release Notes
+
+Prefer official sources in this order:
+
+1. package repository changelog files
+2. GitHub releases
+3. package docs/blog release pages from npm metadata
+4. npm package metadata only when no richer source exists
+
+Read the repository changelog through `gh`, not browser scraping, when a GitHub
+repo is available:
+
+```bash
+gh api \
+  -H "Accept: application/vnd.github.raw" \
+  repos/<owner>/<repo>/contents/CHANGELOG.md
+```
+
+If that path is missing, discover likely changelog paths:
+
+```bash
+gh api repos/<owner>/<repo>/git/trees/HEAD?recursive=1 \
+  --jq '.tree[].path | select(test("(^|/)(CHANGELOG|RELEASES|HISTORY|UPGRADING|MIGRATION|MIGRATIONS)\\\\.(md|mdx|txt)$"; "i"))'
+```
+
+Read GitHub releases:
+
+```bash
+gh release list --repo <owner>/<repo> --limit 20
+gh release view <tag-or-version> --repo <owner>/<repo>
+```
+
+Extract only the sections in range. Reconcile disagreements:
+
+- Changelog files are package-facing signal.
+- GitHub releases are release-manager signal.
+- Docs/blog pages are product-facing signal.
+- If they disagree, keep both facts and investigate in the diff.
+
+## 3. Read The Upstream Diff With `gh`
+
+Use a local upstream clone for navigation, creating it only if missing:
+
+```bash
+test -d ../<repo-name>/.git || gh repo clone <owner>/<repo> ../<repo-name>
+git -C ../<repo-name> fetch origin main --tags
+```
+
+Find refs for the current and target versions. Prefer tags if they exist:
+
+```bash
+git -C ../<repo-name> tag -l "*<version>*" | sort
+git -C ../<repo-name> log --all --oneline -- '*package.json' '*CHANGELOG*'
+```
+
+If tags are unclear, inspect version-bump commits in the package's
+`package.json` or changelog and use the commit before/after each version bump.
+
+Read the compare through `gh`:
+
+```bash
+gh api \
+  repos/<owner>/<repo>/compare/<base-ref>...<target-ref> \
+  --jq '.files[] | select(.filename | test("package|src|cli|server|client|auth|plugin|adapter|schema|migration|agent|mcp|codegen|docs|CHANGELOG"; "i")) | {filename,status,patch}'
+```
+
+If the compare is too large, narrow locally after proving the refs:
+
+```bash
+git -C ../<repo-name> diff <base-ref>..<target-ref> -- \
+  . ':!**/node_modules/**' ':!**/dist/**' ':!**/build/**'
+```
+
+## 4. Search Kitcn For Leverage
+
+Search for local package integration points and hacks:
+
+```bash
+rg -n "<package-name>|<package-import>|<package-domain-term>|TODO|workaround|hack|temporary|shim|compat|adapter|plugin|peer|version" \
+  packages www .agents docs test tooling
+```
+
+Also search institutional notes before proposing work:
+
+```bash
+rg -i --files-with-matches "<package-name>|<package-domain-term>|upgrade|compat|agent|cli|bootstrap|adapter|plugin|peer|version" docs/solutions
+```
+
+Read relevant hits, especially notes about:
+
+- package-specific wrappers, adapters, plugins, or generated code
+- peer dependency ranges and scaffold pins
+- CLI or agent workflow workarounds
+- non-interactive, deterministic, or machine-readable behavior
+- docs/skill sync for package guidance
+- dirty hacks that might be obsolete after the upstream release
+
+## 5. Classify Opportunities
+
+For each release item, classify it:
+
+- `feature`: new package API, CLI command, runtime behavior, integration, or
+  platform feature kitcn can expose.
+- `compatibility`: required work to keep kitcn working with the new version.
+- `agentic`: upstream change that improves non-interactive, deterministic,
+  machine-readable, MCP, CLI, or automation flows.
+- `cleanup`: upstream change that lets kitcn delete a workaround, shim, fallback,
+  prompt handling, wrapper, patch, or doc warning.
+- `docs`: upstream change that only affects user-facing docs, setup guidance, or
+  skills.
+- `no-op`: interesting upstream change with no kitcn action.
+
+For every non-`no-op`, include:
+
+- changelog or release evidence
+- diff evidence
+- kitcn file(s) affected
+- expected implementation seam
+- verification command(s)
+- confidence
+
+Bias toward `agentic` and `cleanup`; kitcn exists to make dependencies sharper
+for humans and agents, not to mirror every upstream bullet.
+
+## 6. Choose One PR Slice
+
+Pick the highest-leverage slice using this order:
+
+1. compatibility breakage
+2. delete dirty hack made obsolete upstream
+3. agentic CLI/tooling unlock
+4. product feature kitcn can expose cleanly
+5. docs or skill-only update
+
+If the winning slice touches published package code, the delegated task must
+update the active changeset and run `bun --cwd packages/kitcn build`.
+
+If it touches scaffold templates, the delegated task must run
+`bun run fixtures:sync` and `bun run fixtures:check`.
+
+## 7. Delegate Through `task`
+
+Load
+[$task](/Users/zbeyens/git/better-convex/.agents/skills/task/SKILL.md) with a
+prompt in this exact shape:
+
+```md
+Implement this package release opportunity.
+
+Package: <package-name>
+Current version/range: <version>
+Target version: <version>
+
+Opportunity: <one-sentence selected slice>
+Class: <feature | compatibility | agentic | cleanup | docs>
+
+Evidence:
+- Changelog/release notes: <short citation or summary>
+- Upstream diff: <refs and files>
+- Kitcn evidence: <local files and docs/solutions notes>
+
+Implementation:
+- <specific files or seams to inspect first>
+- <expected code/doc/test shape>
+
+Acceptance:
+- <tests/checks>
+- <package build if packages/kitcn changes>
+- <fixtures commands if scaffold output changes>
+- open the PR after verification
+
+Do not preserve obsolete package workarounds if the upstream release removes
+the need for them. Hard cut the hack.
+```
+
+Then follow `task` until the PR exists or a real blocker is proven.
+
+## Output
+
+Before delegation, keep the audit terse:
+
+```md
+Package: <package-name>
+Current: <version>
+Target: <version>
+
+| Class | Opportunity | Evidence | Decision |
+| --- | --- | --- | --- |
+| cleanup | ... | ... | selected |
+
+Delegating to task: <selected slice>
+```
+
+After `task` finishes, use its final handoff format.

--- a/.agents/skills/research-wiki/SKILL.md
+++ b/.agents/skills/research-wiki/SKILL.md
@@ -1,0 +1,204 @@
+---
+description: Operate the docs/research compiled layer in either full or maintain mode. Use for research-lane creation, research upkeep, authority-sensitive corpus work, source summaries, concepts, systems, decisions, and open-question pages.
+argument-hint: '[full|maintain] <goal or area>'
+disable-model-invocation: true
+name: research-wiki
+metadata:
+  skiller:
+    source: .agents/rules/research-wiki.mdc
+---
+
+# Research Wiki
+
+Handle $ARGUMENTS. This is the reusable workflow for operating the
+`docs/research` compiled layer without turning research into one-off chat mush.
+
+<task>#$ARGUMENTS</task>
+
+## Purpose
+
+Turn the existing research command docs into one reusable skill entrypoint.
+
+This skill should decide whether the job is:
+
+- a **full** ingest-and-compile pass
+- a **maintain** pass over an existing research lane
+
+The support docs remain canonical detail:
+
+- [docs/research/commands/full-pipeline.md](docs/research/commands/full-pipeline.md)
+- [docs/research/commands/maintain.md](docs/research/commands/maintain.md)
+
+Use them as sub-workflows, not as dead docs.
+
+## Core Rules
+
+- `docs/research` is the compiled layer; `../raw` is the evidence layer.
+- Keep the workflow lossless relative to the support docs above.
+- Update the research layer itself, not just the chat answer.
+- If the topic is authority-sensitive and spans multiple likely corpora, do a
+  **full corpus-level ingest** across the relevant source families instead of a
+  narrow spot check.
+- In `full` mode, verify corpus completeness via an official-source discovery
+  step before declaring a corpus missing, thin, or only partially evidenced.
+- In `full` mode, once official-source discovery confirms that the relevant raw
+  family already exists locally, exhaust the strongest local raw hits before
+  calling `evidence gap` or `contradiction gap`.
+- In `full` mode, every scoped corpus must end in an explicit disposition:
+  - strongest evidence found
+  - raw gap
+  - compile gap
+  - synthesis gap
+  - freshness gap
+  - evidence gap
+  - contradiction gap
+  - structure gap
+    A full pass is not complete until every scoped corpus has one.
+- Do not confuse:
+  - raw evidence
+  - compiled source summaries
+  - synthesized decisions
+  - open questions
+- If evidence is thin or contradictory, say so explicitly and create an
+  `open-questions/` page instead of flattening uncertainty into fake law.
+
+## Read First
+
+Always read:
+
+1. [docs/research/README.md](docs/research/README.md)
+2. [docs/research/index.md](docs/research/index.md)
+3. [docs/research/log.md](docs/research/log.md)
+
+Then choose one support doc:
+
+- [docs/research/commands/full-pipeline.md](docs/research/commands/full-pipeline.md)
+  for `full`
+- [docs/research/commands/maintain.md](docs/research/commands/maintain.md)
+  for `maintain`
+
+## Mode Selection
+
+### Use `full` when:
+
+- the topic is broad or thinly covered
+- the authority question is large enough that trusting the visible local slice
+  would be reckless
+- raw evidence is missing, stale, or uneven
+- the surface spans multiple likely corpora
+- trigger behavior, input behavior, or product claims need a **full
+  corpus-level ingest**
+
+Examples:
+
+- compare Typora / Obsidian / Milkdown on one under-researched trigger surface
+- rebuild a weak authority lane
+- create a new research lane from scratch
+
+### Use `maintain` when:
+
+- the lane already exists in `docs/research`
+- the goal is contradiction cleanup, freshness, backlinks, or stronger compiled
+  synthesis
+- you need upkeep, not a new ingest push
+
+## Full-Mode Requirement
+
+When `full` is chosen for a surface that obviously touches multiple editors or
+source families, do **not** stop after finding one useful source.
+
+Do the full corpus-level pass:
+
+1. scope the relevant corpora
+2. inspect existing compiled coverage
+3. inspect raw coverage across the relevant corpora
+4. run an official-source discovery step per corpus
+5. exhaust the strongest local raw hits per corpus
+6. create a per-corpus evidence ledger
+7. classify gaps per corpus
+8. fill what is safe
+9. update `index.md` and `log.md`
+10. return the remaining gaps honestly
+
+For editor-behavior authority work, that often means some subset of:
+
+- Typora
+- Obsidian
+- Milkdown
+- Google Docs / GitHub Docs / Notion
+
+depending on the actual surface
+
+### Per-Corpus Evidence Ledger
+
+For `full` mode, explicitly close each scoped corpus with:
+
+- corpus name
+- compiled pages inspected
+- raw paths inspected
+- direct raw files actually read
+- official source entrypoints checked
+- strongest evidence found
+- disposition:
+  - `evidenced`
+  - `raw gap`
+  - `compile gap`
+  - `synthesis gap`
+  - `freshness gap`
+  - `evidence gap`
+  - `contradiction gap`
+  - `structure gap`
+- next action if still unresolved
+
+Do not end a full pass with silent corpora.
+
+If a likely corpus was scoped and produced no useful proof, say that directly.
+That is still a result.
+
+Before recording `raw gap`, use official-source discovery to confirm that the
+missing coverage is real and not just a stale or incomplete local raw mirror.
+
+Before recording `evidence gap`, read the strongest local raw hits that your
+searches surfaced for that corpus. Broad grep is routing, not proof.
+
+If raw evidence is missing for a scoped corpus after that discovery step,
+record a `raw gap` explicitly instead of quietly letting another corpus carry
+the whole answer.
+
+If compiled pages are missing but raw exists, record a `compile gap` and create
+the missing source summary when safe.
+
+If evidence exists but still does not answer the behavior question, record an
+`evidence gap` or `contradiction gap` instead of flattening it into a partial
+yes.
+
+If official discovery and local raw search already surfaced an obviously
+relevant file, you do not get to stop at "broad grep over corpus X". Read the
+file and cite it, or explain why it was not actually relevant.
+
+## Outputs
+
+A successful pass should leave behind durable artifacts such as:
+
+- source summaries
+- entity pages
+- concept pages
+- system pages
+- decision pages
+- open-question pages
+- updated index/log entrypoints
+
+## Blunt Rules
+
+- Do not do “research” that only rephrases the first source you found.
+- Do not call something `full` if you only spot-checked one corpus when the
+  topic obviously spans several.
+- Do not close `full` mode without an official-source discovery step for each
+  scoped corpus.
+- Do not treat grep hits as the same thing as inspected evidence.
+- Do not record a corpus as thin, partial, or unresolved when the likely
+  answer is already sitting in local raw unread.
+- Do not close `full` mode without a per-corpus evidence ledger.
+- Do not bypass the compiled layer and patch law straight from raw evidence
+  unless the task is tiny and the evidence is already obvious.
+- Do not leave `index.md` or `log.md` stale after adding research pages.

--- a/.changeset/convex-135-agentic-bootstrap.md
+++ b/.changeset/convex-135-agentic-bootstrap.md
@@ -1,21 +1,10 @@
 ---
-"kitcn": minor
-"@kitcn/resend": minor
+"kitcn": patch
+"@kitcn/resend": patch
 ---
-
-## Breaking changes
-
-- Require Convex 1.35 or newer.
-
-```json
-// Before
-{ "convex": "1.33.0" }
-
-// After
-{ "convex": "1.35.1" }
-```
 
 ## Patches
 
 - Let Convex handle anonymous non-interactive local setup without forcing `CONVEX_AGENT_MODE`.
+- Warn when an app pins an older Convex dependency family than kitcn expects.
 - Support Convex `dev --start` as a pre-run conflict flag.

--- a/.changeset/convex-135-agentic-bootstrap.md
+++ b/.changeset/convex-135-agentic-bootstrap.md
@@ -1,0 +1,21 @@
+---
+"kitcn": minor
+"@kitcn/resend": minor
+---
+
+## Breaking changes
+
+- Require Convex 1.35 or newer.
+
+```json
+// Before
+{ "convex": "1.33.0" }
+
+// After
+{ "convex": "1.35.1" }
+```
+
+## Patches
+
+- Let Convex handle anonymous non-interactive local setup without forcing `CONVEX_AGENT_MODE`.
+- Support Convex `dev --start` as a pre-run conflict flag.

--- a/.claude/skills/convex-release-audit
+++ b/.claude/skills/convex-release-audit
@@ -1,0 +1,1 @@
+../../.agents/skills/convex-release-audit

--- a/.claude/skills/package-release-audit
+++ b/.claude/skills/package-release-audit
@@ -1,0 +1,1 @@
+../../.agents/skills/package-release-audit

--- a/.claude/skills/research-wiki
+++ b/.claude/skills/research-wiki
@@ -1,0 +1,1 @@
+../../.agents/skills/research-wiki

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@tanstack/query-core": "5.90.20",
         "@tanstack/react-query": "5.95.2",
         "@tanstack/solid-query": "5.90.23",
-        "convex": "1.33.0",
+        "convex": "1.35.1",
         "hono": "4.12.9",
         "next": "16.1.6",
         "react": "19.2.4",
@@ -75,7 +75,7 @@
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
         "common-tags": "1.8.2",
-        "convex": "1.33.0",
+        "convex": "1.35.1",
         "date-fns": "4.1.0",
         "embla-carousel-react": "8.6.0",
         "hono": "4.12.9",
@@ -117,7 +117,7 @@
     },
     "packages/kitcn": {
       "name": "kitcn",
-      "version": "0.12.15",
+      "version": "0.12.28",
       "bin": {
         "kitcn": "./dist/cli.mjs",
         "intent": "./bin/intent.js",
@@ -155,7 +155,7 @@
         "@tanstack/react-query": ">=5",
         "@tanstack/solid-query": ">=5",
         "better-auth": "1.5.3",
-        "convex": ">=1.33",
+        "convex": ">=1.35.1",
         "hono": "4.12.9",
         "next": ">=14",
         "react": ">=18",
@@ -174,7 +174,7 @@
     },
     "packages/resend": {
       "name": "@kitcn/resend",
-      "version": "0.12.15",
+      "version": "0.12.28",
       "dependencies": {
         "svix": "^1.84.1",
       },
@@ -183,7 +183,7 @@
         "tsdown": "^0.20.3",
       },
       "peerDependencies": {
-        "convex": ">=1.33",
+        "convex": ">=1.35.1",
         "kitcn": ">=0.11.0 <1",
       },
     },
@@ -971,7 +971,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -1221,7 +1221,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.33.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-xXUAPNUJOEFXnWxseo6LNRYulMXlt2axc6u1oi4uQ4jI5h75qsZnpb+O6V0JRMGPyN+nQg5m5+trFCBv4c7twg=="],
+    "convex": ["convex@1.35.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ=="],
 
     "convex-helpers": ["convex-helpers@0.1.114", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.32.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-elEdh+gG6BDv2dWIWVvBeJPbHnDQS5+WexUuwlGVJXz1EbMkXz/UIQwFIfLMZIXUwW6ot4JYf/1JJKNStrE6lg=="],
 
@@ -2415,7 +2415,7 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -155,7 +155,7 @@
         "@tanstack/react-query": ">=5",
         "@tanstack/solid-query": ">=5",
         "better-auth": "1.5.3",
-        "convex": ">=1.35.1",
+        "convex": ">=1.35",
         "hono": "4.12.9",
         "next": ">=14",
         "react": ">=18",
@@ -183,7 +183,7 @@
         "tsdown": "^0.20.3",
       },
       "peerDependencies": {
-        "convex": ">=1.35.1",
+        "convex": ">=1.35",
         "kitcn": ">=0.11.0 <1",
       },
     },

--- a/docs/solutions/workflow-issues/convex-135-owns-anonymous-noninteractive-setup-20260415.md
+++ b/docs/solutions/workflow-issues/convex-135-owns-anonymous-noninteractive-setup-20260415.md
@@ -1,0 +1,111 @@
+---
+title: Convex 1.35 owns anonymous non-interactive setup
+date: 2026-04-15
+category: workflow-issues
+module: kitcn cli
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - Upgrading Convex CLI behavior that kitcn previously wrapped for agents
+  - Removing local bootstrap code that forces upstream agent environment flags
+tags: [convex, cli, agentic, bootstrap, non-interactive, scenarios]
+---
+
+# Convex 1.35 owns anonymous non-interactive setup
+
+## Context
+
+Convex 1.35 defaults unconfigured non-interactive commands to anonymous local
+deployment setup. That changes the kitcn boundary: `CONVEX_AGENT_MODE=anonymous`
+is no longer kitcn's responsibility for normal local bootstrap, verify, or
+scenario lanes.
+
+Older kitcn fixes correctly injected the env var because Convex needed it at
+the time. After the Convex 1.35 upgrade, keeping that injection preserves stale
+plumbing, emits upstream beta warnings, and makes tests assert implementation
+detail instead of product behavior.
+
+## Guidance
+
+Pin scaffold/runtime Convex installs to the latest supported exact version, but
+set package peer ranges at the release family floor:
+
+```json
+{
+  "dependencies": {
+    "convex": "1.35.1"
+  },
+  "peerDependencies": {
+    "convex": ">=1.35"
+  }
+}
+```
+
+Delete kitcn-owned anonymous-agent injection for local flows:
+
+```ts
+// Before
+env: createBackendCommandEnv({
+  ...params.env,
+  CONVEX_AGENT_MODE: "anonymous",
+});
+
+// After
+env: createBackendCommandEnv(params.env);
+```
+
+Keep preserving explicit user-provided `CONVEX_AGENT_MODE` through
+`createCommandEnv()`. The hard cut is only for kitcn deciding to force the env
+var.
+
+Scenario configs should also stop setting `CONVEX_AGENT_MODE`. Raw Convex
+fixtures and `kitcn verify` should prove the current upstream CLI contract:
+non-interactive setup works without local env magic.
+
+## Why This Matters
+
+Agent-native CLI code gets worse when it carries old upstream escape hatches
+after the upstream API grows the real behavior. The old env var was useful, but
+once Convex owns non-interactive anonymous setup, kitcn should trust that
+contract and keep its own surface smaller.
+
+This also makes scenario output cleaner. If `CONVEX_AGENT_MODE=anonymous mode is
+in beta` appears after the 1.35 upgrade, something is still forcing stale
+plumbing.
+
+## When to Apply
+
+- When a Convex release adds first-class CLI behavior for an old kitcn
+  workaround.
+- When scenario config or CLI code sets upstream environment flags for agentic
+  setup.
+- When docs or tests claim kitcn provisions anonymous Convex deployments
+  directly.
+
+## Examples
+
+Use release evidence to justify the cut before editing:
+
+```bash
+npm view convex version --json
+gh api -H "Accept: application/vnd.github.raw" \
+  repos/get-convex/convex-backend/contents/npm-packages/convex/CHANGELOG.md
+```
+
+Then search for stale local glue:
+
+```bash
+rg -n "CONVEX_AGENT_MODE|anonymous-agent|local-force-upgrade" \
+  packages tooling docs
+```
+
+Do not remove the local backend upgrade fallback just because anonymous setup
+improved. `--local-force-upgrade` still covers the older-backend upgrade prompt,
+which is a different upstream gap.
+
+## Related
+
+- [Published CLI bootstrap must keep TypeScript off the cold path and use anonymous Convex init](/Users/zbeyens/git/better-convex/docs/solutions/integration-issues/published-cli-bootstrap-must-ship-runtime-deps-and-anonymous-convex-init-20260331.md)
+- [Verify must prove local runtime without leaking Convex agent plumbing](/Users/zbeyens/git/better-convex/docs/solutions/integration-issues/verify-command-must-prove-local-runtime-without-leaking-convex-agent-plumbing-20260325.md)
+- [dev local preflight must auto-upgrade local Convex backend](/Users/zbeyens/git/better-convex/docs/solutions/integration-issues/dev-local-preflight-must-auto-upgrade-local-convex-backend-20260410.md)

--- a/example/package.json
+++ b/example/package.json
@@ -43,7 +43,7 @@
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "common-tags": "1.8.2",
-    "convex": "1.33.0",
+    "convex": "1.35.1",
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.6.0",
     "hono": "4.12.9",

--- a/fixtures/next-auth/package.json
+++ b/fixtures/next-auth/package.json
@@ -6,7 +6,7 @@
     "better-auth": "1.5.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.33.0",
+    "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.8.0",

--- a/fixtures/next/package.json
+++ b/fixtures/next/package.json
@@ -5,7 +5,7 @@
     "@tanstack/react-query": "5.95.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.33.0",
+    "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.8.0",

--- a/fixtures/start-auth/package.json
+++ b/fixtures/start-auth/package.json
@@ -14,7 +14,7 @@
     "better-auth": "1.5.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.33.0",
+    "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.8.0",

--- a/fixtures/start/package.json
+++ b/fixtures/start/package.json
@@ -13,7 +13,7 @@
     "@tanstack/router-plugin": "^1.132.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.33.0",
+    "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.8.0",

--- a/fixtures/vite-auth/package.json
+++ b/fixtures/vite-auth/package.json
@@ -8,7 +8,7 @@
     "better-auth": "1.5.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.33.0",
+    "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.8.0",

--- a/fixtures/vite/package.json
+++ b/fixtures/vite/package.json
@@ -7,7 +7,7 @@
     "@tanstack/react-query": "5.95.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.33.0",
+    "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@tanstack/query-core": "5.90.20",
     "@tanstack/react-query": "5.95.2",
     "@tanstack/solid-query": "5.90.23",
-    "convex": "1.33.0",
+    "convex": "1.35.1",
     "hono": "4.12.9",
     "next": "16.1.6",
     "react": "19.2.4",

--- a/packages/kitcn/package.json
+++ b/packages/kitcn/package.json
@@ -89,7 +89,7 @@
     "@tanstack/react-query": ">=5",
     "@tanstack/solid-query": ">=5",
     "better-auth": "1.5.3",
-    "convex": ">=1.33",
+    "convex": ">=1.35",
     "hono": "4.12.9",
     "next": ">=14",
     "react": ">=18",

--- a/packages/kitcn/skills/convex/references/setup/index.md
+++ b/packages/kitcn/skills/convex/references/setup/index.md
@@ -91,9 +91,9 @@ npx kitcn@latest init -t next --yes
 
 Then start the long-running backend with `bunx kitcn dev`, run the
 framework dev server (`bun dev` for the Next starter), and open `/convex` for
-the scaffolded messages demo. In `--yes` mode, kitcn provisions an anonymous
-local Convex deployment when no account is linked yet, so the starter path does
-not stop on a login prompt.
+the scaffolded messages demo. In `--yes` mode, Convex uses anonymous local
+deployment setup when no account is linked yet, so the starter path does not
+stop on a login prompt.
 
 Use the CLI first:
 
@@ -759,7 +759,7 @@ This runbook + references map to the canonical template shape as follows:
 | Symptom                                                                               | Likely Cause                                                                                    | Fix                                                                                                                                                                                         |
 | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@convex/api` not found                                                               | `kitcn dev` not run                                                                     | Run `bunx kitcn dev` and regenerate API metadata                                                                                                                                    |
-| `Cannot prompt for input in non-interactive terminals` during bootstrap               | Convex deployment selection still needs a local choice                                          | Use `bunx kitcn verify` for local proof, or pass `--env-file` / deployment-target args so Convex can resolve the deployment without prompting                                      |
+| `Cannot prompt for input in non-interactive terminals` during bootstrap               | Convex deployment targeting is ambiguous                                                        | Use `bunx kitcn verify` for local proof, or pass `--env-file` / deployment-target args so Convex can resolve the deployment without prompting                                      |
 | Can't find new local backend files under `~/.convex`                                  | Convex now stores new local deployment state per project                                        | Check `.convex/local/default/` in the current project root; treat `~/.convex/**` as legacy storage                                                                                          |
 | `kitcn env push` fails to set auth vars                                       | Target deployment is not active or not initialized                                              | For local proof, run `bunx kitcn verify`. For remote targets, resolve deployment targeting, then rerun `bunx kitcn env push`                                             |
 | `Failed to analyze auth.js` with `Unexpected token` / `map is not a function` on JWKS | Static `JWKS` value is malformed JSON                                                           | Unset/fix `JWKS`; use `getAuthConfigProvider()` fallback or repush with `bunx kitcn env push`                                                                                       |

--- a/packages/kitcn/skills/convex/references/setup/server.md
+++ b/packages/kitcn/skills/convex/references/setup/server.md
@@ -205,7 +205,7 @@ Do not fake generated files.
 Automation/non-interactive path:
 
 1. Run `npx kitcn@latest init --yes` when you want scaffold or adoption plus the one-shot local Convex bootstrap in one command.
-2. Run `bunx kitcn verify` when you want a non-interactive local runtime proof in the current app. Stop any long-running local backend first. It reuses an existing local deployment when one is already configured, and only falls back to anonymous fresh-local setup when it has to.
+2. Run `bunx kitcn verify` when you want a non-interactive local runtime proof in the current app. Stop any long-running local backend first. It reuses an existing local deployment when one is already configured, and lets Convex create anonymous local state when no local deployment is configured.
 3. Confirm the generated runtime exists in `convex/functions/generated/server.ts`.
 4. Then run `bunx kitcn dev` for ongoing codegen/API refresh.
 

--- a/packages/kitcn/src/cli/backend-core.ts
+++ b/packages/kitcn/src/cli/backend-core.ts
@@ -4072,7 +4072,6 @@ function isLocalBackendUpgradePrompt(output: string): boolean {
 export async function runConvexInitIfNeeded(params: {
   execaFn: typeof execa;
   backendAdapter: BackendAdapter;
-  yes?: boolean;
   env?: Record<string, string | undefined>;
   echoOutput?: boolean;
   targetArgs?: string[];
@@ -4097,20 +4096,11 @@ export async function runConvexInitIfNeeded(params: {
       process.cwd(),
       params.env
     ) === 'local';
-  const shouldUseAnonymousAgentMode = params.yes && shouldUseLocalDevPreflight;
-  const agentModeOverride = shouldUseAnonymousAgentMode
-    ? 'anonymous'
-    : params.env?.CONVEX_AGENT_MODE;
   const runCommand = async (commandArgs: string[]) =>
     normalizeConvexCommandResult(
       await params.execaFn(params.backendAdapter.command, commandArgs, {
         cwd: process.cwd(),
-        env: createBackendCommandEnv({
-          ...params.env,
-          ...(agentModeOverride
-            ? { CONVEX_AGENT_MODE: agentModeOverride }
-            : {}),
-        }),
+        env: createBackendCommandEnv(params.env),
         reject: false,
         stdio: 'pipe',
       })
@@ -4320,7 +4310,6 @@ async function runInitializationCodegen(params: {
     const initResult = await runConvexInitIfNeeded({
       execaFn: params.execaFn,
       backendAdapter: runtimeAdapter,
-      yes: params.yes,
       targetArgs: params.targetArgs,
     });
     if (initResult.exitCode !== 0) {
@@ -4535,6 +4524,7 @@ type ResetCliOptions = {
 const VALID_BACKFILL_ENABLED = new Set<BackfillEnabled>(['auto', 'on', 'off']);
 const CONVEX_DEV_PRE_RUN_CONFLICT_FLAGS = [
   '--run',
+  '--start',
   '--run-sh',
   '--run-component',
 ] as const;
@@ -5941,7 +5931,7 @@ export async function run(
       convexDevArgs.some((arg) => isConvexDevPreRunConflictFlag(arg))
     ) {
       throw new Error(
-        '`dev.preRun` cannot be combined with Convex dev run flags (`--run`, `--run-sh`, `--run-component`).'
+        '`dev.preRun` cannot be combined with Convex dev run flags (`--run`, `--start`, `--run-sh`, `--run-component`).'
       );
     }
     const backendAdapter = getBackendAdapter();

--- a/packages/kitcn/src/cli/cli.commands.ts
+++ b/packages/kitcn/src/cli/cli.commands.ts
@@ -136,7 +136,7 @@ function writeRawConvexNextApp(dir: string) {
     name: 'raw-next-convex-app',
     private: true,
     dependencies: {
-      convex: '^1.33.0',
+      convex: '^1.35.1',
       next: '^16.1.5',
       react: '^19.2.4',
       'react-dom': '^19.2.4',
@@ -234,7 +234,7 @@ function writeRawConvexViteApp(dir: string) {
     private: true,
     type: 'module',
     dependencies: {
-      convex: '^1.33.0',
+      convex: '^1.35.1',
       react: '^19.2.4',
       'react-dom': '^19.2.4',
     },
@@ -327,7 +327,7 @@ function writeRawConvexStartApp(dir: string) {
     dependencies: {
       '@tanstack/react-router': '^1.132.0',
       '@tanstack/react-start': '^1.132.0',
-      convex: '^1.33.0',
+      convex: '^1.35.1',
       react: '^19.2.4',
       'react-dom': '^19.2.4',
     },
@@ -7304,7 +7304,7 @@ describe('cli/cli', () => {
         loadCliConfig: loadConfigStub as any,
       })
     ).rejects.toThrow(
-      '`dev.preRun` cannot be combined with Convex dev run flags (`--run`, `--run-sh`, `--run-component`).'
+      '`dev.preRun` cannot be combined with Convex dev run flags (`--run`, `--start`, `--run-sh`, `--run-component`).'
     );
 
     expect(generateMetaStub).not.toHaveBeenCalled();

--- a/packages/kitcn/src/cli/cli.ts
+++ b/packages/kitcn/src/cli/cli.ts
@@ -31,6 +31,7 @@ import { handleResetCommand } from './commands/reset.js';
 import { handleVerifyCommand, VERIFY_HELP_TEXT } from './commands/verify.js';
 import { handleViewCommand, VIEW_HELP_TEXT } from './commands/view.js';
 import type { CliBackend } from './config.js';
+import { resolveSupportedDependencyWarnings } from './supported-dependencies.js';
 import { handleCliError } from './utils/handle-error.js';
 import { logger } from './utils/logger.js';
 
@@ -45,6 +46,15 @@ const LOCAL_NODE_REEXEC_COMMANDS = new Set([
   'add',
   'codegen',
   'dev',
+  'init',
+  'verify',
+]);
+const DEPENDENCY_WARNING_COMMANDS = new Set([
+  'add',
+  'codegen',
+  'deploy',
+  'dev',
+  'env',
   'init',
   'verify',
 ]);
@@ -190,6 +200,18 @@ const printCommandHelp = (command: string, backend: CliBackend = 'convex') => {
   printRootHelp(backend);
 };
 
+function warnSupportedDependencyIssues(command: string) {
+  if (!DEPENDENCY_WARNING_COMMANDS.has(command)) {
+    return;
+  }
+
+  for (const warning of resolveSupportedDependencyWarnings()) {
+    logger.warn(
+      `⚠️  kitcn expects ${warning.packageName} ${warning.minimum}; found ${warning.current}. Run \`bun add ${warning.installSpec}\` when you can.`
+    );
+  }
+}
+
 const handlePassthroughCommand = async (
   argv: string[],
   deps?: Partial<RunDeps>
@@ -276,6 +298,7 @@ export async function run(argv: string[], deps?: Partial<RunDeps>) {
     if (reexecExitCode !== null) {
       return reexecExitCode;
     }
+    warnSupportedDependencyIssues('dev');
     return handleDevCommand(argv, deps);
   }
   if (VERSION_FLAGS.has(argv[0]!)) {
@@ -329,6 +352,7 @@ export async function run(argv: string[], deps?: Partial<RunDeps>) {
   const handler =
     COMMAND_HANDLERS[parsed.command as keyof typeof COMMAND_HANDLERS] ??
     handlePassthroughCommand;
+  warnSupportedDependencyIssues(parsed.command);
   return handler(argv, deps);
 }
 

--- a/packages/kitcn/src/cli/commands/dev.test.ts
+++ b/packages/kitcn/src/cli/commands/dev.test.ts
@@ -9,7 +9,6 @@ import {
   resolveConcaveLocalDevContract,
   resolveConcaveLocalSiteUrl,
   resolveDevStartupRetryDelayMs,
-  resolveImplicitConvexAnonymousAgentMode,
   resolveImplicitConvexRemoteDeploymentEnv,
   resolveSupportedLocalNodeEnvOverrides,
   resolveWatcherCommand,
@@ -255,18 +254,6 @@ describe('cli/commands/dev', () => {
     expect(resolveImplicitConvexRemoteDeploymentEnv(emptyDir)).toBeNull();
   });
 
-  test('resolveImplicitConvexAnonymousAgentMode detects anonymous-agent in .env.local', () => {
-    const dir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'kitcn-dev-anonymous-agent-')
-    );
-    fs.writeFileSync(
-      path.join(dir, '.env.local'),
-      'CONVEX_DEPLOYMENT=anonymous-agent\n'
-    );
-
-    expect(resolveImplicitConvexAnonymousAgentMode(dir)).toBe('anonymous');
-  });
-
   test('resolveConcaveLocalDevContract defaults concave dev to Convex local ports', () => {
     expect(resolveConcaveLocalDevContract([], 'http://localhost:3000')).toEqual(
       {
@@ -367,14 +354,6 @@ describe('cli/commands/dev', () => {
     expect(
       filterDevStartupLine(
         'A minor update is available for Convex (1.33.0 → 1.34.0)'
-      )
-    ).toEqual({
-      kind: 'skip',
-    });
-
-    expect(
-      filterDevStartupLine(
-        'CONVEX_AGENT_MODE=anonymous mode is in beta, functionality may change in the future.'
       )
     ).toEqual({
       kind: 'skip',
@@ -747,7 +726,7 @@ describe('cli/commands/dev', () => {
     }
   });
 
-  test('handleDevCommand prefers convex init for anonymous local deployments when init succeeds', async () => {
+  test('handleDevCommand lets Convex choose anonymous local deployments when init succeeds', async () => {
     const dir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'kitcn-dev-anonymous-agent-local-')
     );
@@ -825,8 +804,8 @@ describe('cli/commands/dev', () => {
         cmd: 'node',
         args: ['/fake/convex/main.js', 'init'],
         opts: {
-          env: expect.objectContaining({
-            CONVEX_AGENT_MODE: 'anonymous',
+          env: expect.not.objectContaining({
+            CONVEX_AGENT_MODE: expect.any(String),
           }),
         },
       });
@@ -834,8 +813,8 @@ describe('cli/commands/dev', () => {
         cmd: 'node',
         args: ['/fake/convex/main.js', 'dev', '--once'],
         opts: {
-          env: expect.objectContaining({
-            CONVEX_AGENT_MODE: 'anonymous',
+          env: expect.not.objectContaining({
+            CONVEX_AGENT_MODE: expect.any(String),
           }),
         },
       });

--- a/packages/kitcn/src/cli/commands/dev.ts
+++ b/packages/kitcn/src/cli/commands/dev.ts
@@ -212,7 +212,6 @@ export function filterDevStartupLine(
   }
   if (
     line.includes('Finished running function "init"') ||
-    line.includes('CONVEX_AGENT_MODE=anonymous mode is in beta') ||
     line.includes('Convex AI files are not installed.') ||
     line.includes('Preparing Convex functions...') ||
     line.includes('Bundling component schemas and implementations') ||
@@ -684,24 +683,6 @@ export function resolveImplicitConvexRemoteDeploymentEnv(
   };
 }
 
-export function resolveImplicitConvexAnonymousAgentMode(
-  cwd = process.cwd()
-): 'anonymous' | undefined {
-  const envLocalPath = join(cwd, '.env.local');
-  if (!fs.existsSync(envLocalPath)) {
-    return;
-  }
-
-  const parsed = parseEnv(fs.readFileSync(envLocalPath, 'utf8'));
-  const deployment = parsed.CONVEX_DEPLOYMENT?.trim();
-  if (
-    deployment === 'anonymous-agent' ||
-    deployment?.startsWith('anonymous:')
-  ) {
-    return 'anonymous';
-  }
-}
-
 function resolveConvexEnvFileCommandEnv(
   args: string[],
   cwd = process.cwd()
@@ -1101,13 +1082,6 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
     explicitConvexCommandEnv === null
       ? resolveImplicitConvexRemoteDeploymentEnv()
       : null;
-  const implicitConvexAgentMode =
-    backend === 'convex' &&
-    explicitConvexTargetArgs.length === 0 &&
-    !explicitConvexCommandEnv?.CONVEX_AGENT_MODE &&
-    !implicitConvexCommandEnv?.CONVEX_AGENT_MODE
-      ? resolveImplicitConvexAnonymousAgentMode()
-      : undefined;
   const effectiveConvexCommandEnv =
     explicitConvexCommandEnv ?? implicitConvexCommandEnv;
   const preRunFunction = config.dev.preRun;
@@ -1126,7 +1100,7 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
     convexDevArgs.some((arg) => isConvexDevPreRunConflictFlag(arg))
   ) {
     throw new Error(
-      '`dev.preRun` cannot be combined with Convex dev run flags (`--run`, `--run-sh`, `--run-component`).'
+      '`dev.preRun` cannot be combined with Convex dev run flags (`--run`, `--start`, `--run-sh`, `--run-component`).'
     );
   }
 
@@ -1220,9 +1194,6 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
     env: {
       ...localNodeEnvOverrides,
       ...effectiveConvexCommandEnv,
-      ...(implicitConvexAgentMode
-        ? { CONVEX_AGENT_MODE: implicitConvexAgentMode }
-        : {}),
     },
     targetArgs,
   });
@@ -1296,9 +1267,6 @@ export const handleDevCommand = async (argv: string[], deps?: DevDeps) => {
       env: createBackendCommandEnv({
         ...localNodeEnvOverrides,
         ...effectiveConvexCommandEnv,
-        ...(implicitConvexAgentMode
-          ? { CONVEX_AGENT_MODE: implicitConvexAgentMode }
-          : {}),
         ...concaveLocalDevContract?.backendEnv,
       }),
       reject: false,

--- a/packages/kitcn/src/cli/commands/init.test.ts
+++ b/packages/kitcn/src/cli/commands/init.test.ts
@@ -277,7 +277,7 @@ describe('cli/commands/init', () => {
             | { env?: Record<string, string | undefined> }
             | undefined
         )?.env?.CONVEX_AGENT_MODE
-      ).toBe('anonymous');
+      ).toBeUndefined();
       expect(fs.existsSync(path.join(expectedProjectDir, 'package.json'))).toBe(
         true
       );

--- a/packages/kitcn/src/cli/commands/verify.test.ts
+++ b/packages/kitcn/src/cli/commands/verify.test.ts
@@ -72,7 +72,7 @@ describe('cli/commands/verify', () => {
     ).rejects.toThrow('`kitcn verify` is only supported for backend convex.');
   });
 
-  test('handleVerifyCommand injects anonymous agent mode and restores local state when no configured local deployment exists', async () => {
+  test('handleVerifyCommand relies on Convex non-interactive anonymous default and restores local state', async () => {
     const dir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'kitcn-verify-command-local-')
     );
@@ -95,7 +95,7 @@ describe('cli/commands/verify', () => {
         return watcherProcess;
       }
       if (args[1] === 'init') {
-        expect(opts?.env?.CONVEX_AGENT_MODE).toBe('anonymous');
+        expect(opts?.env?.CONVEX_AGENT_MODE).toBeUndefined();
         expect(fs.existsSync(path.join(dir, '.convex', 'original.txt'))).toBe(
           false
         );
@@ -105,7 +105,7 @@ describe('cli/commands/verify', () => {
       }
       if (args[1] === 'dev') {
         expect(args).toContain('--once');
-        expect(opts?.env?.CONVEX_AGENT_MODE).toBe('anonymous');
+        expect(opts?.env?.CONVEX_AGENT_MODE).toBeUndefined();
         return convexProcess;
       }
       return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });

--- a/packages/kitcn/src/cli/commands/verify.ts
+++ b/packages/kitcn/src/cli/commands/verify.ts
@@ -31,24 +31,6 @@ function assertNoVerifyLifecycleFlags(args: string[]) {
   }
 }
 
-async function withAnonymousVerifyAgentMode<T>(run: () => Promise<T>) {
-  const previous = process.env.CONVEX_AGENT_MODE;
-  if (!previous) {
-    process.env.CONVEX_AGENT_MODE = 'anonymous';
-  }
-
-  try {
-    return await run();
-  } finally {
-    if (previous === undefined) {
-      // biome-ignore lint/performance/noDelete: process.env must drop the key; assigning undefined writes the string "undefined"
-      delete process.env.CONVEX_AGENT_MODE;
-    } else {
-      process.env.CONVEX_AGENT_MODE = previous;
-    }
-  }
-}
-
 function hasConfiguredLocalConvexDeployment(cwd = process.cwd()) {
   return fs.existsSync(
     path.join(cwd, '.convex', 'local', 'default', 'config.json')
@@ -127,7 +109,5 @@ export const handleVerifyCommand = async (
     return handleDevCommand(devArgv, deps);
   }
 
-  return withIsolatedLocalConvexState(() =>
-    withAnonymousVerifyAgentMode(() => handleDevCommand(devArgv, deps))
-  );
+  return withIsolatedLocalConvexState(() => handleDevCommand(devArgv, deps));
 };

--- a/packages/kitcn/src/cli/supported-dependencies.test.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.test.ts
@@ -12,6 +12,7 @@ import {
   PINNED_ZOD_INSTALL_SPEC,
   resolveScaffoldInstallSpec,
   resolveSupportedDependencyInstallSpec,
+  resolveSupportedDependencyWarnings,
   SUPPORTED_DEPENDENCY_VERSIONS,
 } from './supported-dependencies';
 
@@ -74,6 +75,41 @@ describe('cli/supported-dependencies', () => {
     expect(
       resolveSupportedDependencyInstallSpec('better-auth@1.5.3', env)
     ).toBe('better-auth@1.5.3');
+  });
+
+  test('warns when the app pins an older supported peer dependency', () => {
+    const dir = fs.mkdtempSync('/tmp/kitcn-peer-warning-');
+    fs.writeFileSync(
+      `${dir}/package.json`,
+      JSON.stringify({
+        dependencies: {
+          convex: '^1.33.0',
+        },
+      })
+    );
+
+    expect(resolveSupportedDependencyWarnings(dir)).toEqual([
+      {
+        packageName: 'convex',
+        current: '^1.33.0',
+        minimum: '>=1.35',
+        installSpec: `convex@${SUPPORTED_DEPENDENCY_VERSIONS.convex.exact}`,
+      },
+    ]);
+  });
+
+  test('does not warn when the app has the supported Convex family', () => {
+    const dir = fs.mkdtempSync('/tmp/kitcn-peer-current-');
+    fs.writeFileSync(
+      `${dir}/package.json`,
+      JSON.stringify({
+        dependencies: {
+          convex: '^1.35.0',
+        },
+      })
+    );
+
+    expect(resolveSupportedDependencyWarnings(dir)).toEqual([]);
   });
 
   test('pins scaffold kitcn installs to the current package version', () => {

--- a/packages/kitcn/src/cli/supported-dependencies.test.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.test.ts
@@ -17,7 +17,7 @@ import {
 
 describe('cli/supported-dependencies', () => {
   test('extracts package names from install specs', () => {
-    expect(getPackageNameFromInstallSpec('convex@1.33.0')).toBe('convex');
+    expect(getPackageNameFromInstallSpec('convex@1.35.1')).toBe('convex');
     expect(getPackageNameFromInstallSpec('better-auth@1.5.3')).toBe(
       'better-auth'
     );
@@ -56,7 +56,7 @@ describe('cli/supported-dependencies', () => {
     expect(SUPPORTED_DEPENDENCY_VERSIONS.convex.range).toBe(
       `^${SUPPORTED_DEPENDENCY_VERSIONS.convex.exact}`
     );
-    expect(SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum).toBe('>=1.33');
+    expect(SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum).toBe('>=1.35');
   });
 
   test('resolves local install spec overrides for supported packages', () => {

--- a/packages/kitcn/src/cli/supported-dependencies.test.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.test.ts
@@ -112,6 +112,70 @@ describe('cli/supported-dependencies', () => {
     expect(resolveSupportedDependencyWarnings(dir)).toEqual([]);
   });
 
+  test('does not warn for open-ended ranges that can resolve to supported Convex', () => {
+    const dir = fs.mkdtempSync('/tmp/kitcn-peer-range-');
+    fs.writeFileSync(
+      `${dir}/package.json`,
+      JSON.stringify({
+        dependencies: {
+          convex: '>=1.0.0',
+        },
+      })
+    );
+
+    expect(resolveSupportedDependencyWarnings(dir)).toEqual([]);
+  });
+
+  test('warns for upper-bounded ranges below supported Convex', () => {
+    const dir = fs.mkdtempSync('/tmp/kitcn-peer-upper-bound-');
+    fs.writeFileSync(
+      `${dir}/package.json`,
+      JSON.stringify({
+        dependencies: {
+          convex: '<1.35.0',
+        },
+      })
+    );
+
+    expect(resolveSupportedDependencyWarnings(dir)).toEqual([
+      {
+        packageName: 'convex',
+        current: '<1.35.0',
+        minimum: '>=1.35',
+        installSpec: `convex@${SUPPORTED_DEPENDENCY_VERSIONS.convex.exact}`,
+      },
+    ]);
+  });
+
+  test('warns when installed Convex is older than the supported family', () => {
+    const dir = fs.mkdtempSync('/tmp/kitcn-peer-installed-');
+    fs.mkdirSync(`${dir}/node_modules/convex`, { recursive: true });
+    fs.writeFileSync(
+      `${dir}/package.json`,
+      JSON.stringify({
+        dependencies: {
+          convex: '<1.36.0',
+        },
+      })
+    );
+    fs.writeFileSync(
+      `${dir}/node_modules/convex/package.json`,
+      JSON.stringify({
+        name: 'convex',
+        version: '1.34.1',
+      })
+    );
+
+    expect(resolveSupportedDependencyWarnings(dir)).toEqual([
+      {
+        packageName: 'convex',
+        current: '1.34.1',
+        minimum: '>=1.35',
+        installSpec: `convex@${SUPPORTED_DEPENDENCY_VERSIONS.convex.exact}`,
+      },
+    ]);
+  });
+
   test('pins scaffold kitcn installs to the current package version', () => {
     const packageJson = JSON.parse(
       fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8')

--- a/packages/kitcn/src/cli/supported-dependencies.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.ts
@@ -3,7 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const EXACT_VERSION_RE = /^(\d+)\.(\d+)\.\d+$/;
-const SUPPORTED_CONVEX_VERSION = '1.33.0';
+const SUPPORTED_CONVEX_VERSION = '1.35.1';
 const SUPPORTED_BETTER_AUTH_VERSION = '1.5.3';
 const SUPPORTED_HONO_VERSION = '4.12.9';
 const SUPPORTED_OPENTELEMETRY_API_VERSION = '1.9.0';

--- a/packages/kitcn/src/cli/supported-dependencies.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url';
 
 const EXACT_VERSION_RE = /^(\d+)\.(\d+)\.\d+$/;
 const VERSION_IN_SPEC_RE = /(\d+)\.(\d+)(?:\.\d+)?/;
+const PLAIN_VERSION_SPEC_RE = /^[\^~]?v?\d+\.\d+(?:\.\d+)?$/;
+const UPPER_BOUND_RE = /(?:^|\s)<={0,1}\s*v?(\d+)\.(\d+)(?:\.\d+)?/g;
 const SUPPORTED_CONVEX_VERSION = '1.35.1';
 const SUPPORTED_BETTER_AUTH_VERSION = '1.5.3';
 const SUPPORTED_HONO_VERSION = '4.12.9';
@@ -202,7 +204,41 @@ function readDependencyVersion(
   }
 }
 
-function isVersionSpecBelowMinimum(spec: string, minimum: string): boolean {
+function readInstalledDependencyVersion(
+  packageJsonPath: string,
+  packageName: string
+): string | undefined {
+  const installedPackageJsonPath = join(
+    dirname(packageJsonPath),
+    'node_modules',
+    ...packageName.split('/'),
+    'package.json'
+  );
+  if (!fs.existsSync(installedPackageJsonPath)) {
+    return undefined;
+  }
+  const packageJson = JSON.parse(
+    fs.readFileSync(installedPackageJsonPath, 'utf8')
+  ) as { version?: string };
+  return packageJson.version;
+}
+
+function compareMajorMinor(
+  aMajor: number,
+  aMinor: number,
+  bMajor: number,
+  bMinor: number
+) {
+  if (aMajor !== bMajor) {
+    return aMajor - bMajor;
+  }
+  return aMinor - bMinor;
+}
+
+function isConcreteVersionSpecBelowMinimum(
+  spec: string,
+  minimum: string
+): boolean {
   const specMatch = VERSION_IN_SPEC_RE.exec(spec);
   const minimumMatch = VERSION_IN_SPEC_RE.exec(minimum);
   if (!specMatch || !minimumMatch) {
@@ -215,9 +251,37 @@ function isVersionSpecBelowMinimum(spec: string, minimum: string): boolean {
   const minimumMinor = Number(minimumMatch[2]);
 
   return (
-    specMajor < minimumMajor ||
-    (specMajor === minimumMajor && specMinor < minimumMinor)
+    compareMajorMinor(specMajor, specMinor, minimumMajor, minimumMinor) < 0
   );
+}
+
+function isDeclaredVersionSpecBelowMinimum(
+  spec: string,
+  minimum: string
+): boolean {
+  const normalized = spec.trim();
+  if (PLAIN_VERSION_SPEC_RE.test(normalized)) {
+    return isConcreteVersionSpecBelowMinimum(normalized, minimum);
+  }
+
+  const minimumMatch = VERSION_IN_SPEC_RE.exec(minimum);
+  if (!minimumMatch) {
+    return false;
+  }
+  const minimumMajor = Number(minimumMatch[1]);
+  const minimumMinor = Number(minimumMatch[2]);
+
+  for (const match of normalized.matchAll(UPPER_BOUND_RE)) {
+    const upperMajor = Number(match[1]);
+    const upperMinor = Number(match[2]);
+    if (
+      compareMajorMinor(upperMajor, upperMinor, minimumMajor, minimumMinor) <= 0
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function resolveSupportedDependencyWarnings(
@@ -231,10 +295,31 @@ export function resolveSupportedDependencyWarnings(
   const packageJson = JSON.parse(
     fs.readFileSync(packageJsonPath, 'utf8')
   ) as PackageJsonWithDependencies;
+  const installedConvexVersion = readInstalledDependencyVersion(
+    packageJsonPath,
+    'convex'
+  );
+  if (
+    installedConvexVersion &&
+    isConcreteVersionSpecBelowMinimum(
+      installedConvexVersion,
+      SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum
+    )
+  ) {
+    return [
+      {
+        packageName: 'convex',
+        current: installedConvexVersion,
+        minimum: SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum,
+        installSpec: PINNED_CONVEX_INSTALL_SPEC,
+      },
+    ];
+  }
+
   const convexVersion = readDependencyVersion(packageJson, 'convex');
   if (
     !convexVersion ||
-    !isVersionSpecBelowMinimum(
+    !isDeclaredVersionSpecBelowMinimum(
       convexVersion,
       SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum
     )

--- a/packages/kitcn/src/cli/supported-dependencies.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const EXACT_VERSION_RE = /^(\d+)\.(\d+)\.\d+$/;
+const VERSION_IN_SPEC_RE = /(\d+)\.(\d+)(?:\.\d+)?/;
 const SUPPORTED_CONVEX_VERSION = '1.35.1';
 const SUPPORTED_BETTER_AUTH_VERSION = '1.5.3';
 const SUPPORTED_HONO_VERSION = '4.12.9';
@@ -154,3 +155,99 @@ export const BASELINE_DEPENDENCY_INSTALL_SPECS = [
 ] as const;
 
 export const INIT_TEMPLATE_DEPENDENCY_INSTALL_SPECS = ['superjson'] as const;
+
+const DEPENDENCY_SECTIONS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const;
+
+type PackageJsonWithDependencies = {
+  [key in (typeof DEPENDENCY_SECTIONS)[number]]?: Record<string, string>;
+};
+
+export type SupportedDependencyWarning = {
+  packageName: string;
+  current: string;
+  minimum: string;
+  installSpec: string;
+};
+
+function findNearestPackageJsonPath(cwd: string): string | undefined {
+  let currentDir = cwd;
+  while (true) {
+    const packageJsonPath = join(currentDir, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      return packageJsonPath;
+    }
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+    currentDir = parentDir;
+  }
+}
+
+function readDependencyVersion(
+  packageJson: PackageJsonWithDependencies,
+  packageName: string
+): string | undefined {
+  for (const section of DEPENDENCY_SECTIONS) {
+    const version = packageJson[section]?.[packageName];
+    if (version) {
+      return version;
+    }
+  }
+}
+
+function isVersionSpecBelowMinimum(spec: string, minimum: string): boolean {
+  const specMatch = VERSION_IN_SPEC_RE.exec(spec);
+  const minimumMatch = VERSION_IN_SPEC_RE.exec(minimum);
+  if (!specMatch || !minimumMatch) {
+    return false;
+  }
+
+  const specMajor = Number(specMatch[1]);
+  const specMinor = Number(specMatch[2]);
+  const minimumMajor = Number(minimumMatch[1]);
+  const minimumMinor = Number(minimumMatch[2]);
+
+  return (
+    specMajor < minimumMajor ||
+    (specMajor === minimumMajor && specMinor < minimumMinor)
+  );
+}
+
+export function resolveSupportedDependencyWarnings(
+  cwd = process.cwd()
+): SupportedDependencyWarning[] {
+  const packageJsonPath = findNearestPackageJsonPath(cwd);
+  if (!packageJsonPath) {
+    return [];
+  }
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(packageJsonPath, 'utf8')
+  ) as PackageJsonWithDependencies;
+  const convexVersion = readDependencyVersion(packageJson, 'convex');
+  if (
+    !convexVersion ||
+    !isVersionSpecBelowMinimum(
+      convexVersion,
+      SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum
+    )
+  ) {
+    return [];
+  }
+
+  return [
+    {
+      packageName: 'convex',
+      current: convexVersion,
+      minimum: SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum,
+      installSpec: PINNED_CONVEX_INSTALL_SPEC,
+    },
+  ];
+}

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "kitcn": ">=0.11.0 <1",
-    "convex": ">=1.33"
+    "convex": ">=1.35"
   },
   "devDependencies": {
     "kitcn": "workspace:*",

--- a/test/concave/fixture/package.json
+++ b/test/concave/fixture/package.json
@@ -2,6 +2,6 @@
   "name": "kitcn-concave-fixture",
   "private": true,
   "dependencies": {
-    "convex": "1.33.0"
+    "convex": "1.35.1"
   }
 }

--- a/tooling/node-env-smoke.ts
+++ b/tooling/node-env-smoke.ts
@@ -11,25 +11,11 @@ const DIST_CLI_PATH = path.join(
   'cli.mjs'
 );
 
-const createAnonymousRunCommand = (
-  cmd: string[],
-  cwd: string,
-  options: Parameters<typeof run>[2] = {}
-) =>
-  run(cmd, cwd, {
-    ...options,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-      ...options.env,
-    },
-  });
-
 export const runNodeEnvSmoke = async () => {
   const { generatedAppDir, tempRoot } = await generateFreshApp({
     backend: 'convex',
     generatedAppName: 'node-env-smoke',
     initTemplate: 'vite',
-    runCommand: createAnonymousRunCommand,
   });
 
   try {
@@ -47,11 +33,11 @@ export const runNodeEnvSmoke = async () => {
       ].join('\n')
     );
 
-    await createAnonymousRunCommand(
+    await run(
       ['node', DIST_CLI_PATH, '--backend', 'convex', 'env', 'push'],
       generatedAppDir
     );
-    await createAnonymousRunCommand(
+    await run(
       [
         'node',
         DIST_CLI_PATH,

--- a/tooling/scenario-fixtures/create-convex-bare/package.json
+++ b/tooling/scenario-fixtures/create-convex-bare/package.json
@@ -9,7 +9,7 @@
     "lint": "tsc -p convex && eslint . --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "convex": "^1.33.0"
+    "convex": "^1.35.1"
   },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^1.1.1",

--- a/tooling/scenario-fixtures/create-convex-nextjs-shadcn/package.json
+++ b/tooling/scenario-fixtures/create-convex-nextjs-shadcn/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-toggle-group": "^1.1.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "^1.33.0",
+    "convex": "^1.35.1",
     "lucide-react": "^0.544.0",
     "next": "^16.1.5",
     "next-themes": "^0.4.4",

--- a/tooling/scenario-fixtures/create-convex-react-vite-shadcn/package.json
+++ b/tooling/scenario-fixtures/create-convex-react-vite-shadcn/package.json
@@ -21,7 +21,7 @@
     "@radix-ui/react-toggle-group": "^1.0.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "convex": "^1.33.0",
+    "convex": "^1.35.1",
     "next-themes": "^0.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/tooling/scenario.config.ts
+++ b/tooling/scenario.config.ts
@@ -55,6 +55,7 @@ export type ScenarioDefinition = {
   backend?: TemplateBackend;
   check: boolean;
   env?: Record<string, string>;
+  isolateConvexEnv?: boolean;
   label: string;
   setup: readonly ScenarioStep[];
   source: ScenarioSource;
@@ -141,6 +142,7 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'convex-next-auth-bootstrap': {
     backend: 'convex',
     check: true,
+    isolateConvexEnv: true,
     label: 'convex next auth bootstrap',
     setup: [['add', 'auth', '--yes', '--no-codegen']],
     validation: {
@@ -156,6 +158,7 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'convex-vite-auth-bootstrap': {
     backend: 'convex',
     check: true,
+    isolateConvexEnv: true,
     label: 'convex vite auth bootstrap',
     setup: [['add', 'auth', '--yes', '--no-codegen']],
     validation: {
@@ -170,6 +173,7 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'convex-next-all': {
     backend: 'convex',
     check: true,
+    isolateConvexEnv: true,
     label: 'convex next all',
     setup: [
       ['add', 'ratelimit', '--yes', '--no-codegen'],
@@ -189,6 +193,7 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'create-convex-nextjs-shadcn-auth': {
     backend: 'convex',
     check: false,
+    isolateConvexEnv: true,
     label: 'create-convex nextjs-shadcn auth adoption',
     setup: [],
     validation: {
@@ -206,6 +211,7 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'raw-start-auth-adoption': {
     backend: 'convex',
     check: false,
+    isolateConvexEnv: true,
     label: 'raw start auth adoption',
     setup: [],
     validation: {
@@ -222,6 +228,7 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   },
   'create-convex-bare': {
     check: true,
+    isolateConvexEnv: true,
     label: 'create-convex bare runtime',
     setup: [],
     validation: {
@@ -234,6 +241,7 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   },
   'create-convex-nextjs-shadcn': {
     check: true,
+    isolateConvexEnv: true,
     label: 'create-convex nextjs-shadcn adoption',
     setup: [['init', '--yes', '--json']],
     validation: {
@@ -246,6 +254,7 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   },
   'create-convex-react-vite-shadcn': {
     check: true,
+    isolateConvexEnv: true,
     label: 'create-convex react-vite-shadcn adoption',
     setup: [['init', '--yes', '--json']],
     validation: {

--- a/tooling/scenario.config.ts
+++ b/tooling/scenario.config.ts
@@ -141,9 +141,6 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'convex-next-auth-bootstrap': {
     backend: 'convex',
     check: true,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-    },
     label: 'convex next auth bootstrap',
     setup: [['add', 'auth', '--yes', '--no-codegen']],
     validation: {
@@ -159,9 +156,6 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'convex-vite-auth-bootstrap': {
     backend: 'convex',
     check: true,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-    },
     label: 'convex vite auth bootstrap',
     setup: [['add', 'auth', '--yes', '--no-codegen']],
     validation: {
@@ -176,9 +170,6 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'convex-next-all': {
     backend: 'convex',
     check: true,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-    },
     label: 'convex next all',
     setup: [
       ['add', 'ratelimit', '--yes', '--no-codegen'],
@@ -198,9 +189,6 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'create-convex-nextjs-shadcn-auth': {
     backend: 'convex',
     check: false,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-    },
     label: 'create-convex nextjs-shadcn auth adoption',
     setup: [],
     validation: {
@@ -218,9 +206,6 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   'raw-start-auth-adoption': {
     backend: 'convex',
     check: false,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-    },
     label: 'raw start auth adoption',
     setup: [],
     validation: {
@@ -237,9 +222,6 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   },
   'create-convex-bare': {
     check: true,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-    },
     label: 'create-convex bare runtime',
     setup: [],
     validation: {
@@ -252,9 +234,6 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   },
   'create-convex-nextjs-shadcn': {
     check: true,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-    },
     label: 'create-convex nextjs-shadcn adoption',
     setup: [['init', '--yes', '--json']],
     validation: {
@@ -267,9 +246,6 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioKey, ScenarioDefinition> = {
   },
   'create-convex-react-vite-shadcn': {
     check: true,
-    env: {
-      CONVEX_AGENT_MODE: 'anonymous',
-    },
     label: 'create-convex react-vite-shadcn adoption',
     setup: [['init', '--yes', '--json']],
     validation: {

--- a/tooling/scenarios.test.ts
+++ b/tooling/scenarios.test.ts
@@ -453,8 +453,8 @@ describe('tooling/scenarios', () => {
       'convex'
     );
     expect(
-      SCENARIO_DEFINITIONS['convex-next-auth-bootstrap'].env?.CONVEX_AGENT_MODE
-    ).toBe('anonymous');
+      SCENARIO_DEFINITIONS['convex-next-auth-bootstrap'].env
+    ).toBeUndefined();
     expect(
       SCENARIO_DEFINITIONS['convex-next-auth-bootstrap'].validation.beforeCheck
     ).toEqual([['init', '--yes', '--json']]);
@@ -475,9 +475,6 @@ describe('tooling/scenarios', () => {
     expect(SCENARIO_DEFINITIONS['convex-next-all']).toMatchObject({
       backend: 'convex',
       check: true,
-      env: {
-        CONVEX_AGENT_MODE: 'anonymous',
-      },
       label: 'convex next all',
       setup: [
         ['add', 'ratelimit', '--yes', '--no-codegen'],
@@ -493,9 +490,6 @@ describe('tooling/scenarios', () => {
     expect(SCENARIO_DEFINITIONS['create-convex-nextjs-shadcn-auth']).toEqual({
       backend: 'convex',
       check: false,
-      env: {
-        CONVEX_AGENT_MODE: 'anonymous',
-      },
       label: 'create-convex nextjs-shadcn auth adoption',
       setup: [],
       source: {
@@ -513,9 +507,6 @@ describe('tooling/scenarios', () => {
     expect(SCENARIO_DEFINITIONS['raw-start-auth-adoption']).toEqual({
       backend: 'convex',
       check: false,
-      env: {
-        CONVEX_AGENT_MODE: 'anonymous',
-      },
       label: 'raw start auth adoption',
       setup: [],
       source: {
@@ -845,7 +836,7 @@ describe('tooling/scenarios', () => {
     }
   });
 
-  test('runScenarioDev injects anonymous agent mode for raw create-convex fixtures and bypasses upstream raw dev for bare apps', async () => {
+  test('runScenarioDev bypasses upstream raw dev for bare create-convex apps', async () => {
     const rootDir = `/tmp/kitcn-scenario-create-convex-dev-${Date.now()}-${Math.random()
       .toString(36)
       .slice(2)}`;
@@ -886,12 +877,8 @@ describe('tooling/scenarios', () => {
     expect(calls[0]).toMatchObject({
       cmd: buildLocalCliCommand(['dev'], { backend: 'concave' }),
       cwd: projectDir,
-      options: {
-        env: expect.objectContaining({
-          CONVEX_AGENT_MODE: 'anonymous',
-        }),
-      },
     });
+    expect(calls[0]?.options).toBeUndefined();
   });
 
   test('runScenarioDev bypasses raw create-convex predev and uses dev:frontend plus convex:dev when available', async () => {

--- a/tooling/scenarios.test.ts
+++ b/tooling/scenarios.test.ts
@@ -26,6 +26,7 @@ import {
   resolvePrepareBootstrapSteps,
   resolveScenarioInstallSpecs,
   resolveScenarioKeysForCheck,
+  resolveScenarioProcessEnv,
   resolveScenarioProofPath,
   resolveScenarioStepEnv,
   runScenarioDev,
@@ -456,6 +457,9 @@ describe('tooling/scenarios', () => {
       SCENARIO_DEFINITIONS['convex-next-auth-bootstrap'].env
     ).toBeUndefined();
     expect(
+      SCENARIO_DEFINITIONS['convex-next-auth-bootstrap'].isolateConvexEnv
+    ).toBe(true);
+    expect(
       SCENARIO_DEFINITIONS['convex-next-auth-bootstrap'].validation.beforeCheck
     ).toEqual([['init', '--yes', '--json']]);
     expect(SCENARIO_DEFINITIONS['convex-vite-auth-bootstrap']).toMatchObject({
@@ -475,6 +479,7 @@ describe('tooling/scenarios', () => {
     expect(SCENARIO_DEFINITIONS['convex-next-all']).toMatchObject({
       backend: 'convex',
       check: true,
+      isolateConvexEnv: true,
       label: 'convex next all',
       setup: [
         ['add', 'ratelimit', '--yes', '--no-codegen'],
@@ -490,6 +495,7 @@ describe('tooling/scenarios', () => {
     expect(SCENARIO_DEFINITIONS['create-convex-nextjs-shadcn-auth']).toEqual({
       backend: 'convex',
       check: false,
+      isolateConvexEnv: true,
       label: 'create-convex nextjs-shadcn auth adoption',
       setup: [],
       source: {
@@ -507,6 +513,7 @@ describe('tooling/scenarios', () => {
     expect(SCENARIO_DEFINITIONS['raw-start-auth-adoption']).toEqual({
       backend: 'convex',
       check: false,
+      isolateConvexEnv: true,
       label: 'raw start auth adoption',
       setup: [],
       source: {
@@ -877,8 +884,25 @@ describe('tooling/scenarios', () => {
     expect(calls[0]).toMatchObject({
       cmd: buildLocalCliCommand(['dev'], { backend: 'concave' }),
       cwd: projectDir,
+      options: {
+        env: expect.objectContaining({
+          CONVEX_DEPLOYMENT: undefined,
+          HOME: expect.stringContaining(
+            'tmp/scenario-homes/create-convex-bare'
+          ),
+        }),
+      },
     });
-    expect(calls[0]?.options).toBeUndefined();
+  });
+
+  test('resolveScenarioProcessEnv isolates Convex scenario home for spawned processes', () => {
+    const env = resolveScenarioProcessEnv('create-convex-bare');
+
+    expect(env.CONVEX_DEPLOYMENT).toBeUndefined();
+    expect(env.CONVEX_DEPLOY_KEY).toBeUndefined();
+    expect(env.CONVEX_SELF_HOSTED_URL).toBeUndefined();
+    expect(env.CONVEX_SELF_HOSTED_ADMIN_KEY).toBeUndefined();
+    expect(env.HOME).toContain('tmp/scenario-homes/create-convex-bare');
   });
 
   test('runScenarioDev bypasses raw create-convex predev and uses dev:frontend plus convex:dev when available', async () => {

--- a/tooling/scenarios.ts
+++ b/tooling/scenarios.ts
@@ -292,10 +292,6 @@ const createScenarioRunCommand = (
   if (!scenarioEnv) {
     return baseRunCommand;
   }
-  const scenarioHome =
-    scenarioEnv.CONVEX_AGENT_MODE === 'anonymous'
-      ? path.join(PROJECT_ROOT, 'tmp', 'scenario-homes', scenarioKey)
-      : undefined;
 
   return (
     cmd: string[],
@@ -306,11 +302,6 @@ const createScenarioRunCommand = (
       ...options,
       env: {
         ...CLEARED_CONVEX_ENV,
-        ...(scenarioHome
-          ? {
-              HOME: scenarioHome,
-            }
-          : {}),
         ...scenarioEnv,
         ...options.env,
       },
@@ -326,19 +317,9 @@ const resolveScenarioProcessEnv = (scenarioKey: ScenarioKey) => {
     };
   }
 
-  const scenarioHome =
-    scenarioEnv.CONVEX_AGENT_MODE === 'anonymous'
-      ? path.join(PROJECT_ROOT, 'tmp', 'scenario-homes', scenarioKey)
-      : undefined;
-
   return {
     ...process.env,
     ...CLEARED_CONVEX_ENV,
-    ...(scenarioHome
-      ? {
-          HOME: scenarioHome,
-        }
-      : {}),
     ...scenarioEnv,
   };
 };

--- a/tooling/scenarios.ts
+++ b/tooling/scenarios.ts
@@ -284,12 +284,18 @@ const getScenarioBackend = (
   backend?: TemplateBackend
 ) => SCENARIO_DEFINITIONS[scenarioKey].backend ?? backend ?? 'concave';
 
+const getScenarioHome = (scenarioKey: ScenarioKey) =>
+  SCENARIO_DEFINITIONS[scenarioKey].isolateConvexEnv
+    ? path.join(PROJECT_ROOT, 'tmp', 'scenario-homes', scenarioKey)
+    : undefined;
+
 const createScenarioRunCommand = (
   scenarioKey: ScenarioKey,
   baseRunCommand: typeof run
 ) => {
   const scenarioEnv = SCENARIO_DEFINITIONS[scenarioKey].env;
-  if (!scenarioEnv) {
+  const scenarioHome = getScenarioHome(scenarioKey);
+  if (!scenarioEnv && !scenarioHome) {
     return baseRunCommand;
   }
 
@@ -302,24 +308,28 @@ const createScenarioRunCommand = (
       ...options,
       env: {
         ...CLEARED_CONVEX_ENV,
+        ...(scenarioHome ? { HOME: scenarioHome } : {}),
         ...scenarioEnv,
         ...options.env,
       },
     });
 };
 
-const resolveScenarioProcessEnv = (scenarioKey: ScenarioKey) => {
+export const resolveScenarioProcessEnv = (scenarioKey: ScenarioKey) => {
   const scenarioEnv = SCENARIO_DEFINITIONS[scenarioKey].env;
+  const scenarioHome = getScenarioHome(scenarioKey);
   if (!scenarioEnv) {
     return {
       ...process.env,
       ...CLEARED_CONVEX_ENV,
+      ...(scenarioHome ? { HOME: scenarioHome } : {}),
     };
   }
 
   return {
     ...process.env,
     ...CLEARED_CONVEX_ENV,
+    ...(scenarioHome ? { HOME: scenarioHome } : {}),
     ...scenarioEnv,
   };
 };

--- a/www/content/docs/cli/backend.mdx
+++ b/www/content/docs/cli/backend.mdx
@@ -69,7 +69,8 @@ dev boot cleanly right now?
 
 - runs the runtime path through `dev --once`
 - reuses the current local Convex deployment when one is already configured
-- falls back to local anonymous setup for fresh non-interactive Convex verify
+- lets Convex use its non-interactive anonymous local setup when no local
+  deployment is configured
 
 ## codegen
 
@@ -182,10 +183,9 @@ npx kitcn env set <name> <value>
 npx kitcn env remove <name>
 ```
 
-`kitcn env set` keeps Convex 1.33 behavior for interactive values,
-`--from-file`, and stdin input. `kitcn env pull` gives you the same robust
-export format, so `env pull --out <path>` and `env set --from-file <path>`
-round-trip cleanly.
+`kitcn env set` supports interactive values, `--from-file`, and stdin input.
+`kitcn env pull` gives you the same robust export format, so
+`env pull --out <path>` and `env set --from-file <path>` round-trip cleanly.
 
 Unknown commands on backend `convex` pass straight through to the Convex CLI,
 so `kitcn insights` opens the same insights surface as `convex insights`.


### PR DESCRIPTION
🎫 Issue ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | ➖ N/A | ➖ N/A |
| Verified | ✅ | ➖ N/A |

**✅ Outcome**
- Upgrade Convex pins/scaffold fixtures to `1.35.1`.
- Keep package release impact as patch and peer range at Convex `>=1.35`.
- Warn when an app still pins an older Convex dependency family; no hard error.
- Remove kitcn/scenario forcing of `CONVEX_AGENT_MODE=anonymous`; Convex owns non-interactive anonymous local setup now.
- Add `convex-release-audit` skill for future Convex release scans.
- Add `package-release-audit` skill for generic npm package release scans.
- Capture the reusable Convex 1.35 bootstrap learning in `docs/solutions`.
- Include synced `research-wiki` skill from the current checkout.

**🏗️ Design**
- Chosen seam: dependency pins + CLI bootstrap env handling + soft peer warning at CLI entry + reusable release-audit skills.
- Why not quick patch: only bumping `package.json` would leave stale agent-mode hacks and no signal for old app pins.
- Why not broader change: explicit local deployment commands and component HTTP routes are separate product slices.

**🧪 Verified**
- `bun lint:fix`
- `bun typecheck`
- `bun --cwd packages/kitcn build`
- `bun test packages/kitcn/src/cli/supported-dependencies.test.ts packages/kitcn/src/cli/cli.test.ts`
- `bun test packages/kitcn/src/cli/commands/dev.test.ts packages/kitcn/src/cli/commands/verify.test.ts packages/kitcn/src/cli/commands/init.test.ts packages/kitcn/src/cli/supported-dependencies.test.ts`
- `CI=1 bun test ./packages/kitcn/src/cli/cli.commands.ts`
- `bun test ./tooling/scenarios.test.ts`
- `bun run fixtures:sync`
- `bun run fixtures:check`
- `quick_validate.py .agents/skills/package-release-audit`
- `bun check`
