### PR TITLE
fix: stop custom preset init crash

### DIFF
--- a/.changeset/fix-auth-env-runner.md
+++ b/.changeset/fix-auth-env-runner.md
@@ -5,3 +5,4 @@
 ## Patches
 
 - Fix auth env sync and local auth bootstrap so `kitcn add auth`, `kitcn env push`, and `kitcn dev --bootstrap` use the real Convex CLI entrypoint more reliably across runtimes and platforms.
+- Fix `kitcn init -t <next|start|vite>` custom shadcn preset exits so they stop with a clear rerun instruction instead of crashing while patching scaffold files.

--- a/packages/kitcn/src/cli/backend-core.ts
+++ b/packages/kitcn/src/cli/backend-core.ts
@@ -1337,14 +1337,21 @@ export async function createProjectWithShadcn(params: {
   }
 }
 
+function buildMissingShadcnScaffoldMessage(projectDir: string): string {
+  const targetDir = normalizePath(relative(process.cwd(), projectDir) || '.');
+  return [
+    'Shadcn exited without creating a supported local scaffold.',
+    'This usually means you chose the Custom preset.',
+    `Run the generated shadcn command from ui.shadcn.com in ${targetDir} then re-run \`kitcn init --yes\` to adopt it.`,
+  ].join(' ');
+}
+
 function moveStagedProjectIntoExistingDir(params: {
   stagedProjectDir: string;
   targetDir: string;
 }) {
   if (!fs.existsSync(params.stagedProjectDir)) {
-    throw new Error(
-      `shadcn init did not create the staged project at ${params.stagedProjectDir}.`
-    );
+    throw new Error(buildMissingShadcnScaffoldMessage(params.targetDir));
   }
   if (
     !fs.existsSync(params.targetDir) ||
@@ -3010,6 +3017,16 @@ async function runScaffoldCommandFlow(params: {
     params.projectDir,
     params.template
   );
+  if (
+    params.template &&
+    !resolveProjectScaffoldContext({
+      cwd: scaffoldProjectDir,
+      allowMissing: true,
+      allowUnsupported: true,
+    })
+  ) {
+    throw new Error(buildMissingShadcnScaffoldMessage(scaffoldProjectDir));
+  }
 
   return withWorkingDirectory(scaffoldProjectDir, async () => {
     const config = params.loadCliConfigFn(params.configPath);

--- a/packages/kitcn/src/cli/commands/init.test.ts
+++ b/packages/kitcn/src/cli/commands/init.test.ts
@@ -487,6 +487,77 @@ describe('cli/commands/init', () => {
     }
   });
 
+  test('handleInitCommand stops with custom preset guidance when shadcn exits without a scaffold', async () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-init-command-start-custom-preset-')
+    );
+    const execaStub = mock(
+      async () => ({ exitCode: 0, stdout: '', stderr: '' }) as any
+    );
+    const generateMetaStub = mock(async () => {});
+    const syncEnvStub = mock(async () => {});
+    const loadConfigStub = mock(() => createDefaultConfig());
+    const originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      await expect(
+        handleInitCommand(['init', '-t', 'start', '--yes'], {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          generateMeta: generateMetaStub as any,
+          syncEnv: syncEnvStub as any,
+          loadCliConfig: loadConfigStub as any,
+        })
+      ).rejects.toThrow(
+        'Shadcn exited without creating a supported local scaffold. This usually means you chose the Custom preset. Run the generated shadcn command from ui.shadcn.com in . then re-run `kitcn init --yes` to adopt it.'
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  test('handleInitCommand stops with custom preset guidance when shadcn creates an empty staged project', async () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-init-command-start-custom-empty-')
+    );
+    const execaStub = mock(async (_cmd: string, args: string[]) => {
+      if (args.includes(INIT_SHADCN_PACKAGE_SPEC)) {
+        const cwdFlagIndex = args.indexOf('--cwd');
+        const nameFlagIndex = args.indexOf('--name');
+        const baseDir =
+          cwdFlagIndex >= 0 && args[cwdFlagIndex + 1]
+            ? args[cwdFlagIndex + 1]!
+            : tmpDir;
+        const projectName =
+          nameFlagIndex >= 0 && args[nameFlagIndex + 1]
+            ? args[nameFlagIndex + 1]!
+            : path.basename(tmpDir);
+        fs.mkdirSync(path.join(baseDir, projectName), { recursive: true });
+      }
+      return { exitCode: 0, stdout: '', stderr: '' } as any;
+    });
+    const generateMetaStub = mock(async () => {});
+    const syncEnvStub = mock(async () => {});
+    const loadConfigStub = mock(() => createDefaultConfig());
+    const originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      await expect(
+        handleInitCommand(['init', '-t', 'start', '--yes'], {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          generateMeta: generateMetaStub as any,
+          syncEnv: syncEnvStub as any,
+          loadCliConfig: loadConfigStub as any,
+        })
+      ).rejects.toThrow(
+        'Shadcn exited without creating a supported local scaffold. This usually means you chose the Custom preset. Run the generated shadcn command from ui.shadcn.com in . then re-run `kitcn init --yes` to adopt it.'
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   test('handleInitCommand scaffolds into the current empty directory with -t next', async () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'kitcn-init-command-next-current-dir-')


### PR DESCRIPTION
🐛 Fixes #215
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 | ➖ N/A |
| Verified | 🟢 | ➖ N/A |

**✅ Outcome**
- Stop `kitcn init -t <next|start|vite>` before overlay patching when shadcn exits without a usable local scaffold.
- Replace the misleading staged-dir / `tsconfig.json` crashes with one clear next-step message for the custom preset path.
- Add regression coverage for both failure shapes: no scaffold at all and an empty staged project.

**⚠️ Caveat**
- Custom presets are still a manual handoff: run the generated shadcn command first, then re-run `kitcn init --yes` to adopt the scaffold.

**🏗️ Design**
- Chosen seam: fresh-scaffold boundary in `runScaffoldCommandFlow`, plus the staged-project move error path.
- Why not quick patch: catching the later `tsconfig.json` error is too late and misses the missing-staged-dir branch entirely.
- Why not broader change: fully automating the shadcn custom builder flow would mean owning a browser-driven upstream workflow. Not worth it for this bug.

**🧪 Verified**
- `bun test packages/kitcn/src/cli/commands/init.test.ts`
- `bun run lint:fix`
- `bun run typecheck`
- `bun --cwd packages/kitcn build`
- `bun run fixtures:sync`
- `bun run fixtures:check`
- `bun run scenario:test -- create-convex-react-vite-shadcn`
- manual repro in `/Users/zbeyens/git/tmp/kitcn-215-fixed` now ends with the new guidance message after the Custom preset path
- `bun run check`
