### PR TITLE
fix: forward deploy env for migrate and aggregate

### DIFF
--- a/.changeset/serious-pans-sparkle.md
+++ b/.changeset/serious-pans-sparkle.md
@@ -1,0 +1,8 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `kitcn migrate` and `kitcn aggregate` so Convex prod-target runs keep
+  ambient deployment auth env in CI.

--- a/packages/kitcn/src/cli/backend-core.ts
+++ b/packages/kitcn/src/cli/backend-core.ts
@@ -5594,8 +5594,9 @@ export async function runAggregatePruneFlow(params: {
   execaFn: typeof execa;
   backendAdapter: BackendAdapter;
   targetArgs: string[];
+  env?: Record<string, string | undefined>;
 }): Promise<number> {
-  const { execaFn, backendAdapter, targetArgs } = params;
+  const { execaFn, backendAdapter, targetArgs, env } = params;
   const result = await runBackendFunction(
     execaFn,
     backendAdapter,
@@ -5606,6 +5607,7 @@ export async function runAggregatePruneFlow(params: {
     targetArgs,
     {
       echoOutput: false,
+      env,
     }
   );
 

--- a/packages/kitcn/src/cli/commands/aggregate.test.ts
+++ b/packages/kitcn/src/cli/commands/aggregate.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { createDefaultConfig } from '../test-utils';
+import { handleAggregateCommand } from './aggregate';
+
+describe('cli/commands/aggregate', () => {
+  const withConvexDeployKey = async (
+    deployKey: string,
+    run: () => Promise<void>
+  ) => {
+    const originalDeployKey = process.env.CONVEX_DEPLOY_KEY;
+    process.env.CONVEX_DEPLOY_KEY = deployKey;
+
+    try {
+      await run();
+    } finally {
+      process.env.CONVEX_DEPLOY_KEY = originalDeployKey;
+    }
+  };
+
+  test('handleAggregateCommand(backfill) forwards ambient Convex deployment env for convex backend', async () => {
+    const calls: Record<string, string | undefined>[] = [];
+    const execaStub = mock(
+      async (
+        _cmd: string,
+        _args: string[],
+        options?: { env?: Record<string, string | undefined> }
+      ) => {
+        calls.push(options?.env ?? {});
+        return {
+          exitCode: 0,
+          stdout: `${JSON.stringify({ scheduled: 0, targets: 0 })}\n`,
+          stderr: '',
+        } as any;
+      }
+    );
+    const loadConfigStub = mock(() => {
+      const config = createDefaultConfig();
+      config.deploy.aggregateBackfill.wait = false;
+      return config;
+    });
+
+    await withConvexDeployKey('prod:demo|secret', async () => {
+      const exitCode = await handleAggregateCommand(
+        ['aggregate', 'backfill', '--prod'],
+        {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          loadCliConfig: loadConfigStub as any,
+        }
+      );
+
+      expect(exitCode).toBe(0);
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(
+      expect.objectContaining({
+        CONVEX_DEPLOY_KEY: 'prod:demo|secret',
+      })
+    );
+  });
+
+  test('handleAggregateCommand(prune) forwards ambient Convex deployment env for convex backend', async () => {
+    const calls: Record<string, string | undefined>[] = [];
+    const execaStub = mock(
+      async (
+        _cmd: string,
+        _args: string[],
+        options?: { env?: Record<string, string | undefined> }
+      ) => {
+        calls.push(options?.env ?? {});
+        return {
+          exitCode: 0,
+          stdout: `${JSON.stringify({ pruned: 0 })}\n`,
+          stderr: '',
+        } as any;
+      }
+    );
+    const loadConfigStub = mock(() => createDefaultConfig());
+
+    await withConvexDeployKey('prod:demo|secret', async () => {
+      const exitCode = await handleAggregateCommand(
+        ['aggregate', 'prune', '--prod'],
+        {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          loadCliConfig: loadConfigStub as any,
+        }
+      );
+
+      expect(exitCode).toBe(0);
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(
+      expect.objectContaining({
+        CONVEX_DEPLOY_KEY: 'prod:demo|secret',
+      })
+    );
+  });
+});

--- a/packages/kitcn/src/cli/commands/aggregate.ts
+++ b/packages/kitcn/src/cli/commands/aggregate.ts
@@ -2,6 +2,7 @@ import {
   createBackendAdapter,
   extractBackendRunTargetArgs,
   extractBackfillCliOptions,
+  getConvexDeploymentCommandEnv,
   parseArgs,
   type RunDeps,
   resolveBackfillConfig,
@@ -43,6 +44,8 @@ export const handleAggregateCommand = async (
     realConvexPath,
     realConcavePath,
   });
+  const commandEnv =
+    backend === 'convex' ? getConvexDeploymentCommandEnv() : undefined;
   const {
     remainingArgs: aggregateCommandArgs,
     overrides: aggregateBackfillOverrides,
@@ -62,6 +65,7 @@ export const handleAggregateCommand = async (
       execaFn,
       backendAdapter,
       targetArgs,
+      env: commandEnv,
     });
   }
 
@@ -71,6 +75,7 @@ export const handleAggregateCommand = async (
     backfillConfig,
     mode: subcommand === 'rebuild' ? 'rebuild' : 'resume',
     targetArgs,
+    env: commandEnv,
     context: 'aggregate',
   });
 };

--- a/packages/kitcn/src/cli/commands/migrate.test.ts
+++ b/packages/kitcn/src/cli/commands/migrate.test.ts
@@ -13,6 +13,20 @@ import {
 } from './migrate';
 
 describe('cli/commands/migrate', () => {
+  const withConvexDeployKey = async (
+    deployKey: string,
+    run: () => Promise<void>
+  ) => {
+    const originalDeployKey = process.env.CONVEX_DEPLOY_KEY;
+    process.env.CONVEX_DEPLOY_KEY = deployKey;
+
+    try {
+      await run();
+    } finally {
+      process.env.CONVEX_DEPLOY_KEY = originalDeployKey;
+    }
+  };
+
   test('parseMigrateCommandArgs parses create/list/up/down/status/cancel shapes', () => {
     expect(parseMigrateCommandArgs(['create', 'Add', 'field'])).toEqual({
       subcommand: 'create',
@@ -253,5 +267,129 @@ describe('cli/commands/migrate', () => {
     expect(exitCode).toBe(0);
     expect(calls).toHaveLength(2);
     expect(calls[1]?.args).toContain('generated/server:migrationStatus');
+  });
+
+  test('handleMigrateCommand(up) forwards ambient Convex deployment env for convex backend', async () => {
+    const calls: Array<{
+      args: string[];
+      env: Record<string, string | undefined>;
+    }> = [];
+    const execaStub = mock(
+      async (_cmd: string, args: string[], options?: { env?: unknown }) => {
+        calls.push({
+          args,
+          env: (options?.env ?? {}) as Record<string, string | undefined>,
+        });
+        return {
+          exitCode: 0,
+          stdout: `${JSON.stringify({ status: 'noop' })}\n`,
+          stderr: '',
+        } as any;
+      }
+    );
+    const loadConfigStub = mock(() => {
+      const config = createDefaultConfig();
+      config.deploy.migrations.wait = false;
+      return config;
+    });
+
+    await withConvexDeployKey('prod:demo|secret', async () => {
+      const exitCode = await handleMigrateCommand(
+        ['migrate', 'up', '--prod', '--yes'],
+        {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          loadCliConfig: loadConfigStub as any,
+        }
+      );
+
+      expect(exitCode).toBe(0);
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toContain('--prod');
+    expect(calls[0]?.env).toEqual(
+      expect.objectContaining({
+        CONVEX_DEPLOY_KEY: 'prod:demo|secret',
+      })
+    );
+  });
+
+  test('handleMigrateCommand(status) forwards ambient Convex deployment env for convex backend', async () => {
+    const calls: Record<string, string | undefined>[] = [];
+    const execaStub = mock(
+      async (
+        _cmd: string,
+        _args: string[],
+        options?: { env?: Record<string, string | undefined> }
+      ) => {
+        calls.push(options?.env ?? {});
+        return {
+          exitCode: 0,
+          stdout: '{}\n',
+          stderr: '',
+        } as any;
+      }
+    );
+    const loadConfigStub = mock(() => createDefaultConfig());
+
+    await withConvexDeployKey('prod:demo|secret', async () => {
+      const exitCode = await handleMigrateCommand(
+        ['migrate', 'status', '--prod'],
+        {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          loadCliConfig: loadConfigStub as any,
+        }
+      );
+
+      expect(exitCode).toBe(0);
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(
+      expect.objectContaining({
+        CONVEX_DEPLOY_KEY: 'prod:demo|secret',
+      })
+    );
+  });
+
+  test('handleMigrateCommand(cancel) forwards ambient Convex deployment env for convex backend', async () => {
+    const calls: Record<string, string | undefined>[] = [];
+    const execaStub = mock(
+      async (
+        _cmd: string,
+        _args: string[],
+        options?: { env?: Record<string, string | undefined> }
+      ) => {
+        calls.push(options?.env ?? {});
+        return {
+          exitCode: 0,
+          stdout: '{}\n',
+          stderr: '',
+        } as any;
+      }
+    );
+    const loadConfigStub = mock(() => createDefaultConfig());
+
+    await withConvexDeployKey('prod:demo|secret', async () => {
+      const exitCode = await handleMigrateCommand(
+        ['migrate', 'cancel', '--prod', '--run-id', 'mr_123'],
+        {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          loadCliConfig: loadConfigStub as any,
+        }
+      );
+
+      expect(exitCode).toBe(0);
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(
+      expect.objectContaining({
+        CONVEX_DEPLOY_KEY: 'prod:demo|secret',
+      })
+    );
   });
 });

--- a/packages/kitcn/src/cli/commands/migrate.ts
+++ b/packages/kitcn/src/cli/commands/migrate.ts
@@ -3,6 +3,7 @@ import {
   extractBackendRunTargetArgs,
   extractMigrationCliOptions,
   extractMigrationDownOptions,
+  getConvexDeploymentCommandEnv,
   parseArgs,
   type RunDeps,
   resolveConfiguredBackend,
@@ -110,6 +111,8 @@ export const handleMigrateCommand = async (
     realConvexPath,
     realConcavePath,
   });
+  const commandEnv =
+    backend === 'convex' ? getConvexDeploymentCommandEnv() : undefined;
 
   if (migrateArgs.subcommand === 'create') {
     const rawName = migrateArgs.restArgs.join(' ').trim();
@@ -142,6 +145,7 @@ export const handleMigrateCommand = async (
       backendAdapter,
       migrationConfig,
       targetArgs,
+      env: commandEnv,
       context: 'migration',
       direction: 'up',
     });
@@ -156,6 +160,7 @@ export const handleMigrateCommand = async (
       backendAdapter,
       migrationConfig,
       targetArgs: downTargetArgs,
+      env: commandEnv,
       context: 'migration',
       direction: 'down',
       steps,
@@ -169,7 +174,10 @@ export const handleMigrateCommand = async (
       backendAdapter,
       'generated/server:migrationStatus',
       {},
-      targetArgs
+      targetArgs,
+      {
+        env: commandEnv,
+      }
     );
     return statusResult.exitCode;
   }
@@ -203,7 +211,10 @@ export const handleMigrateCommand = async (
     backendAdapter,
     'generated/server:migrationCancel',
     runId ? { runId } : {},
-    cancelTargetArgs
+    cancelTargetArgs,
+    {
+      env: commandEnv,
+    }
   );
   return cancelResult.exitCode;
 };


### PR DESCRIPTION
🐛 Fixes [#225](https://github.com/udecode/kitcn/issues/225)
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 | ➖ N/A |
| Verified | 🟢 | ➖ N/A |

**✅ Outcome**
- Forward ambient Convex deployment auth env from standalone `migrate` and `aggregate` command handlers for prod-target runs.
- Cover `migrate up/status/cancel` and `aggregate backfill/prune` with regression tests.
- Add a patch changeset for the package release.

**🏗️ Design**
- Chosen seam: thread `getConvexDeploymentCommandEnv()` through standalone command handlers and extend `runAggregatePruneFlow()` to accept forwarded env.
- Why not quick patch: fixing only one branch would leave the same regression in sibling standalone paths.
- Why not broader change: keep `createBackendCommandEnv()` default wipe intact so local dev/codegen behavior stays unchanged.

**🧪 Verified**
- `bun test packages/kitcn/src/cli/commands/migrate.test.ts packages/kitcn/src/cli/commands/aggregate.test.ts`
- `bun run lint:fix`
- `bun run typecheck`
- `bun --cwd packages/kitcn build`
- `bun run check`
