### PR TITLE
fix(auth): suppress internal oidc deprecation warning

### DIFF
--- a/.changeset/calm-lobsters-whisper.md
+++ b/.changeset/calm-lobsters-whisper.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix noisy `oidc-provider` deprecation warnings from the internal Convex auth plugin.

--- a/packages/kitcn/src/auth/internal/convex-plugin.test.ts
+++ b/packages/kitcn/src/auth/internal/convex-plugin.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'bun:test';
+import type { AuthConfig } from 'convex/server';
+import { convex } from './convex-plugin';
+
+test('convex suppresses the internal oidc provider deprecation warning', () => {
+  const originalSiteUrl = process.env.CONVEX_SITE_URL;
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+
+  process.env.CONVEX_SITE_URL = 'https://convex.invalid';
+  console.warn = (...args) => {
+    warnings.push(args.join(' '));
+  };
+
+  try {
+    convex({
+      authConfig: {
+        providers: [
+          {
+            applicationID: 'convex',
+            issuer: 'https://issuer.invalid',
+          },
+        ],
+      } as AuthConfig,
+    });
+  } finally {
+    console.warn = originalWarn;
+    if (originalSiteUrl === undefined) {
+      delete process.env.CONVEX_SITE_URL;
+    } else {
+      process.env.CONVEX_SITE_URL = originalSiteUrl;
+    }
+  }
+
+  expect(
+    warnings.some((warning) =>
+      warning.includes('"oidc-provider" plugin is deprecated')
+    )
+  ).toBe(false);
+});

--- a/packages/kitcn/src/auth/internal/convex-plugin.ts
+++ b/packages/kitcn/src/auth/internal/convex-plugin.ts
@@ -100,6 +100,7 @@ export const convex = (opts: {
       issuer: `${process.env.CONVEX_SITE_URL}`,
       jwks_uri: `${process.env.CONVEX_SITE_URL}${opts.options?.basePath ?? '/api/auth'}/convex/jwks`,
     },
+    __skipDeprecationWarning: true,
   });
   const providerConfig = parseAuthConfig(opts.authConfig, opts);
 


### PR DESCRIPTION
🐛 Fixes #231
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | ➖ N/A | ➖ N/A |
| Verified | ✅ | ➖ N/A |

**✅ Outcome**
- Add `__skipDeprecationWarning: true` to the internal Convex auth OIDC provider.
- Add a regression test covering `convex(...)`.
- Add a patch changeset.
- Same repro that logged the deprecation before now returns `[]`.

**⚠️ Caveat**
- This only removes the warning. The eventual `oidc-provider` -> `oauth-provider` migration is separate.

**🏗️ Design**
- Chosen seam: internal Convex auth plugin OIDC provider construction.
- Why not quick patch: log filtering would hide the symptom, not fix the source.
- Why not broader change: full provider migration is larger auth-runtime work; Better Auth already exposes the intended suppression flag for internal wrappers.

**🧪 Verified**
- Manual repro before fix: `convex(...)` emitted the deprecation warning.
- Manual repro after fix: same command returned `[]`.
- `bun test packages/kitcn/src/auth/internal/convex-plugin.test.ts`
- `bun typecheck`
- `bun --cwd packages/kitcn build`
- `bun check`
