### PR TITLE
fix(auth): dedupe raw Convex auth schema import

### DIFF
--- a/.changeset/fair-auth-schema-import.md
+++ b/.changeset/fair-auth-schema-import.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `kitcn add auth --preset convex` so schema registration reuses existing `authSchema` imports.

--- a/packages/kitcn/src/cli/registry/items/auth/auth-item.test.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-item.test.ts
@@ -549,4 +549,61 @@ ${userUnit.relations},
       owner: 'managed',
     });
   });
+
+  test('convex auth schema registration reuses existing double-quoted authSchema import', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kitcn-auth-item-'));
+    const functionsDir = path.join(dir, 'convex', 'functions');
+    const schemaPath = path.join(functionsDir, 'schema.ts');
+    const schemaSource = `
+      import { authSchema } from "./authSchema";
+      import { defineSchema } from "convex/server";
+
+      export default defineSchema({
+        messages: {},
+      });
+    `.trim();
+
+    fs.mkdirSync(functionsDir, { recursive: true });
+    fs.writeFileSync(schemaPath, schemaSource, 'utf8');
+
+    const descriptor = getPluginCatalogEntry('auth');
+    const plan =
+      await descriptor.integration?.buildSchemaRegistrationPlanFile?.({
+        config: createDefaultConfig(),
+        functionsDir,
+        lockfile: {
+          plugins: {},
+        },
+        overwrite: true,
+        preset: 'convex',
+        preview: false,
+        promptAdapter: {
+          confirm: async () => false,
+          isInteractive: () => false,
+          multiselect: async () => [],
+          select: async () => 'ignored',
+        },
+        roots: {
+          appRootDir: null,
+          clientLibRootDir: null,
+          crpcFilePath: path.join(dir, 'convex', 'lib', 'crpc.ts'),
+          envFilePath: path.join(dir, 'convex', 'lib', 'get-env.ts'),
+          functionsRootDir: functionsDir,
+          libRootDir: path.join(dir, 'convex', 'lib'),
+          projectContext: null,
+          sharedApiFilePath: path.join(dir, 'convex', 'shared', 'api.ts'),
+        },
+        yes: true,
+      });
+
+    expect(
+      plan?.content.match(
+        /import \{ authSchema \} from ['"]\.\/authSchema['"];/g
+      )
+    ).toHaveLength(1);
+    expect(plan?.content).toContain(
+      'import { authSchema } from "./authSchema";'
+    );
+    expect(plan?.content).toContain('...authSchema,');
+  });
 });

--- a/packages/kitcn/src/cli/registry/items/auth/auth-item.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-item.ts
@@ -70,6 +70,8 @@ const AUTH_CONVEX_HTTP_IMPORT_RE = /from\s+['"]kitcn\/auth\/http['"]/;
 const AUTH_CONVEX_HTTP_GET_AUTH_IMPORT_RE =
   /from\s+['"]\.\/generated\/auth['"]/;
 const AUTH_CONVEX_SCHEMA_CALL_RE = /defineSchema\(\s*\{/;
+const AUTH_CONVEX_SCHEMA_AUTH_SCHEMA_IMPORT_RE =
+  /import\s+\{\s*authSchema\s*\}\s+from\s+['"]\.\/authSchema['"];?/;
 const AUTH_CONVEX_APP_IMPORT_RE = /import App from ['"][^'"]+['"];?/;
 const AUTH_CONVEX_PROVIDER_IMPORT_RE =
   /import\s+\{\s*ConvexProvider,\s*ConvexReactClient\s*\}\s+from\s+['"]convex\/react['"];?/;
@@ -624,7 +626,7 @@ function buildAuthConvexSchemaPlanFile(
   const schemaPath = getSchemaFilePath(params.functionsDir);
   let source = fs.readFileSync(schemaPath, 'utf8');
 
-  if (!source.includes("import { authSchema } from './authSchema';")) {
+  if (!AUTH_CONVEX_SCHEMA_AUTH_SCHEMA_IMPORT_RE.test(source)) {
     source = `import { authSchema } from './authSchema';\n${source}`;
   }
   if (!source.includes('...authSchema')) {


### PR DESCRIPTION
🐛 Fixes duplicate `authSchema` import on raw Convex auth add
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 focused registry regression failed | ➖ N/A |
| Verified | 🟢 `bun check` | ➖ N/A |

**✅ Outcome**
- `kitcn add auth --preset convex` reuses existing `authSchema` imports with either quote style.
- Added regression coverage for double-quoted `authSchema` imports.
- Added patch changeset.

**🏗️ Design**
- Chosen seam: raw Convex schema registration builder.
- Why not quick patch: exact string matching caused the duplicate.
- Why not broader change: AST rewrite is overkill for one import guard.

**🧪 Verified**
- `bun check`