### PR TITLE
fix(auth): refresh raw schema and release automation

### DIFF
--- a/.changeset/raw-convex-auth-schema.md
+++ b/.changeset/raw-convex-auth-schema.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix raw Convex auth reruns so added Better Auth plugins refresh the generated schema without `--overwrite`.

--- a/.github/workflows/changeset-auto-release.yml
+++ b/.github/workflows/changeset-auto-release.yml
@@ -1,0 +1,83 @@
+name: Changeset Auto Release Checkbox
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  sync-auto-release-checkbox:
+    name: Sync auto-release checkbox
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'udecode/kitcn' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository)
+      )
+
+    steps:
+      - name: 📥 Checkout workflow helper
+        uses: actions/checkout@v4
+        with:
+          ref: >-
+            ${{
+              github.event_name == 'pull_request'
+                && github.event.pull_request.head.sha
+                || github.event.repository.default_branch
+            }}
+          persist-credentials: false
+
+      - name: 🔁 Sync auto-release checkbox
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url');
+            const helperUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/tooling/auto-release-pr.mjs`
+            ).href;
+            const {
+              getChangesetReleaseType,
+              shouldManageAutoReleaseBlock,
+              upsertAutoReleaseBlock,
+            } = await import(helperUrl);
+
+            const pullRequest = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+
+            const hasChangeset = shouldManageAutoReleaseBlock({
+              files,
+              title: pullRequest.title ?? '',
+            });
+            const releaseType = hasChangeset
+              ? getChangesetReleaseType(files)
+              : null;
+            const currentBody = pullRequest.body ?? '';
+            const nextBody = upsertAutoReleaseBlock(currentBody, {
+              defaultChecked: releaseType === 'patch',
+              hasChangeset,
+            });
+
+            if (nextBody === currentBody) {
+              core.info('PR body already matches auto-release policy.');
+              return;
+            }
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              body: nextBody,
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
   default:
     name: CI
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.title != '[Release] Version packages'
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,85 @@ jobs:
           # @link https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
           fetch-depth: 0
 
+      - name: 🔎 Detect auto-release opt-in
+        id: auto_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { pathToFileURL } = await import('node:url');
+            const helperUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/tooling/auto-release-pr.mjs`
+            ).href;
+            const { hasChangesetFile, isAutoReleaseChecked } = await import(helperUrl);
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumbers = new Set();
+
+            const { data: associatedPullRequests } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: context.sha,
+              });
+
+            for (const pullRequest of associatedPullRequests) {
+              pullNumbers.add(pullRequest.number);
+            }
+
+            const headCommitMessage = context.payload.head_commit?.message ?? '';
+            for (const match of headCommitMessage.matchAll(/\(#(\d+)\)|#(\d+)/g)) {
+              const pullNumber = Number(match[1] ?? match[2]);
+
+              if (pullNumber) pullNumbers.add(pullNumber);
+            }
+
+            for (const pullNumber of pullNumbers) {
+              let pullRequest;
+
+              try {
+                const { data } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pullNumber,
+                });
+
+                pullRequest = data;
+              } catch (error) {
+                core.warning(`Could not read PR #${pullNumber}: ${error.message}`);
+                continue;
+              }
+
+              if (!pullRequest.merged_at) {
+                core.info(`Skipping PR #${pullRequest.number}; it is not merged.`);
+                continue;
+              }
+
+              if (!isAutoReleaseChecked(pullRequest.body ?? '')) {
+                core.info(`Skipping PR #${pullRequest.number}; auto-release is unchecked.`);
+                continue;
+              }
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pullRequest.number,
+                per_page: 100,
+              });
+
+              if (!hasChangesetFile(files)) {
+                core.info(`Skipping PR #${pullRequest.number}; no changeset file found.`);
+                continue;
+              }
+
+              core.setOutput('enabled', 'true');
+              core.setOutput('source_pr', String(pullRequest.number));
+              core.notice(`Auto-release enabled by PR #${pullRequest.number}.`);
+              return;
+            }
+
+            core.setOutput('enabled', 'false');
+
       - uses: oven-sh/setup-bun@v2
         name: Install bun
         with:
@@ -69,5 +148,20 @@ jobs:
           # See https://github.com/changesets/action/issues/147
           HOME: ${{ github.workspace }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: 🤖 Merge Version Packages PR
+        if: ${{ steps.auto_release.outputs.enabled == 'true' && steps.changesets.outputs.pullRequestNumber != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+          RELEASE_PR: ${{ steps.changesets.outputs.pullRequestNumber }}
+          SOURCE_PR: ${{ steps.auto_release.outputs.source_pr }}
+        run: |
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "API_TOKEN_GITHUB is required so the merged release PR can trigger publish workflows."
+            exit 1
+          fi
+
+          gh pr comment "$RELEASE_PR" --body "Merging because PR #${SOURCE_PR} checked auto release."
+          gh pr merge "$RELEASE_PR" --squash --delete-branch --admin

--- a/docs/solutions/integration-issues/auth-schema-reconcile-via-add-command-20260323.md
+++ b/docs/solutions/integration-issues/auth-schema-reconcile-via-add-command-20260323.md
@@ -11,8 +11,10 @@ symptoms:
   - docs tell users to run `@better-auth/cli generate` by hand after changing auth plugins or auth fields
   - managed auth schema files drift from the current auth definition
   - raw Convex and kitcn auth paths use different generated files but need the same refresh behavior
+  - `kitcn add auth --preset convex --yes` reports the generated raw Convex auth schema in "Skipped files" after auth plugins change
 module: auth-cli
 resolved: 2026-03-23
+last_updated: 2026-04-23
 ---
 
 # Auth schema reconciliation belongs to add auth
@@ -40,10 +42,16 @@ So rerunning `kitcn add auth` could patch routes and other files, but
 it could not refresh the managed auth schema file from the current auth
 options.
 
+A later raw Convex failure exposed the apply-layer half of the same ownership
+contract. Reconciliation computed fresh `authSchema.ts` content, but scaffold
+files with a template id require explicit overwrite by default. In
+non-interactive `--yes` mode, the generated schema was skipped unless the user
+deleted the file or passed `--overwrite`.
+
 ## Solution
 
-Teach the registry planner a generic scaffold-file reconciliation seam, then use
-it for auth.
+Teach the registry planner a generic scaffold-file reconciliation hook, then
+use it for auth.
 
 Auth now:
 
@@ -58,18 +66,39 @@ Mode-specific output stays intact:
 - raw Convex adoption refreshes `<functionsDir>/authSchema.ts` with
   `export const authSchema = ...`
 
+Generated auth schema files also carry managed-update policy through the
+scaffold planner:
+
+```ts
+nextFiles[index] = {
+  ...nextFiles[index]!,
+  content,
+  requiresExplicitOverwrite: false,
+};
+```
+
+That lets `kitcn add auth --preset convex --yes` refresh generated schema
+content while preserving user-owned auth runtime, config, and client files.
+
 ## Verification
 
 - `bun test packages/kitcn/src/auth/create-schema-orm.test.ts packages/kitcn/src/auth/create-schema.test.ts packages/kitcn/src/cli/registry/index.test.ts packages/kitcn/src/cli/registry/planner.test.ts packages/kitcn/src/cli/registry/items/auth/reconcile-auth-schema.test.ts`
 - `bun --cwd packages/kitcn build`
 - `bun --cwd packages/kitcn typecheck`
 - `bun lint:fix`
+- `bun test packages/kitcn/src/cli/cli.commands.ts -t "regenerates raw convex auth schema"`
+- `bun run test:cli`
+- `bun test packages/kitcn/src/cli/registry/planner.test.ts packages/kitcn/src/cli/registry/items/auth/reconcile-auth-schema.test.ts`
+- `bun typecheck`
 
 ## Prevention
 
-1. Managed scaffold files need a reconciliation seam, not one-off external CLI
+1. Managed scaffold files need a reconciliation hook, not one-off external CLI
    instructions.
 2. Keep one public verb per capability. Installing and refreshing auth both
    belong to `add auth`.
 3. If docs require users to hand-run a generator for a file the CLI already
    owns, the architecture is lying.
+4. Preserve user-authored scaffold files and auto-refresh generated schema
+   files with separate apply policies. `--yes` should skip user edits, not skip
+   managed schema regeneration.

--- a/docs/solutions/test-failures/scenario-stale-port-cleanup-must-not-kill-unrelated-listeners-20260425.md
+++ b/docs/solutions/test-failures/scenario-stale-port-cleanup-must-not-kill-unrelated-listeners-20260425.md
@@ -1,0 +1,105 @@
+---
+title: Scenario stale-port cleanup must not kill unrelated listeners
+date: 2026-04-25
+category: test-failures
+module: scenarios
+problem_type: test_failure
+component: tooling
+symptoms:
+  - "`bun run scenario:test -- all` dies with SIGKILL after the first scenario"
+  - "A single scenario like `bun run scenario:test -- expo` passes"
+  - "Running `expo` then `expo-auth` in one process dies between scenarios"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - scenarios
+  - runtime
+  - cleanup
+  - lsof
+  - sigkill
+---
+
+# Scenario stale-port cleanup must not kill unrelated listeners
+
+## Problem
+
+The aggregate scenario runtime gate can kill itself between scenarios when
+stale prepared apps point at shared local ports. The bug hides in cleanup, so
+single-scenario proof can pass while `scenario:test -- all` dies.
+
+## Symptoms
+
+- `bun run scenario:test -- all` exits with SIGKILL immediately after the
+  first scenario reaches ready.
+- `bun run scenario:test -- expo` and `bun run scenario:test -- expo-auth`
+  both pass on their own.
+- A two-scenario repro logs `AFTER expo`, then dies before `expo-auth` starts.
+
+## What Didn't Work
+
+- Treating the failure as memory pressure was too vague. The machine had other
+  stale processes, but the first scenario passed reliably on its own.
+- Rerunning the full gate without isolating the transition only repeated the
+  SIGKILL.
+- Looking only at dev server shutdown missed the stale prepared-app cleanup
+  that runs before the next scenario is prepared.
+
+## Solution
+
+Constrain stale-port cleanup to processes that are actually owned by the
+prepared scenario project.
+
+Before this fix, `stopLocalConvexBackendForProject()` read a port from the old
+project's `.env.local`, ran `lsof -ti tcp:<port>`, and sent `kill -9` to every
+listener. That was too broad because scenario ports are shared across prepared
+apps.
+
+The fixed flow checks each candidate listener's cwd and only kills it when the
+process cwd is inside the target scenario project:
+
+```ts
+export const isProcessOwnedByProject = (pid: string, projectDir: string) => {
+  const result = Bun.spawnSync({
+    cmd: ["lsof", "-a", "-p", pid, "-d", "cwd", "-Fn"],
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+
+  const resolvedProjectDir = path.resolve(projectDir);
+  return result.stdout
+    .toString()
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("n"))
+    .some((line) => {
+      const cwd = path.resolve(line.slice(1));
+      return (
+        cwd === resolvedProjectDir ||
+        cwd.startsWith(`${resolvedProjectDir}${path.sep}`)
+      );
+    });
+};
+```
+
+Add a regression with an unrelated child listener on the stale port. Cleanup
+must leave that process alive.
+
+## Why This Works
+
+The cleanup intent is to stop stale processes from the prepared scenario app,
+not to own the whole machine's port table. Filtering by cwd preserves that
+intent while avoiding a broad `kill -9` against any process that happens to use
+the same localhost port.
+
+## Prevention
+
+- Never kill by port alone in scenario tooling.
+- For temp-app cleanup, prove both sides: stale project-owned listeners are
+  eligible, unrelated listeners are not.
+- When `scenario:test -- all` fails but individual scenarios pass, debug the
+  transition between scenarios before blaming the scenario itself.
+
+## Related Issues
+
+- [Scenario dev needed a Vite frontend split and React 18-safe client build](../integration-issues/scenario-vite-dev-split-and-react18-runtime-20260322.md)

--- a/fixtures/next-auth/package.json
+++ b/fixtures/next-auth/package.json
@@ -9,7 +9,7 @@
     "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.11.0",
     "next": "16.1.7",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",

--- a/fixtures/next/package.json
+++ b/fixtures/next/package.json
@@ -8,7 +8,7 @@
     "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.11.0",
     "next": "16.1.7",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",

--- a/fixtures/start-auth/package.json
+++ b/fixtures/start-auth/package.json
@@ -17,7 +17,7 @@
     "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.11.0",
     "nitro": "latest",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/fixtures/start/package.json
+++ b/fixtures/start/package.json
@@ -16,7 +16,7 @@
     "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.11.0",
     "nitro": "latest",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/fixtures/vite-auth/package.json
+++ b/fixtures/vite-auth/package.json
@@ -11,7 +11,7 @@
     "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.11.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "shadcn": "latest",

--- a/fixtures/vite/package.json
+++ b/fixtures/vite/package.json
@@ -10,7 +10,7 @@
     "convex": "1.35.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.11.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "shadcn": "latest",

--- a/packages/kitcn/src/cli/cli.commands.ts
+++ b/packages/kitcn/src/cli/cli.commands.ts
@@ -2922,6 +2922,106 @@ describe('cli/cli', () => {
     }
   });
 
+  test('run(add auth --preset convex --yes) regenerates raw convex auth schema on rerun', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-cli-add-auth-convex-schema-rerun-')
+    );
+    const oldCwd = process.cwd();
+    writeRawConvexNextApp(dir);
+    fs.writeFileSync(
+      path.join(dir, '.env.local'),
+      'CONVEX_DEPLOYMENT=local:demo\nNEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210\n'
+    );
+    process.chdir(dir);
+
+    try {
+      const execaStub = mock(async (_cmd: string, args: string[]) => {
+        if (args[0] === '/fake/convex/main.js' && args[1] === 'codegen') {
+          return { exitCode: 0, stdout: '', stderr: '' } as any;
+        }
+
+        return { exitCode: 0 } as any;
+      });
+      const generateMetaStub = mock(async () => {});
+      const syncEnvStub = mock(async () => {});
+      const loadConfigStub = mock(() => createDefaultConfig());
+
+      await run(['add', 'auth', '--preset', 'convex', '--yes'], {
+        realConvex: '/fake/convex/main.js',
+        execa: execaStub as any,
+        generateMeta: generateMetaStub as any,
+        syncEnv: syncEnvStub as any,
+        loadCliConfig: loadConfigStub as any,
+      });
+
+      const authPath = path.join(dir, 'convex', 'auth.ts');
+      const authSource = fs
+        .readFileSync(authPath, 'utf8')
+        .replace(
+          "import { convex } from 'kitcn/auth';",
+          "import { convex } from 'kitcn/auth';\nimport { admin } from 'better-auth/plugins';"
+        )
+        .replace(
+          `  plugins: [
+    convex({
+      authConfig,
+      jwks: process.env.JWKS,
+    }),
+  ],`,
+          `  plugins: [
+    convex({
+      authConfig,
+      jwks: process.env.JWKS,
+    }),
+    admin(),
+  ],`
+        );
+      fs.writeFileSync(authPath, authSource, 'utf8');
+
+      const nodeModulesDir = path.join(dir, 'node_modules');
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync(
+        path.join(oldCwd, 'packages', 'kitcn'),
+        path.join(nodeModulesDir, 'kitcn')
+      );
+      fs.symlinkSync(
+        path.join(oldCwd, 'node_modules', 'better-auth'),
+        path.join(nodeModulesDir, 'better-auth')
+      );
+      fs.symlinkSync(
+        path.join(oldCwd, 'node_modules', 'zod'),
+        path.join(nodeModulesDir, 'zod')
+      );
+
+      const exitCode = await run(
+        ['add', 'auth', '--preset', 'convex', '--yes', '--no-codegen'],
+        {
+          realConvex: '/fake/convex/main.js',
+          execa: execaStub as any,
+          generateMeta: generateMetaStub as any,
+          syncEnv: syncEnvStub as any,
+          loadCliConfig: loadConfigStub as any,
+        }
+      );
+
+      expect(exitCode).toBe(0);
+
+      const authSchemaSource = fs.readFileSync(
+        path.join(dir, 'convex', 'authSchema.ts'),
+        'utf8'
+      );
+      expect(authSchemaSource).toContain(
+        'role: v.optional(v.union(v.null(), v.string()))'
+      );
+      expect(authSchemaSource).toContain(
+        'banned: v.optional(v.union(v.null(), v.boolean()))'
+      );
+      expect(fs.readFileSync(authPath, 'utf8')).toBe(authSource);
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
   test('run(add ratelimit/auth/resend --yes --no-codegen) keeps auth in root schema and other plugins in one ordered extend call', async () => {
     const dir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'kitcn-cli-add-plugin-stack-')

--- a/packages/kitcn/src/cli/registry/items/auth/reconcile-auth-schema.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/reconcile-auth-schema.ts
@@ -22,6 +22,7 @@ type AuthScaffoldFile = {
   content: string;
   filePath: string;
   lockfilePath: string;
+  requiresExplicitOverwrite?: boolean;
   templateId: string;
 };
 
@@ -459,6 +460,7 @@ export const reconcileAuthScaffoldFiles = async ({
       nextFiles[index] = {
         ...nextFiles[index]!,
         content,
+        requiresExplicitOverwrite: false,
       };
     }
   }

--- a/packages/kitcn/src/cli/registry/planner.ts
+++ b/packages/kitcn/src/cli/registry/planner.ts
@@ -896,6 +896,7 @@ export const buildPluginInstallPlan = async (params: {
         templateId: file.templateId,
         filePath: file.filePath,
         content: file.content,
+        requiresExplicitOverwrite: file.requiresExplicitOverwrite,
         createReason: 'Create scaffold file.',
         updateReason: 'Update scaffold file.',
         skipReason: 'Scaffold file is already up to date.',

--- a/packages/kitcn/src/cli/registry/types.ts
+++ b/packages/kitcn/src/cli/registry/types.ts
@@ -84,6 +84,7 @@ export type PluginResolvedScaffoldFile = {
   filePath: string;
   lockfilePath: string;
   content: string;
+  requiresExplicitOverwrite?: boolean;
 };
 
 export type PluginRegistryIntegration = {

--- a/tooling/auto-release-pr.mjs
+++ b/tooling/auto-release-pr.mjs
@@ -1,0 +1,17 @@
+const checkedAutoReleasePattern = /-\s*\[[xX]\]\s*Auto release/;
+
+export function hasChangesetFile(files) {
+  return files.some((file) => {
+    const filename = typeof file === 'string' ? file : file.filename;
+
+    return (
+      filename?.startsWith('.changeset/') &&
+      filename.endsWith('.md') &&
+      filename !== '.changeset/README.md'
+    );
+  });
+}
+
+export function isAutoReleaseChecked(body = '') {
+  return checkedAutoReleasePattern.test(body);
+}

--- a/tooling/auto-release-pr.mjs
+++ b/tooling/auto-release-pr.mjs
@@ -1,4 +1,15 @@
+export const AUTO_RELEASE_START = '<!-- auto-release:start -->';
+export const AUTO_RELEASE_END = '<!-- auto-release:end -->';
+
+const checkboxText = 'Auto release';
+const blockPattern = new RegExp(
+  `${escapeRegExp(AUTO_RELEASE_START)}[\\s\\S]*?${escapeRegExp(AUTO_RELEASE_END)}\\n*`,
+  'm'
+);
 const checkedAutoReleasePattern = /-\s*\[[xX]\]\s*Auto release/;
+const changesetFrontmatterPattern = /^---\r?\n([\s\S]*?)\r?\n---/;
+const changesetReleaseTypePattern = /:\s*(major|minor|patch)\b/g;
+const versionPackagesTitlePattern = /\bVersion Packages\b/i;
 
 export function hasChangesetFile(files) {
   return files.some((file) => {
@@ -12,6 +23,92 @@ export function hasChangesetFile(files) {
   });
 }
 
+export function getChangesetReleaseType(files) {
+  const releaseTypes = files
+    .filter(isChangesetFile)
+    .flatMap((file) => parseChangesetReleaseTypes(getChangesetContent(file)));
+
+  if (releaseTypes.includes('major')) return 'major';
+  if (releaseTypes.includes('minor')) return 'minor';
+  if (releaseTypes.includes('patch')) return 'patch';
+
+  return null;
+}
+
 export function isAutoReleaseChecked(body = '') {
-  return checkedAutoReleasePattern.test(body);
+  const block = getAutoReleaseBlock(body);
+
+  return checkedAutoReleasePattern.test(block);
+}
+
+export function isVersionPackagesTitle(title = '') {
+  return versionPackagesTitlePattern.test(title);
+}
+
+export function shouldManageAutoReleaseBlock({ files, title }) {
+  return !isVersionPackagesTitle(title) && hasChangesetFile(files);
+}
+
+export function upsertAutoReleaseBlock(
+  body,
+  { defaultChecked = false, hasChangeset }
+) {
+  const bodyWithoutBlock = body.replace(blockPattern, '').trimEnd();
+
+  if (!hasChangeset) {
+    return bodyWithoutBlock;
+  }
+
+  const checked = getAutoReleaseBlock(body)
+    ? isAutoReleaseChecked(body)
+    : defaultChecked;
+  const checkbox = `- [${checked ? 'x' : ' '}] ${checkboxText}`;
+  const block = `${AUTO_RELEASE_START}
+${checkbox}
+${AUTO_RELEASE_END}`;
+
+  return `${block}${bodyWithoutBlock ? `\n\n${bodyWithoutBlock}` : ''}\n`;
+}
+
+function getAutoReleaseBlock(body) {
+  return body.match(blockPattern)?.[0] ?? '';
+}
+
+function getChangesetContent(file) {
+  if (typeof file === 'string') return '';
+  if (typeof file.contents === 'string') return file.contents;
+  if (typeof file.content === 'string') return file.content;
+  if (typeof file.patch === 'string') return getAddedPatchContent(file.patch);
+
+  return '';
+}
+
+function getAddedPatchContent(patch) {
+  return patch
+    .split('\n')
+    .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+    .map((line) => line.slice(1))
+    .join('\n');
+}
+
+function isChangesetFile(file) {
+  const filename = typeof file === 'string' ? file : file.filename;
+
+  return (
+    filename?.startsWith('.changeset/') &&
+    filename.endsWith('.md') &&
+    filename !== '.changeset/README.md'
+  );
+}
+
+function parseChangesetReleaseTypes(content) {
+  const frontmatter = content.match(changesetFrontmatterPattern)?.[1];
+
+  return [...(frontmatter ?? '').matchAll(changesetReleaseTypePattern)].map(
+    (match) => match[1]
+  );
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/tooling/scenarios.test.ts
+++ b/tooling/scenarios.test.ts
@@ -31,6 +31,7 @@ import {
   resolveScenarioStepEnv,
   runScenarioDev,
   runScenarioTest,
+  stopLocalConvexBackendForProject,
 } from './scenarios';
 
 describe('tooling/scenarios', () => {
@@ -573,6 +574,84 @@ describe('tooling/scenarios', () => {
           resolve();
         });
       });
+    }
+  });
+
+  test('stopLocalConvexBackendForProject leaves unrelated listeners on the same port alone', async () => {
+    const server = createServer();
+    const reservedPort = await new Promise<number>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, () => {
+        resolve((server.address() as { port: number }).port);
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+
+    const rootDir = `/tmp/kitcn-scenario-stop-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`;
+    const projectDir = `${rootDir}/project`;
+    const unrelatedDir = `${rootDir}/unrelated`;
+
+    await Bun.write(
+      `${projectDir}/.env.local`,
+      `NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:${reservedPort}\n`
+    );
+    await Bun.write(`${unrelatedDir}/.keep`, '');
+
+    const child = Bun.spawn({
+      cmd: [
+        'bun',
+        '-e',
+        `Bun.serve({ port: ${reservedPort}, fetch() { return new Response("ok"); } }); setInterval(() => {}, 1000);`,
+      ],
+      cwd: unrelatedDir,
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+
+    try {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        try {
+          await findAvailableScenarioDevPort({
+            maxAttempts: 1,
+            preferredPort: reservedPort,
+          });
+        } catch {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+
+      await expect(
+        findAvailableScenarioDevPort({
+          maxAttempts: 1,
+          preferredPort: reservedPort,
+        })
+      ).rejects.toThrow('Could not find an open local scenario dev port');
+
+      stopLocalConvexBackendForProject(projectDir);
+
+      const exited = await Promise.race([
+        child.exited.then(() => true),
+        new Promise<boolean>((resolve) =>
+          setTimeout(() => resolve(false), 250)
+        ),
+      ]);
+      expect(exited).toBe(false);
+    } finally {
+      child.kill('SIGKILL');
+      await child.exited.catch(() => {});
+      await Bun.$`rm -rf ${rootDir}`.quiet();
     }
   });
 

--- a/tooling/scenarios.ts
+++ b/tooling/scenarios.ts
@@ -73,6 +73,7 @@ const SCENARIO_FIXTURE_ROOT = path.join(
   'scenario-fixtures'
 );
 const LOCALHOST_PORT_RE = /https?:\/\/(?:127\.0\.0\.1|localhost):(\d+)/;
+const LINE_SPLIT_RE = /\r?\n/;
 const PID_SPLIT_RE = /\s+/;
 const CLEARED_CONVEX_ENV = {
   CONVEX_DEPLOYMENT: undefined,
@@ -187,7 +188,32 @@ const extractLocalConvexPort = (projectDir: string) => {
   return match?.[1];
 };
 
-const stopLocalConvexBackendForProject = (projectDir: string) => {
+export const isProcessOwnedByProject = (pid: string, projectDir: string) => {
+  const result = Bun.spawnSync({
+    cmd: ['lsof', '-a', '-p', pid, '-d', 'cwd', '-Fn'],
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'ignore',
+  });
+  if (result.exitCode !== 0) {
+    return false;
+  }
+
+  const resolvedProjectDir = path.resolve(projectDir);
+  return result.stdout
+    .toString()
+    .split(LINE_SPLIT_RE)
+    .filter((line) => line.startsWith('n'))
+    .some((line) => {
+      const cwd = path.resolve(line.slice(1));
+      return (
+        cwd === resolvedProjectDir ||
+        cwd.startsWith(`${resolvedProjectDir}${path.sep}`)
+      );
+    });
+};
+
+export const stopLocalConvexBackendForProject = (projectDir: string) => {
   const port = extractLocalConvexPort(projectDir);
   if (!port) {
     return;
@@ -207,7 +233,7 @@ const stopLocalConvexBackendForProject = (projectDir: string) => {
     .toString()
     .split(PID_SPLIT_RE)
     .map((pid) => pid.trim())
-    .filter(Boolean);
+    .filter((pid) => pid && isProcessOwnedByProject(pid, projectDir));
   if (pids.length === 0) {
     return;
   }


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Summary
- refresh generated raw Convex auth schema files during non-overwrite auth reruns
- add CLI regression for `kitcn add auth --preset convex --yes` after plugin changes
- tighten scenario cleanup so stale-port cleanup cannot kill unrelated listeners
- sync release automation to directly merge generated Version Packages PRs when `Auto release` is checked
- skip CI for generated `[Release] Version packages` PRs

## Verification
- `bun check`
