### PR TITLE
Fix auth mutation client typing

### DIFF
--- a/.changeset/fix-auth-mutations-convex-client.md
+++ b/.changeset/fix-auth-mutations-convex-client.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `createAuthMutations` support for Better Auth clients that use the Convex client plugin.

--- a/docs/solutions/integration-issues/better-auth-1-6-support-needs-structural-convex-auth-wrappers-20260416.md
+++ b/docs/solutions/integration-issues/better-auth-1-6-support-needs-structural-convex-auth-wrappers-20260416.md
@@ -1,7 +1,7 @@
 ---
 title: Better Auth 1.6 support needs structural Convex auth wrappers
 date: 2026-04-16
-last_updated: 2026-04-16
+last_updated: 2026-04-26
 category: integration-issues
 module: auth-client
 problem_type: integration_issue
@@ -10,6 +10,9 @@ symptoms:
   - upgrading `better-auth` from `1.5.3` to `1.6.5` breaks typecheck in kitcn auth clients and generated auth apps
   - `createAuthMutations(authClient)` reports missing `signIn`, `signOut`, or `signUp` even though those methods exist at runtime
   - generated auth pages see `authClient.useSession().data` collapse to `never`
+  - Better Auth `1.6.x` clients using `convexClient()` fail
+    `createAuthMutations(authClient)` because `getSession` has a narrower
+    constrained generic signature than kitcn's helper accepted
 root_cause: wrong_api
 resolution_type: code_fix
 severity: high
@@ -64,6 +67,10 @@ Key changes:
   mutation helper boundaries instead of pushing that debt into app code
 - vendor the small Convex Better Auth runtime surfaces kitcn uses so package
   code no longer imports or depends on `@convex-dev/better-auth`
+- type mutation-helper methods as callable auth capabilities, not as
+  `(...args: unknown[]) => Promise<unknown>`. Better Auth methods can have
+  narrower params, optional options, generics, and sync-or-async return shapes.
+  Keep that variance at the package boundary and call through one local helper.
 
 ## Why This Works
 
@@ -78,6 +85,12 @@ By making kitcn depend on structural contracts at the boundaries, we stop
 TypeScript from forcing those three packages to agree on every internal generic
 detail before the app can compile.
 
+For `createAuthMutations`, the important TypeScript detail is parameter
+variance. A method that accepts a specific Better Auth options object is not
+assignable to `(...args: unknown[]) => Promise<unknown>` under strict function
+types. Model the stored auth methods as `(...args: never[]) => unknown`, then
+cast only at the call boundary where kitcn owns the exact invocation.
+
 ## Prevention
 
 1. When a dependency wrapper sits between two fast-moving auth libraries,
@@ -89,8 +102,13 @@ detail before the app can compile.
    auth client type widening. The generated apps are the real proof.
 4. Never put dependency-compatibility casts in scaffolded app code. Wrap the
    unstable dependency boundary in the package API.
+5. Add a type-level regression test when the bug is assignability-only. A small
+   `ts.createProgram()` fixture that compiles `createAuthClient({ plugins:
+   [convexClient()] })` plus `createAuthMutations(authClient)` catches the exact
+   failure without depending on runtime auth setup.
 
 ## Related Issues
 
 - `docs/solutions/integration-issues/better-auth-1-5-generated-auth-runtime-typing.md`
 - `docs/solutions/integration-issues/convex-better-auth-upstream-sync-runtime-fixes-20260416.md`
+- GitHub issue `udecode/kitcn#243`

--- a/packages/kitcn/src/cli/watcher.test.ts
+++ b/packages/kitcn/src/cli/watcher.test.ts
@@ -543,6 +543,14 @@ describe('cli/watcher', () => {
     });
 
     try {
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          watcher.on('ready', () => resolve());
+        }),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('watcher was not ready')), 2000)
+        ),
+      ]);
       await new Promise((resolve) => setTimeout(resolve, 100));
       await writeFile(sourceFile, 'export const value = 2;\n');
 

--- a/packages/kitcn/src/react/auth-mutations.ts
+++ b/packages/kitcn/src/react/auth-mutations.ts
@@ -92,7 +92,10 @@ const seedReturnedToken = (store: AuthStore, value: unknown) => {
   }
 };
 
-type AnyFn = (...args: unknown[]) => Promise<unknown>;
+type AnyAuthFn = (...args: never[]) => unknown;
+type AuthCall<TArgs extends unknown[]> = (
+  ...args: TArgs
+) => Promise<unknown> | unknown;
 type AuthResponse = {
   data?: unknown;
   error?: {
@@ -110,6 +113,13 @@ const toAuthMutationError = (error: AuthResponse['error']) =>
     status: error?.status ?? 500,
     statusText: error?.statusText ?? 'AUTH_ERROR',
   });
+const callAuthMethod = async <TArgs extends unknown[]>(
+  method: AnyAuthFn,
+  ...args: TArgs
+) => {
+  const callable = method as AuthCall<TArgs>;
+  return callable(...args);
+};
 type MutationArgsWithFetchOptions = {
   fetchOptions?: Record<string, unknown>;
 };
@@ -139,15 +149,15 @@ type AuthClient = {
       };
     };
   };
-  getSession?: AnyFn;
-  signOut?: AnyFn;
+  getSession?: AnyAuthFn;
+  signOut?: AnyAuthFn;
   signIn?: {
-    anonymous?: AnyFn;
-    social?: AnyFn;
-    email?: AnyFn;
+    anonymous?: AnyAuthFn;
+    social?: AnyAuthFn;
+    email?: AnyAuthFn;
   };
   signUp?: {
-    email?: AnyFn;
+    email?: AnyAuthFn;
   };
 };
 
@@ -179,7 +189,7 @@ const hydrateReturnedSession = async (
     return;
   }
 
-  const session = (await authClient.getSession({
+  const session = (await callAuthMethod(authClient.getSession, {
     fetchOptions: {
       credentials: 'omit',
       headers: {
@@ -255,14 +265,15 @@ export function createAuthMutations(
     return {
       ...options,
       mutationFn: async (args?: unknown) => {
-        if (typeof authClient.signOut !== 'function') {
+        const signOut = authClient.signOut;
+        if (typeof signOut !== 'function') {
           throw new Error('Auth client does not expose signOut');
         }
         // Set isAuthenticated: false BEFORE unsubscribing to prevent re-subscriptions
         // (cache events check shouldSkipSubscription which reads isAuthenticated)
         authStoreApi.set('isAuthenticated', false);
         convexQueryClient?.unsubscribeAuthQueries();
-        const res = (await authClient.signOut(args)) as AuthResponse;
+        const res = (await callAuthMethod(signOut, args)) as AuthResponse;
         if (res?.error) {
           throw toAuthMutationError(res.error);
         }
@@ -283,10 +294,12 @@ export function createAuthMutations(
     return {
       ...options,
       mutationFn: async (args: unknown) => {
-        if (typeof authClient.signIn?.social !== 'function') {
+        const signInSocial = authClient.signIn?.social;
+        if (typeof signInSocial !== 'function') {
           throw new Error('Auth client does not expose signIn.social');
         }
-        const res = (await authClient.signIn.social(
+        const res = (await callAuthMethod(
+          signInSocial,
           withDisabledSessionSignal(args)
         )) as AuthResponse;
         if (res?.error) {
@@ -309,10 +322,12 @@ export function createAuthMutations(
     return {
       ...options,
       mutationFn: async (args: unknown) => {
-        if (typeof authClient.signIn?.email !== 'function') {
+        const signInEmail = authClient.signIn?.email;
+        if (typeof signInEmail !== 'function') {
           throw new Error('Auth client does not expose signIn.email');
         }
-        const res = (await authClient.signIn.email(
+        const res = (await callAuthMethod(
+          signInEmail,
           withDisabledSessionSignal(args)
         )) as AuthResponse;
         if (res?.error) {
@@ -335,10 +350,12 @@ export function createAuthMutations(
     return {
       ...options,
       mutationFn: async (args: unknown) => {
-        if (typeof authClient.signUp?.email !== 'function') {
+        const signUpEmail = authClient.signUp?.email;
+        if (typeof signUpEmail !== 'function') {
           throw new Error('Auth client does not expose signUp.email');
         }
-        const res = (await authClient.signUp.email(
+        const res = (await callAuthMethod(
+          signUpEmail,
           withDisabledSessionSignal(args)
         )) as AuthResponse;
         if (res?.error) {

--- a/packages/kitcn/src/react/auth-mutations.types.test.ts
+++ b/packages/kitcn/src/react/auth-mutations.types.test.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const formatDiagnostics = (diagnostics: readonly ts.Diagnostic[]) =>
+  ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => '\n',
+  });
+
+describe('createAuthMutations types', () => {
+  test('accepts a better-auth client with the kitcn convexClient plugin', () => {
+    const rootDir = process.cwd();
+    const tmpRoot = path.join(rootDir, 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const fixtureDir = fs.mkdtempSync(
+      path.join(tmpRoot, 'kitcn-auth-mutations-types-')
+    );
+    const fixtureFile = path.join(fixtureDir, 'repro.ts');
+
+    try {
+      fs.writeFileSync(
+        fixtureFile,
+        `import { createAuthClient } from "better-auth/react";
+import { convexClient } from "../../packages/kitcn/src/auth-client/index";
+import { createAuthMutations } from "../../packages/kitcn/src/react/auth-mutations";
+
+const authClient = createAuthClient({
+  baseURL: "http://localhost:3000",
+  plugins: [convexClient()],
+});
+
+createAuthMutations(authClient);
+`
+      );
+
+      const program = ts.createProgram([fixtureFile], {
+        allowImportingTsExtensions: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        noEmit: true,
+        skipLibCheck: true,
+        strict: true,
+        strictFunctionTypes: true,
+        target: ts.ScriptTarget.ES2022,
+        types: ['bun-types'],
+      });
+      const diagnostics = ts.getPreEmitDiagnostics(program);
+
+      expect(formatDiagnostics(diagnostics)).toBe('');
+    } finally {
+      fs.rmSync(fixtureDir, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes [#243](https://github.com/udecode/kitcn/issues/243)
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 Type regression failed with `getSession` assignability error | ➖ N/A |
| Verified | 🟢 Regression passed; `bun check` green | ➖ N/A |

**✅ Outcome**
- `createAuthMutations(authClient)` accepts Better Auth clients using `convexClient()`.
- No user casts.
- Patch changeset added.
- Existing Better Auth 1.6 solution note refreshed.
- Watcher test made deterministic after full gate exposed flake.

**⚠️ Caveat**
- No browser surface. TypeScript/package behavior only.

**🏗️ Design**
- Chosen seam: `createAuthMutations` structural auth method boundary.
- Why not quick patch: casting user auth clients exports package compat debt into app code.
- Why not broader change: `convexClient()` runtime shape was right; replacing the auth client surface was unnecessary.

**🧪 Verified**
- `bun lint:fix`
- `bun typecheck`
- `bun --cwd packages/kitcn build`
- `bun test packages/kitcn/src/react/auth-mutations.types.test.ts packages/kitcn/src/react/auth-mutations.test.tsx`
- `bun test packages/kitcn/src/cli/watcher.test.ts -t "startWatcher reacts to a real file change with chokidar v5"`
- `bun check`
