### PR TITLE
convex 1.36

### DIFF
--- a/.changeset/convex-136-env-default.md
+++ b/.changeset/convex-136-env-default.md
@@ -18,3 +18,7 @@ bun add convex@1.36.1
 ## Features
 
 - Add `kitcn env default` passthrough for Convex default environment variables.
+
+## Patches
+
+- Document Convex inline query, branch deployment, deploy message, and preview deployment passthroughs.

--- a/.changeset/convex-136-env-default.md
+++ b/.changeset/convex-136-env-default.md
@@ -21,4 +21,5 @@ bun add convex@1.36.1
 
 ## Patches
 
+- Align Better Auth scaffolds and auth runtime helpers with Better Auth 1.6.9.
 - Document Convex inline query, branch deployment, deploy message, and preview deployment passthroughs.

--- a/.changeset/convex-136-env-default.md
+++ b/.changeset/convex-136-env-default.md
@@ -1,0 +1,20 @@
+---
+"kitcn": minor
+"@kitcn/resend": minor
+---
+
+## Breaking changes
+
+- Require Convex 1.36 or newer.
+
+```bash
+# Before
+bun add convex@1.35.1
+
+# After
+bun add convex@1.36.1
+```
+
+## Features
+
+- Add `kitcn env default` passthrough for Convex default environment variables.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@tanstack/query-core": "5.90.20",
         "@tanstack/react-query": "5.95.2",
         "@tanstack/solid-query": "5.90.23",
-        "convex": "1.35.1",
+        "convex": "1.36.1",
         "hono": "4.12.9",
         "next": "16.1.6",
         "react": "19.2.4",
@@ -76,7 +76,7 @@
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
         "common-tags": "1.8.2",
-        "convex": "1.35.1",
+        "convex": "1.36.1",
         "date-fns": "4.1.0",
         "embla-carousel-react": "8.6.0",
         "hono": "4.12.9",
@@ -119,7 +119,7 @@
     },
     "packages/kitcn": {
       "name": "kitcn",
-      "version": "0.13.6",
+      "version": "0.13.10",
       "bin": {
         "kitcn": "./dist/cli.mjs",
         "intent": "./bin/intent.js",
@@ -158,7 +158,7 @@
         "@tanstack/react-query": ">=5",
         "@tanstack/solid-query": ">=5",
         "better-auth": "1.6.5",
-        "convex": ">=1.35",
+        "convex": ">=1.36",
         "hono": "4.12.9",
         "next": ">=14",
         "react": ">=18",
@@ -177,7 +177,7 @@
     },
     "packages/resend": {
       "name": "@kitcn/resend",
-      "version": "0.13.6",
+      "version": "0.13.10",
       "dependencies": {
         "svix": "^1.84.1",
       },
@@ -186,7 +186,7 @@
         "tsdown": "^0.20.3",
       },
       "peerDependencies": {
-        "convex": ">=1.35",
+        "convex": ">=1.36",
         "kitcn": ">=0.11.0 <1",
       },
     },
@@ -982,7 +982,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -1232,7 +1232,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.35.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ=="],
+    "convex": ["convex@1.36.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-NVnwNqU+h8jyPuS0Itvj4MPH9c2yF+tA/RNoSDpCqiLhmYD4+kZxm0dDkVM0QDzz66wem9NqheBb9YQGsHwzBQ=="],
 
     "convex-test": ["convex-test@0.0.41", "", { "peerDependencies": { "convex": "^1.16.4" } }, "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ=="],
 
@@ -2426,7 +2426,7 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@typescript-eslint/parser": "8.56.1",
         "@typescript/native-preview": "^7.0.0-dev.20260225.1",
         "@vitest/coverage-v8": "^4.0.18",
-        "better-auth": "1.6.5",
+        "better-auth": "1.6.9",
         "bun-types": "^1.3.9",
         "concurrently": "^9.2.1",
         "convex-test": "^0.0.41",
@@ -62,7 +62,7 @@
       "name": "example",
       "version": "0.1.0",
       "dependencies": {
-        "@better-auth/stripe": "1.6.5",
+        "@better-auth/stripe": "1.6.9",
         "@convex-dev/react-query": "0.1.0",
         "@hookform/resolvers": "5.2.2",
         "@kitcn/resend": "workspace:*",
@@ -71,7 +71,7 @@
         "@react-email/render": "2.0.4",
         "@t3-oss/env-nextjs": "0.13.10",
         "@tanstack/react-query": "5.95.2",
-        "better-auth": "1.6.5",
+        "better-auth": "1.6.9",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
@@ -157,7 +157,7 @@
         "@tanstack/query-core": ">=5",
         "@tanstack/react-query": ">=5",
         "@tanstack/solid-query": ">=5",
-        "better-auth": "1.6.5",
+        "better-auth": "1.6.9",
         "convex": ">=1.36",
         "hono": "4.12.9",
         "next": ">=14",
@@ -278,21 +278,21 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@better-auth/core": ["@better-auth/core@1.6.5", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-T3u4rVsJcMWShG2qfQUlU1HdkQGLYX0+lcR48QV2Cp2kpBOLOTYdt+p6zZtGm2Omx/ReEouRQyKy7pYtahRQuA=="],
+    "@better-auth/core": ["@better-auth/core@1.6.9", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w=="],
 
-    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.5", "", { "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-9YjPW35+h66D+QA+YqEJ9pFP97ClLFR+QrTPZojkeP0PTYqpW0ErBK3p1pwRTJG88yK+o3Y4yOwoacMTBxz0jQ=="],
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw=="],
 
-    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.5", "", { "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0", "kysely": "^0.28.14" }, "optionalPeers": ["kysely"] }, "sha512-kbevd70qzKNR3ZHF7q6/e0XXYRCXanLB2rvmTd3T8WbNEd9kYMqKjgTGNxL1ri5N+PEDUK6zfHx/HrvaEOfoHw=="],
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "kysely": "^0.28.14" }, "optionalPeers": ["kysely"] }, "sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw=="],
 
-    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.5", "", { "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0" } }, "sha512-5qFUpSdQi+RwHSmNyHMSsJIrFjed8d/ASS61L2xyW7sjBLTIuR7JcgS6hif5cQbtPeq+Qz+Wct5q8oKw33qyqQ=="],
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0" } }, "sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ=="],
 
-    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.5", "", { "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-HvOUFTiSEFSGTzL/vE3FntTwQiZ79O/V+QcsCimR+65Bj3tOqdFaC1G2Yd1dQ9l2YHNXA9SNBrGekbk66RzJMw=="],
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw=="],
 
-    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.5", "", { "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-d7PUO5XoimYYDEG/DoYVbOSbyVYJBDuZgvY9pjf8INccBTCD1BzcyEJ9NQil4huXWj4fcNaGOt2FG0OI8NtWOA=="],
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q=="],
 
-    "@better-auth/stripe": ["@better-auth/stripe@1.6.5", "", { "dependencies": { "defu": "^6.1.5", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.5", "better-auth": "^1.6.5", "better-call": "1.3.5", "stripe": "^18 || ^19 || ^20 || ^21 || ^22" } }, "sha512-FnY3EptDjgpn5g6F04jrkz4R0qoygXUtftRWzINDOVU5FXfymKbFYKa5euVO3pQFilR0sEhCzB7aoRuSa6lr6w=="],
+    "@better-auth/stripe": ["@better-auth/stripe@1.6.9", "", { "dependencies": { "defu": "^6.1.5", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.9", "better-auth": "^1.6.9", "better-call": "1.3.5", "stripe": "^18 || ^19 || ^20 || ^21 || ^22" } }, "sha512-ONXc1GkANZImGjL9pAR1k1ZPwBrFpxE4V/QLsZHp+c+7j4CCW5N2ozZ3p82gfj+6Svi7t2xAt6vbr3M68zVsvQ=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.5", "", { "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21" } }, "sha512-Ag3CjAP+tLretKPq+pYdU/gU4pFIcey/AoNQzw671wV5JQZXrMitS65INi8j8QuYfol2xgQrht5KVlcxGrkhHQ=="],
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21" } }, "sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A=="],
 
     "@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
 
@@ -1148,7 +1148,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.8", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ=="],
 
-    "better-auth": ["better-auth@1.6.5", "", { "dependencies": { "@better-auth/core": "1.6.5", "@better-auth/drizzle-adapter": "1.6.5", "@better-auth/kysely-adapter": "1.6.5", "@better-auth/memory-adapter": "1.6.5", "@better-auth/mongo-adapter": "1.6.5", "@better-auth/prisma-adapter": "1.6.5", "@better-auth/telemetry": "1.6.5", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.14", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-rSt8JtJOJK0MqPShXINCmM6DV30GsDvnCTlIxQIzP9OpUx/umA40nUc4ALZHQyqAPbw1ib/a549kIWw/WyxxKA=="],
+    "better-auth": ["better-auth@1.6.9", "", { "dependencies": { "@better-auth/core": "1.6.9", "@better-auth/drizzle-adapter": "1.6.9", "@better-auth/kysely-adapter": "1.6.9", "@better-auth/memory-adapter": "1.6.9", "@better-auth/mongo-adapter": "1.6.9", "@better-auth/prisma-adapter": "1.6.9", "@better-auth/telemetry": "1.6.9", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.14", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA=="],
 
     "better-call": ["better-call@1.3.5", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA=="],
 
@@ -1292,7 +1292,7 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
-    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -2362,8 +2362,6 @@
 
     "@better-auth/core/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@better-auth/stripe/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "@changesets/changelog-github/dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
@@ -2533,6 +2531,8 @@
     "rolldown-plugin-solid/rolldown": ["rolldown@1.0.0-rc.9", "", { "dependencies": { "@oxc-project/types": "=0.115.0", "@rolldown/pluginutils": "1.0.0-rc.9" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-x64": "1.0.0-rc.9", "@rolldown/binding-freebsd-x64": "1.0.0-rc.9", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q=="],
 
     "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "tsdown/defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "ultracite/@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 

--- a/docs/solutions/workflow-issues/convex-136-release-audits-should-ship-one-thin-cli-slice-20260426.md
+++ b/docs/solutions/workflow-issues/convex-136-release-audits-should-ship-one-thin-cli-slice-20260426.md
@@ -1,0 +1,107 @@
+---
+title: Convex 1.36 release audits should ship one thin CLI slice
+date: 2026-04-26
+category: workflow-issues
+module: kitcn cli
+problem_type: workflow_issue
+component: tooling
+severity: medium
+applies_when:
+  - Auditing a newer Convex npm release for kitcn work
+  - A Convex CLI feature can be exposed without wrapping its behavior
+  - A Convex version bump changes scaffold pins or supported peer floors
+tags: [convex, cli, release-audit, env-default, fixtures, changeset]
+---
+
+# Convex 1.36 release audits should ship one thin CLI slice
+
+## Context
+
+Convex 1.36 added several useful features: default environment variables,
+inline CLI queries, deployment messages, and function metadata reflection.
+That does not mean kitcn should mirror every feature.
+
+The useful slice was `convex env default`: kitcn already owns `kitcn env`
+delegation, and default env values improve new dev, preview, and production
+deployment setup without adding a new abstraction.
+
+## Guidance
+
+Treat Convex release audits as selection work, not a shopping spree:
+
+1. Read Ship, the package changelog, and the upstream diff.
+2. Classify each item as `compatibility`, `cleanup`, `agentic`, `feature`, or
+   `no-op`.
+3. Ship one coherent slice.
+4. Prefer passthrough when Convex already owns the behavior.
+
+For Convex 1.36 default env values, the right shape is thin delegation:
+
+```bash
+kitcn env default list --type dev
+kitcn env default set SITE_URL https://app.example.com --type prod
+```
+
+Do not add a kitcn-specific default-env store, parser, or lifecycle. Allow the
+subcommand, forward it to `convex env default`, and document the Convex-owned
+contract.
+
+When the selected slice depends on a new Convex CLI feature:
+
+- Pin scaffold/runtime installs to the exact supported version.
+- Raise package peer floors to the release family, for example `>=1.36`.
+- Update `www/` docs and packed Convex skill references in the same diff.
+- Write a changeset because published package behavior changed.
+- Run fixture sync/check when scaffold output package pins change.
+
+## Why This Matters
+
+kitcn gets worse when it shadows Convex. The package should sharpen agent and
+developer workflows, not become a second Convex CLI with stale copies of every
+new flag.
+
+Thin passthrough keeps ownership clean: Convex owns deployment defaults; kitcn
+owns discoverability, docs, scaffolds, and deterministic verification.
+
+## When to Apply
+
+- Convex ships a CLI subcommand that fits an existing kitcn command group.
+- A release includes several attractive features but only one has a small,
+  proven kitcn integration path.
+- A Convex version bump affects scaffold pins, peer dependency warnings, or
+  docs/skill setup guidance.
+
+## Examples
+
+Audit first:
+
+```bash
+npm view convex version --json
+gh api -H "Accept: application/vnd.github.raw" \
+  repos/get-convex/convex-backend/contents/npm-packages/convex/CHANGELOG.md
+git -C ../convex-backend diff <current-ref>..<target-ref> -- \
+  npm-packages/convex
+```
+
+Then keep the implementation boring:
+
+```ts
+const SUPPORTED_ENV_SUBCOMMANDS = new Set([
+  "get",
+  "set",
+  "list",
+  "default",
+]);
+```
+
+For scaffold pin changes, verify both generated output and runtime:
+
+```bash
+bun run fixtures:sync
+bun run fixtures:check
+bun check
+```
+
+## Related
+
+- [Convex 1.35 owns anonymous non-interactive setup](/Users/zbeyens/git/better-convex/docs/solutions/workflow-issues/convex-135-owns-anonymous-noninteractive-setup-20260415.md)

--- a/example/package.json
+++ b/example/package.json
@@ -45,7 +45,7 @@
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "common-tags": "1.8.2",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.6.0",
     "hono": "4.12.9",

--- a/example/package.json
+++ b/example/package.json
@@ -31,7 +31,7 @@
     "typecheck:watch": "tsc --noEmit --watch"
   },
   "dependencies": {
-    "@better-auth/stripe": "1.6.5",
+    "@better-auth/stripe": "1.6.9",
     "@convex-dev/react-query": "0.1.0",
     "@hookform/resolvers": "5.2.2",
     "@kitcn/resend": "workspace:*",
@@ -40,7 +40,7 @@
     "@react-email/render": "2.0.4",
     "@t3-oss/env-nextjs": "0.13.10",
     "@tanstack/react-query": "5.95.2",
-    "better-auth": "1.6.5",
+    "better-auth": "1.6.9",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",

--- a/fixtures/expo-auth/package.json
+++ b/fixtures/expo-auth/package.json
@@ -7,7 +7,7 @@
     "@react-navigation/native": "^7.1.33",
     "@tanstack/react-query": "5.95.2",
     "better-auth": "1.6.5",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "expo": "~55.0.17",
     "expo-constants": "~55.0.15",
     "expo-device": "~55.0.15",

--- a/fixtures/expo-auth/package.json
+++ b/fixtures/expo-auth/package.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "@better-auth/expo": "1.6.5",
+    "@better-auth/expo": "1.6.9",
     "@opentelemetry/api": "1.9.0",
     "@react-navigation/bottom-tabs": "^7.15.5",
     "@react-navigation/elements": "^2.9.10",
     "@react-navigation/native": "^7.1.33",
     "@tanstack/react-query": "5.95.2",
-    "better-auth": "1.6.5",
+    "better-auth": "1.6.9",
     "convex": "1.36.1",
     "expo": "~55.0.17",
     "expo-constants": "~55.0.15",

--- a/fixtures/expo/package.json
+++ b/fixtures/expo/package.json
@@ -5,7 +5,7 @@
     "@react-navigation/elements": "^2.9.10",
     "@react-navigation/native": "^7.1.33",
     "@tanstack/react-query": "5.95.2",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "expo": "~55.0.17",
     "expo-constants": "~55.0.15",
     "expo-device": "~55.0.15",

--- a/fixtures/next-auth/package.json
+++ b/fixtures/next-auth/package.json
@@ -3,7 +3,7 @@
     "@base-ui/react": "^1.4.1",
     "@opentelemetry/api": "1.9.0",
     "@tanstack/react-query": "5.95.2",
-    "better-auth": "1.6.5",
+    "better-auth": "1.6.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "1.36.1",

--- a/fixtures/next-auth/package.json
+++ b/fixtures/next-auth/package.json
@@ -6,7 +6,7 @@
     "better-auth": "1.6.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.11.0",

--- a/fixtures/next/package.json
+++ b/fixtures/next/package.json
@@ -5,7 +5,7 @@
     "@tanstack/react-query": "5.95.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.11.0",

--- a/fixtures/start-auth/package.json
+++ b/fixtures/start-auth/package.json
@@ -14,7 +14,7 @@
     "better-auth": "1.6.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.11.0",

--- a/fixtures/start-auth/package.json
+++ b/fixtures/start-auth/package.json
@@ -11,7 +11,7 @@
     "@tanstack/react-router-ssr-query": "^1.166.9",
     "@tanstack/react-start": "^1.166.15",
     "@tanstack/router-plugin": "^1.166.13",
-    "better-auth": "1.6.5",
+    "better-auth": "1.6.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "1.36.1",

--- a/fixtures/start/package.json
+++ b/fixtures/start/package.json
@@ -13,7 +13,7 @@
     "@tanstack/router-plugin": "^1.166.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.11.0",

--- a/fixtures/vite-auth/package.json
+++ b/fixtures/vite-auth/package.json
@@ -5,7 +5,7 @@
     "@opentelemetry/api": "1.9.0",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "5.95.2",
-    "better-auth": "1.6.5",
+    "better-auth": "1.6.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "1.36.1",

--- a/fixtures/vite-auth/package.json
+++ b/fixtures/vite-auth/package.json
@@ -8,7 +8,7 @@
     "better-auth": "1.6.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.11.0",

--- a/fixtures/vite/package.json
+++ b/fixtures/vite/package.json
@@ -7,7 +7,7 @@
     "@tanstack/react-query": "5.95.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
     "lucide-react": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@typescript-eslint/parser": "8.56.1",
     "@typescript/native-preview": "^7.0.0-dev.20260225.1",
     "@vitest/coverage-v8": "^4.0.18",
-    "better-auth": "1.6.5",
+    "better-auth": "1.6.9",
     "bun-types": "^1.3.9",
     "concurrently": "^9.2.1",
     "convex-test": "^0.0.41",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@tanstack/query-core": "5.90.20",
     "@tanstack/react-query": "5.95.2",
     "@tanstack/solid-query": "5.90.23",
-    "convex": "1.35.1",
+    "convex": "1.36.1",
     "hono": "4.12.9",
     "next": "16.1.6",
     "react": "19.2.4",

--- a/packages/kitcn/package.json
+++ b/packages/kitcn/package.json
@@ -90,7 +90,7 @@
     "@tanstack/react-query": ">=5",
     "@tanstack/solid-query": ">=5",
     "better-auth": "1.6.5",
-    "convex": ">=1.35",
+    "convex": ">=1.36",
     "hono": "4.12.9",
     "next": ">=14",
     "react": ">=18",

--- a/packages/kitcn/package.json
+++ b/packages/kitcn/package.json
@@ -89,7 +89,7 @@
     "@tanstack/query-core": ">=5",
     "@tanstack/react-query": ">=5",
     "@tanstack/solid-query": ">=5",
-    "better-auth": "1.6.5",
+    "better-auth": "1.6.9",
     "convex": ">=1.36",
     "hono": "4.12.9",
     "next": ">=14",

--- a/packages/kitcn/skills/convex/references/features/auth.md
+++ b/packages/kitcn/skills/convex/references/features/auth.md
@@ -228,6 +228,7 @@ Convex remote / repair:
 2. Use `npx kitcn env push --prod` for production sync.
 3. Use `npx kitcn env push --rotate` when you want fresh keys plus fresh `JWKS`.
 4. `kitcn env push` writes deployment env for you. No manual copy step.
+5. Use `npx kitcn env default set ... --type <dev|preview|prod>` for project defaults that should apply to new deployments.
 
 Concave manual lane:
 1. Use `npx kitcn --backend concave auth jwks` when you need a manual static `JWKS` payload.

--- a/packages/kitcn/skills/convex/references/features/migrations.md
+++ b/packages/kitcn/skills/convex/references/features/migrations.md
@@ -94,6 +94,8 @@ export const migrations = defineMigrationSet([migration1, migration2]);
 ## Deploy Integration
 
 `kitcn deploy` auto-runs: `convex deploy` → `migrate up` → `aggregate backfill`.
+Convex deploy flags pass through first, including `--message` for deployment
+history and `--preview-name` for reusable preview deployments.
 
 Config in `kitcn.json`:
 

--- a/packages/kitcn/skills/convex/references/setup/index.md
+++ b/packages/kitcn/skills/convex/references/setup/index.md
@@ -623,6 +623,8 @@ bunx kitcn codegen
 bunx kitcn env push
 bunx kitcn env push --prod
 bunx kitcn env push --rotate
+bunx kitcn env default list --type dev
+bunx kitcn env default set SITE_URL https://app.example.com --type prod
 bunx kitcn auth jwks
 bunx kitcn auth jwks --rotate
 # deploy with automatic aggregate backfill:
@@ -644,6 +646,8 @@ bunx kitcn --backend concave auth jwks --rotate --url http://localhost:3210
 On backend `convex`, `kitcn dev` watches `convex/.env` during a local
 dev session and auto-pushes later edits. Keep `env push` for `--prod`,
 `--rotate`, or explicit repair against an already active deployment.
+Use `env default` when new dev, preview, or production deployments should start
+with the same project-level values.
 
 On backend `concave`, `kitcn env` is not the right seam. Use `auth jwks`
 for manual static `JWKS` export instead.

--- a/packages/kitcn/skills/convex/references/setup/index.md
+++ b/packages/kitcn/skills/convex/references/setup/index.md
@@ -600,6 +600,7 @@ Recommended scripts:
     "verify": "kitcn verify",
     "reset": "kitcn reset --yes --after init",
     "seed": "convex run seed:seed",
+    "inspect": "kitcn run --inline-query 'await ctx.db.query(\"messages\").take(5)'",
     "env:push": "kitcn env push",
     "env:push:rotate": "kitcn env push --rotate"
   }
@@ -627,8 +628,14 @@ bunx kitcn env default list --type dev
 bunx kitcn env default set SITE_URL https://app.example.com --type prod
 bunx kitcn auth jwks
 bunx kitcn auth jwks --rotate
+# ad-hoc readonly database inspection:
+bunx kitcn run --inline-query 'await ctx.db.query("messages").take(5)'
+# create/select a branch-scoped cloud dev deployment:
+bunx kitcn deployment create "$(git branch --show-current)" --type dev --select
 # deploy with automatic aggregate backfill:
 bunx kitcn deploy --prod
+bunx kitcn deploy --prod --message "Release $(git rev-parse --short HEAD)"
+bunx kitcn deploy --preview-name "$(git branch --show-current)"
 # aggregate index management:
 bunx kitcn aggregate rebuild --prod
 bunx kitcn aggregate backfill --prod
@@ -648,8 +655,15 @@ dev session and auto-pushes later edits. Keep `env push` for `--prod`,
 `--rotate`, or explicit repair against an already active deployment.
 Use `env default` when new dev, preview, or production deployments should start
 with the same project-level values.
+Unknown Convex commands pass through `kitcn`, so use `kitcn run --inline-query`
+for quick readonly inspection and `kitcn deployment create ... --select` for
+branch-scoped cloud dev deployments. `kitcn deploy` forwards Convex deployment
+flags such as `--message` and `--preview-name`, then runs kitcn migrations and
+aggregate backfill against the selected deployment.
+Convex `ctx.meta` APIs belong inside app functions; do not invent a kitcn
+wrapper for them.
 
-On backend `concave`, `kitcn env` is not the right seam. Use `auth jwks`
+On backend `concave`, `kitcn env` is not the right command. Use `auth jwks`
 for manual static `JWKS` export instead.
 
 ### 11.2 Phase A gate: non-auth baseline (required before auth work)

--- a/packages/kitcn/skills/convex/references/setup/server.md
+++ b/packages/kitcn/skills/convex/references/setup/server.md
@@ -225,6 +225,10 @@ Agent command policy:
 4. Use `bunx kitcn verify` for one-shot local runtime proof in CI or agent runs, with any long-running local backend stopped first.
 5. Use manual `bunx kitcn codegen` only as fallback when `kitcn dev` cannot be run and backend is already active.
 6. Use `bunx kitcn insights` for cloud-deployment debugging; it forwards to the upstream Convex insights CLI.
+7. Use `bunx kitcn run --inline-query 'await ctx.db.query("messages").take(5)'` for quick readonly database inspection.
+8. Use `bunx kitcn deployment create "$(git branch --show-current)" --type dev --select` when a branch needs its own shared cloud dev deployment.
+9. Use `bunx kitcn env default set ... --type <dev|preview|prod>` before creating deployments that should start with shared env defaults.
+10. Use Convex `ctx.meta` APIs directly inside functions. Do not add kitcn wrappers for function metadata or transaction metrics.
 
 One-time codegen (optional; use only when `kitcn dev` is not running):
 

--- a/packages/kitcn/src/auth/internal/convex-plugin.ts
+++ b/packages/kitcn/src/auth/internal/convex-plugin.ts
@@ -240,6 +240,7 @@ export const convex = (opts: {
                 ctx.context.session ?? ctx.context.newSession;
               const { token } = await jwt.endpoints.getToken({
                 ...ctx,
+                asResponse: false,
                 headers: {},
                 method: 'GET',
                 returnHeaders: false,
@@ -282,6 +283,7 @@ export const convex = (opts: {
         async (ctx) => {
           return await oidcProvider.endpoints.getOpenIdConfig({
             ...ctx,
+            asResponse: false,
             returnHeaders: false,
             returnStatus: false,
           });
@@ -305,6 +307,7 @@ export const convex = (opts: {
         async (ctx) => {
           return await jwt.endpoints.getJwks({
             ...ctx,
+            asResponse: false,
             returnHeaders: false,
             returnStatus: false,
           });
@@ -326,7 +329,10 @@ export const convex = (opts: {
         async (ctx) => {
           await jwtPlugin(jwtOptions).endpoints.getJwks({
             ...ctx,
+            asResponse: false,
             method: 'GET',
+            returnHeaders: false,
+            returnStatus: false,
           });
           const jwks: any[] = await ctx.context.adapter.findMany({
             model: 'jwks',
@@ -361,7 +367,10 @@ export const convex = (opts: {
 
           await jwtPlugin(jwtOptions).endpoints.getJwks({
             ...ctx,
+            asResponse: false,
             method: 'GET',
+            returnHeaders: false,
+            returnStatus: false,
           });
           const jwks: any[] = await ctx.context.adapter.findMany({
             model: 'jwks',
@@ -391,6 +400,7 @@ export const convex = (opts: {
           const runEndpoint = async () => {
             const response = await jwt.endpoints.getToken({
               ...ctx,
+              asResponse: false,
               returnHeaders: false,
               returnStatus: false,
             });

--- a/packages/kitcn/src/cli/cli.commands.ts
+++ b/packages/kitcn/src/cli/cli.commands.ts
@@ -6483,6 +6483,72 @@ describe('cli/cli', () => {
     ]);
   });
 
+  test('run(run --inline-query) passes through to convex', async () => {
+    const calls: { cmd: string; args: string[] }[] = [];
+    const execaStub = mock(async (cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      return { exitCode: 0 } as any;
+    });
+    const generateMetaStub = mock(async () => {});
+    const syncEnvStub = mock(async () => {});
+    const loadConfigStub = mock(() => createDefaultConfig());
+
+    const query = 'await ctx.db.query("messages").take(5)';
+    const exitCode = await run(['run', '--inline-query', query], {
+      realConvex: '/fake/convex/main.js',
+      execa: execaStub as any,
+      generateMeta: generateMetaStub as any,
+      syncEnv: syncEnvStub as any,
+      loadCliConfig: loadConfigStub as any,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([
+      {
+        cmd: 'node',
+        args: ['/fake/convex/main.js', 'run', '--inline-query', query],
+      },
+    ]);
+  });
+
+  test('run(deployment create --select) passes through to convex', async () => {
+    const calls: { cmd: string; args: string[] }[] = [];
+    const execaStub = mock(async (cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      return { exitCode: 0 } as any;
+    });
+    const generateMetaStub = mock(async () => {});
+    const syncEnvStub = mock(async () => {});
+    const loadConfigStub = mock(() => createDefaultConfig());
+
+    const exitCode = await run(
+      ['deployment', 'create', 'feature-branch', '--type', 'dev', '--select'],
+      {
+        realConvex: '/fake/convex/main.js',
+        execa: execaStub as any,
+        generateMeta: generateMetaStub as any,
+        syncEnv: syncEnvStub as any,
+        loadCliConfig: loadConfigStub as any,
+      }
+    );
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([
+      {
+        cmd: 'node',
+        args: [
+          '/fake/convex/main.js',
+          'deployment',
+          'create',
+          'feature-branch',
+          '--type',
+          'dev',
+          '--select',
+        ],
+      },
+    ]);
+  });
+
   test('run(analyze) delegates to internal analyzer and does not invoke convex CLI', async () => {
     const execaStub = mock(async () => ({ exitCode: 0 }) as any);
     const runAnalyzeStub = mock(async () => 5);
@@ -6547,7 +6613,7 @@ describe('cli/cli', () => {
     const loadConfigStub = mock(() => createDefaultConfig());
 
     const exitCode = await run(
-      ['deploy', '--debug', '--api', 'out', '--prod'],
+      ['deploy', '--debug', '--api', 'out', '--prod', '--message', 'ship it'],
       {
         realConvex: '/fake/convex/main.js',
         execa: execaStub as any,
@@ -6561,7 +6627,13 @@ describe('cli/cli', () => {
     expect(loadConfigStub).toHaveBeenCalledWith(undefined);
     expect(calls[0]).toEqual({
       cmd: 'node',
-      args: ['/fake/convex/main.js', 'deploy', '--prod'],
+      args: [
+        '/fake/convex/main.js',
+        'deploy',
+        '--prod',
+        '--message',
+        'ship it',
+      ],
     });
     expect(calls[1]?.args).toContain('generated/server:migrationRun');
     expect(calls[2]?.args).toContain('generated/server:migrationStatus');

--- a/packages/kitcn/src/cli/cli.commands.ts
+++ b/packages/kitcn/src/cli/cli.commands.ts
@@ -2255,7 +2255,7 @@ describe('cli/cli', () => {
       expectDependencyInstallCallWithPackages(
         execaStub.mock.calls as unknown as unknown[],
         [
-          '@better-auth/expo@1.6.5',
+          '@better-auth/expo@1.6.9',
           'expo-secure-store@~55.0.8',
           'expo-network@~55.0.8',
         ]

--- a/packages/kitcn/src/cli/commands/env.test.ts
+++ b/packages/kitcn/src/cli/commands/env.test.ts
@@ -42,4 +42,43 @@ describe('cli/commands/env', () => {
       targetArgs: ['--preview-name', 'pr-139'],
     });
   });
+
+  test('handleEnvCommand(default) forwards to convex env default', async () => {
+    const execaStub = mock(async () => ({ exitCode: 0 }));
+
+    await handleEnvCommand(
+      [
+        'env',
+        'default',
+        'set',
+        'SITE_URL',
+        'https://app.test',
+        '--type',
+        'prod',
+      ],
+      {
+        execa: execaStub as any,
+        loadCliConfig: (() => createDefaultConfig()) as any,
+        realConvex: '/fake/convex/main.js',
+      }
+    );
+
+    expect(execaStub).toHaveBeenCalledWith(
+      'node',
+      [
+        '/fake/convex/main.js',
+        'env',
+        'default',
+        'set',
+        'SITE_URL',
+        'https://app.test',
+        '--type',
+        'prod',
+      ],
+      expect.objectContaining({
+        reject: false,
+        stdio: 'inherit',
+      })
+    );
+  });
 });

--- a/packages/kitcn/src/cli/commands/env.ts
+++ b/packages/kitcn/src/cli/commands/env.ts
@@ -11,6 +11,7 @@ import { logger } from '../utils/logger.js';
 
 const HELP_FLAGS = new Set(['--help', '-h']);
 const SUPPORTED_ENV_SUBCOMMANDS = [
+  'default',
   'push',
   'pull',
   'list',
@@ -33,6 +34,7 @@ const TARGET_FLAGS_WITH_VALUE = new Set([
 export const ENV_HELP_TEXT = `Usage: kitcn env <command> [options]
 
 Commands:
+  default <command>           Manage default env values for new deployments
   push                       Push local env values to Convex
   pull                       Pull remote env values from Convex
   list                       List remote env values
@@ -47,6 +49,9 @@ Push options:
 
 Pull options:
   --out <path>               Write pulled values to a file
+
+Default options:
+  Forwarded to convex env default.
 
 Target options:
   --prod

--- a/packages/kitcn/src/cli/registry/items/auth/auth-item.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-item.ts
@@ -98,7 +98,7 @@ const AUTH_ENV_FIELDS = [
     schema: 'z.string().optional()',
   },
 ] as const;
-const BETTER_AUTH_EXPO_INSTALL_SPEC = '@better-auth/expo@1.6.5';
+const BETTER_AUTH_EXPO_INSTALL_SPEC = '@better-auth/expo@1.6.9';
 const EXPO_SECURE_STORE_INSTALL_SPEC = 'expo-secure-store@~55.0.8';
 const EXPO_NETWORK_INSTALL_SPEC = 'expo-network@~55.0.8';
 

--- a/packages/kitcn/src/cli/supported-dependencies.test.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.test.ts
@@ -18,7 +18,7 @@ import {
 
 describe('cli/supported-dependencies', () => {
   test('extracts package names from install specs', () => {
-    expect(getPackageNameFromInstallSpec('convex@1.35.1')).toBe('convex');
+    expect(getPackageNameFromInstallSpec('convex@1.36.1')).toBe('convex');
     expect(getPackageNameFromInstallSpec('better-auth@1.6.5')).toBe(
       'better-auth'
     );
@@ -57,7 +57,7 @@ describe('cli/supported-dependencies', () => {
     expect(SUPPORTED_DEPENDENCY_VERSIONS.convex.range).toBe(
       `^${SUPPORTED_DEPENDENCY_VERSIONS.convex.exact}`
     );
-    expect(SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum).toBe('>=1.35');
+    expect(SUPPORTED_DEPENDENCY_VERSIONS.convex.minimum).toBe('>=1.36');
   });
 
   test('resolves local install spec overrides for supported packages', () => {
@@ -92,7 +92,7 @@ describe('cli/supported-dependencies', () => {
       {
         packageName: 'convex',
         current: '^1.33.0',
-        minimum: '>=1.35',
+        minimum: '>=1.36',
         installSpec: `convex@${SUPPORTED_DEPENDENCY_VERSIONS.convex.exact}`,
       },
     ]);
@@ -104,7 +104,7 @@ describe('cli/supported-dependencies', () => {
       `${dir}/package.json`,
       JSON.stringify({
         dependencies: {
-          convex: '^1.35.0',
+          convex: '^1.36.0',
         },
       })
     );
@@ -132,7 +132,7 @@ describe('cli/supported-dependencies', () => {
       `${dir}/package.json`,
       JSON.stringify({
         dependencies: {
-          convex: '<1.35.0',
+          convex: '<1.36.0',
         },
       })
     );
@@ -140,8 +140,8 @@ describe('cli/supported-dependencies', () => {
     expect(resolveSupportedDependencyWarnings(dir)).toEqual([
       {
         packageName: 'convex',
-        current: '<1.35.0',
-        minimum: '>=1.35',
+        current: '<1.36.0',
+        minimum: '>=1.36',
         installSpec: `convex@${SUPPORTED_DEPENDENCY_VERSIONS.convex.exact}`,
       },
     ]);
@@ -170,7 +170,7 @@ describe('cli/supported-dependencies', () => {
       {
         packageName: 'convex',
         current: '1.34.1',
-        minimum: '>=1.35',
+        minimum: '>=1.36',
         installSpec: `convex@${SUPPORTED_DEPENDENCY_VERSIONS.convex.exact}`,
       },
     ]);

--- a/packages/kitcn/src/cli/supported-dependencies.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.ts
@@ -6,7 +6,7 @@ const EXACT_VERSION_RE = /^(\d+)\.(\d+)\.\d+$/;
 const VERSION_IN_SPEC_RE = /(\d+)\.(\d+)(?:\.\d+)?/;
 const PLAIN_VERSION_SPEC_RE = /^[\^~]?v?\d+\.\d+(?:\.\d+)?$/;
 const UPPER_BOUND_RE = /(?:^|\s)<={0,1}\s*v?(\d+)\.(\d+)(?:\.\d+)?/g;
-const SUPPORTED_CONVEX_VERSION = '1.35.1';
+const SUPPORTED_CONVEX_VERSION = '1.36.1';
 const SUPPORTED_BETTER_AUTH_VERSION = '1.6.5';
 const SUPPORTED_HONO_VERSION = '4.12.9';
 const SUPPORTED_OPENTELEMETRY_API_VERSION = '1.9.0';

--- a/packages/kitcn/src/cli/supported-dependencies.ts
+++ b/packages/kitcn/src/cli/supported-dependencies.ts
@@ -7,7 +7,7 @@ const VERSION_IN_SPEC_RE = /(\d+)\.(\d+)(?:\.\d+)?/;
 const PLAIN_VERSION_SPEC_RE = /^[\^~]?v?\d+\.\d+(?:\.\d+)?$/;
 const UPPER_BOUND_RE = /(?:^|\s)<={0,1}\s*v?(\d+)\.(\d+)(?:\.\d+)?/g;
 const SUPPORTED_CONVEX_VERSION = '1.36.1';
-const SUPPORTED_BETTER_AUTH_VERSION = '1.6.5';
+const SUPPORTED_BETTER_AUTH_VERSION = '1.6.9';
 const SUPPORTED_HONO_VERSION = '4.12.9';
 const SUPPORTED_OPENTELEMETRY_API_VERSION = '1.9.0';
 const SUPPORTED_TANSTACK_REACT_QUERY_VERSION = '5.95.2';

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "kitcn": ">=0.11.0 <1",
-    "convex": ">=1.35"
+    "convex": ">=1.36"
   },
   "devDependencies": {
     "kitcn": "workspace:*",

--- a/test/concave/fixture/package.json
+++ b/test/concave/fixture/package.json
@@ -2,6 +2,6 @@
   "name": "kitcn-concave-fixture",
   "private": true,
   "dependencies": {
-    "convex": "1.35.1"
+    "convex": "1.36.1"
   }
 }

--- a/tooling/scenario-fixtures/create-convex-bare/package.json
+++ b/tooling/scenario-fixtures/create-convex-bare/package.json
@@ -9,7 +9,7 @@
     "lint": "tsc -p convex && eslint . --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "convex": "^1.35.1"
+    "convex": "^1.36.1"
   },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^1.1.1",

--- a/tooling/scenario-fixtures/create-convex-nextjs-shadcn/package.json
+++ b/tooling/scenario-fixtures/create-convex-nextjs-shadcn/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-toggle-group": "^1.1.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "^1.35.1",
+    "convex": "^1.36.1",
     "lucide-react": "^0.544.0",
     "next": "^16.1.5",
     "next-themes": "^0.4.4",

--- a/tooling/scenario-fixtures/create-convex-react-vite-shadcn/package.json
+++ b/tooling/scenario-fixtures/create-convex-react-vite-shadcn/package.json
@@ -21,7 +21,7 @@
     "@radix-ui/react-toggle-group": "^1.0.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "convex": "^1.35.1",
+    "convex": "^1.36.1",
     "next-themes": "^0.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/www/content/docs/cli/backend.mdx
+++ b/www/content/docs/cli/backend.mdx
@@ -194,6 +194,28 @@ by new dev, preview, and production deployments.
 Unknown commands on backend `convex` pass straight through to the Convex CLI,
 so `kitcn insights` opens the same insights surface as `convex insights`.
 
+## Convex passthrough
+
+Unknown Convex commands stay available through `kitcn`:
+
+```bash showLineNumbers
+# Run an ad-hoc readonly query without adding a function file
+npx kitcn run --inline-query 'await ctx.db.query("messages").take(5)'
+
+# Create and select a shared dev deployment for the current branch
+npx kitcn deployment create "$(git branch --show-current)" --type dev --select
+
+# Create a long-lived staging deployment
+npx kitcn deployment create staging --type prod
+```
+
+Use `kitcn env default` before creating new deployments when every dev,
+preview, or production deployment should start with the same env values.
+
+Convex runtime APIs such as `ctx.meta.getFunctionMetadata()` and
+`ctx.meta.getTransactionMetrics()` are used inside Convex functions. `kitcn`
+does not wrap them.
+
 ### Concave backend
 
 For manual JWKS export on Concave:
@@ -228,7 +250,7 @@ Use this when you want a manual static `JWKS` payload without going through
 
 This command prints the payload. It does not update env by itself.
 
-Convex target flags are forwarded to the backend `run` seam:
+Convex target flags are forwarded to the backend `run` command:
 
 - `--prod`
 - `--deployment-name <name>`
@@ -254,7 +276,7 @@ On backend `concave`, this is the manual JWKS sync path.
 This command only prints `JWKS=...`. Save that value into your deployment env
 yourself.
 
-Concave target flags are forwarded to the backend `run` seam:
+Concave target flags are forwarded to the backend `run` command:
 
 - `--url <url>`
 - `--port <port>`
@@ -271,6 +293,8 @@ Shared options:
 
 ```bash showLineNumbers
 npx kitcn deploy --prod
+npx kitcn deploy --prod --message "Release $(git rev-parse --short HEAD)"
+npx kitcn deploy --preview-name "$(git branch --show-current)"
 ```
 
 `kitcn deploy` runs:
@@ -297,6 +321,8 @@ Options:
 | `--migrations-timeout-ms <n>` | Max migration wait duration before timeout |
 | `--migrations-strict` / `--no-migrations-strict` | Fail deploy on migration timeout/error |
 | `--migrations-allow-drift` / `--no-migrations-allow-drift` | Override drift blocking policy |
+| `--message <text>` | Forward deployment audit-log message to Convex |
+| `--preview-name <name>` | Deploy to a reusable preview deployment |
 
 Already-`READY` indexes are skipped (noop). See [Resume Compatibility](#resume-compatibility) for full behavior rules.
 

--- a/www/content/docs/cli/backend.mdx
+++ b/www/content/docs/cli/backend.mdx
@@ -181,11 +181,15 @@ npx kitcn env list
 npx kitcn env get <name>
 npx kitcn env set <name> <value>
 npx kitcn env remove <name>
+npx kitcn env default list --type dev
+npx kitcn env default set SITE_URL https://app.example.com --type prod
 ```
 
 `kitcn env set` supports interactive values, `--from-file`, and stdin input.
 `kitcn env pull` gives you the same robust export format, so
 `env pull --out <path>` and `env set --from-file <path>` round-trip cleanly.
+`kitcn env default` forwards to `convex env default` for project defaults used
+by new dev, preview, and production deployments.
 
 Unknown commands on backend `convex` pass straight through to the Convex CLI,
 so `kitcn insights` opens the same insights surface as `convex insights`.


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🧩 Issue ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 targeted tests added for missing `env default` passthrough coverage, Convex 1.36 passthrough rot risk, and stale Better Auth 1.6 pins | ➖ N/A |
| Verified | 🟢 targeted CLI/auth tests; ✅ full `bun check`; ✅ auth E2E | 🟢 `bun run test:e2e -- next-auth` |

**✅ Outcome**
- Added `kitcn env default` passthrough to Convex 1.36 default environment variables.
- Bumped supported Convex floor/pins to 1.36.1 / `>=1.36`.
- Documented and regression-tested the relevant existing Convex passthroughs: `run --inline-query`, `deployment create --select`, `deploy --message`, and reusable preview deploys.
- Synced Better Auth scaffolds/runtime helpers to Better Auth 1.6.9, including Expo/Stripe companion pins.
- Added Better Auth 1.6 endpoint compatibility options in the vendored Convex plugin helper calls.
- Synced docs, packed Convex skill references, fixtures, changeset, and workflow learning.

**⚠️ Caveat**
- `ctx.meta` is intentionally not wrapped. It belongs directly inside Convex functions; a kitcn wrapper would be fake abstraction.
- Upstream `convex-better-auth` release plumbing/docs/example churn was skipped; only runtime/scaffold compatibility relevant to kitcn landed.

**🏗️ Design**
- Convex CLI features stay as thin passthroughs with regression coverage.
- Better Auth sync is a hard pin/runtime compatibility update, not a new auth abstraction.
- No compatibility shims: current Better Auth 1.6.9 behavior is the supported surface.

**🧪 Verified**
- `bun test packages/kitcn/src/cli/commands/env.test.ts packages/kitcn/src/cli/supported-dependencies.test.ts`
- `bun test ./packages/kitcn/src/cli/cli.commands.ts`
- `bun test packages/kitcn/src/auth/internal/convex-plugin.test.ts packages/kitcn/src/auth/internal/token.test.ts packages/kitcn/src/auth/registerRoutes.test.ts packages/kitcn/src/auth-nextjs/index.test.ts packages/kitcn/src/auth-start/index.test.ts packages/kitcn/src/cli/supported-dependencies.test.ts packages/kitcn/src/cli/registry/items/auth/auth-item.test.ts packages/kitcn/src/cli/registry/dependencies.test.ts tooling/dependency-pins.test.ts`
- `bun typecheck`
- `bun lint:fix`
- `bun --cwd packages/kitcn build`
- `bun run fixtures:sync`
- `bun run fixtures:check`
- `bun check`
- `bun run scenario:dev -- next-auth` + `bun run test:e2e -- next-auth`
