### PR TITLE
fix: preserve null Convex query results

### DIFF
--- a/.changeset/null-convex-query-cache.md
+++ b/.changeset/null-convex-query-cache.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix Convex query cache updates when a subscription returns `null`.

--- a/packages/kitcn/src/react/client.lifecycle.test.ts
+++ b/packages/kitcn/src/react/client.lifecycle.test.ts
@@ -235,7 +235,7 @@ describe('ConvexQueryClient (client mode lifecycle)', () => {
     unsubPublic();
   });
 
-  test('onUpdateQueryKeyHash does not overwrite existing data with null/undefined subscription values', async () => {
+  test('onUpdateQueryKeyHash keeps existing data for undefined but accepts null subscription values', async () => {
     const ConvexQueryClient = await getClientConvexQueryClient('update-values');
 
     const queryClient = new QueryClient();
@@ -282,15 +282,16 @@ describe('ConvexQueryClient (client mode lifecycle)', () => {
     client.onUpdateQueryKeyHash((query as any).queryHash);
     expect(setQueryData).not.toHaveBeenCalled();
 
-    // null -> should NOT overwrite existing data
+    // null -> valid Convex result, should overwrite existing data
     localQueryValue = null;
     client.onUpdateQueryKeyHash((query as any).queryHash);
-    expect(setQueryData).not.toHaveBeenCalled();
+    expect(setQueryData).toHaveBeenCalledTimes(1);
+    expect(setQueryData).toHaveBeenCalledWith(queryKey as any, null);
 
     // non-nullish -> should update
     localQueryValue = { updated: true };
     client.onUpdateQueryKeyHash((query as any).queryHash);
-    expect(setQueryData).toHaveBeenCalledTimes(1);
+    expect(setQueryData).toHaveBeenCalledTimes(2);
     expect(setQueryData).toHaveBeenCalledWith(queryKey as any, {
       updated: true,
     });

--- a/packages/kitcn/src/react/client.ts
+++ b/packages/kitcn/src/react/client.ts
@@ -512,14 +512,11 @@ export class ConvexQueryClient {
     }
 
     if (result.ok) {
-      // Don't overwrite hydrated data with null/undefined from initial subscription
+      // Don't overwrite hydrated data with undefined from initial subscription
       // localQueryResult() returns undefined before the server sends the first update
-      // Guard against both null and undefined - subscription sends null before server responds
       const existingData = this.queryClient.getQueryData(queryKey);
-      const hasResultValue =
-        result.value !== null && result.value !== undefined;
-      const hasExistingData =
-        existingData !== null && existingData !== undefined;
+      const hasResultValue = result.value !== undefined;
+      const hasExistingData = existingData !== undefined;
 
       if (hasResultValue || !hasExistingData) {
         this.queryClient.setQueryData(

--- a/packages/kitcn/src/solid/client.lifecycle.vitest.ts
+++ b/packages/kitcn/src/solid/client.lifecycle.vitest.ts
@@ -150,7 +150,7 @@ describe('ConvexQueryClient (client mode lifecycle)', () => {
     unsubOptional();
   });
 
-  test('onUpdateQueryKeyHash does not overwrite existing data with null/undefined subscription values', () => {
+  test('onUpdateQueryKeyHash keeps existing data for undefined but accepts null subscription values', () => {
     const queryClient = new QueryClient();
     const convexClient = createMockConvexClient();
     const client = new ConvexQueryClient(convexClient, {
@@ -190,15 +190,16 @@ describe('ConvexQueryClient (client mode lifecycle)', () => {
     client.onUpdateQueryKeyHash((query as any).queryHash);
     expect(setQueryData).not.toHaveBeenCalled();
 
-    // null -> should NOT overwrite existing data
+    // null -> valid Convex result, should overwrite existing data
     localQueryValue = null;
     client.onUpdateQueryKeyHash((query as any).queryHash);
-    expect(setQueryData).not.toHaveBeenCalled();
+    expect(setQueryData).toHaveBeenCalledTimes(1);
+    expect(setQueryData).toHaveBeenCalledWith(queryKey as any, null);
 
     // non-nullish -> should update
     localQueryValue = { updated: true };
     client.onUpdateQueryKeyHash((query as any).queryHash);
-    expect(setQueryData).toHaveBeenCalledTimes(1);
+    expect(setQueryData).toHaveBeenCalledTimes(2);
     expect(setQueryData).toHaveBeenCalledWith(queryKey as any, {
       updated: true,
     });

--- a/packages/kitcn/src/solid/client.ts
+++ b/packages/kitcn/src/solid/client.ts
@@ -402,14 +402,11 @@ export class ConvexQueryClient {
     }
 
     if (result.ok) {
-      // Don't overwrite hydrated data with null/undefined from initial subscription
+      // Don't overwrite hydrated data with undefined from initial subscription
       // getCurrentValue() returns undefined before the server sends the first update
-      // Guard against both null and undefined
       const existingData = this.queryClient.getQueryData(queryKey);
-      const hasResultValue =
-        result.value !== null && result.value !== undefined;
-      const hasExistingData =
-        existingData !== null && existingData !== undefined;
+      const hasResultValue = result.value !== undefined;
+      const hasExistingData = existingData !== undefined;
 
       if (hasResultValue || !hasExistingData) {
         this.queryClient.setQueryData(


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes ConvexQueryClient dropping valid `null` subscription results
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 React/Solid cache regressions | ➖ N/A |
| Verified | 🟢 `bun check` | ➖ N/A |

**✅ Outcome**
- `null` subscription results now replace existing React and Solid TanStack Query data.
- `undefined` still preserves existing hydrated data while the subscription has no server value yet.

**⚠️ Caveat**
- No browser surface; package cache behavior only.

**🏗️ Design**
- Chosen boundary: `ConvexQueryClient.onUpdateQueryKeyHash` in React and Solid.
- Why not quick patch: callers cannot distinguish valid `null` from cache-stale behavior after the bridge drops it.
- Why not broader change: upstream adapter already treats `null` as data; only kitcn's nullish guard diverged.

**🧪 Verified**
- `bun test packages/kitcn/src/react/client.lifecycle.test.ts`
- `bun run test:vitest -- packages/kitcn/src/solid/client.lifecycle.vitest.ts`
- `bun lint:fix`
- `bun --cwd packages/kitcn build`
- `bun typecheck`
- `bun check`
