### PR TITLE
Add provider query client auth sync

### DIFF
--- a/.agents/skills/kitcn/references/features/auth.md
+++ b/.agents/skills/kitcn/references/features/auth.md
@@ -387,6 +387,7 @@ All from `kitcn/react`:
 <ConvexAuthProvider
   client={convex}
   authClient={authClient}
+  convexQueryClient={convexQueryClient} // when using TanStack Query
   initialToken={token}           // from SSR (caller.getToken())
   onMutationUnauthorized={() => router.push('/login')}
   onQueryUnauthorized={({ queryName }) => console.log(`Unauth: ${queryName}`)}

--- a/.agents/skills/kitcn/references/features/react.md
+++ b/.agents/skills/kitcn/references/features/react.md
@@ -113,35 +113,30 @@ function QueryProvider({ children }) {
 **With auth** — swap `ConvexProvider` for `ConvexAuthProvider`:
 ```tsx
 import { ConvexAuthProvider } from 'kitcn/auth/client';
-import { ConvexReactClient, getConvexQueryClientSingleton, getQueryClientSingleton, useAuthStore } from 'kitcn/react';
+import { ConvexReactClient, getConvexQueryClientSingleton, getQueryClientSingleton } from 'kitcn/react';
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export function AppConvexProvider({ children, token }: { children: ReactNode; token?: string }) {
   const router = useRouter();
+  const queryClient = getQueryClientSingleton(createQueryClient);
+  const convexQueryClient = getConvexQueryClientSingleton({ convex, queryClient });
+
   return (
     <ConvexAuthProvider
       authClient={authClient}
       client={convex}
+      convexQueryClient={convexQueryClient}
       initialToken={token}
       onMutationUnauthorized={() => router.push('/login')}
       onQueryUnauthorized={() => router.push('/login')}
     >
-      <QueryProvider>{children}</QueryProvider>
+      <QueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </QueryClientProvider>
     </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }) {
-  const authStore = useAuthStore(); // pass to singleton
-  const queryClient = getQueryClientSingleton(createQueryClient);
-  const convexQueryClient = getConvexQueryClientSingleton({ authStore, convex, queryClient });
-  return (
-    <QueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </QueryClientProvider>
   );
 }
 ```
@@ -156,7 +151,7 @@ function QueryProvider({ children }) {
 `getConvexQueryClientSingleton` options:
 - `convex` — ConvexReactClient
 - `queryClient` — TanStack QueryClient
-- `authStore` — from `useAuthStore()` (auth apps only)
+- `authStore` — optional manual auth-store bridge
 - `unsubscribeDelay` — ms before unsubscribing after unmount (default 3000). Covers StrictMode + quick back-nav.
 
 ### ConvexQueryClient (Bridge)

--- a/.agents/skills/kitcn/references/setup/react.md
+++ b/.agents/skills/kitcn/references/setup/react.md
@@ -119,7 +119,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from "kitcn/react";
 import type { ReactNode } from "react";
 
@@ -136,33 +135,25 @@ export function AppConvexProvider({
   children: ReactNode;
   token?: string;
 }) {
-  return (
-    <ConvexAuthProvider
-      authClient={authClient}
-      client={convex}
-      initialToken={token}
-    >
-      <QueryProvider>{children}</QueryProvider>
-    </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
-
   const queryClient = getQueryClientSingleton(createQueryClient);
   const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
     convex,
     queryClient,
   });
 
   return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
+    <ConvexAuthProvider
+      authClient={authClient}
+      client={convex}
+      convexQueryClient={convexQueryClient}
+      initialToken={token}
+    >
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
+    </ConvexAuthProvider>
   );
 }
 ```

--- a/.changeset/convex-auth-provider-query-client.md
+++ b/.changeset/convex-auth-provider-query-client.md
@@ -1,0 +1,7 @@
+---
+"kitcn": patch
+---
+
+## Features
+
+- Support syncing shared Convex query clients directly from `ConvexAuthProvider`.

--- a/docs/solutions/integration-issues/convex-auth-provider-must-sync-shared-query-client-20260520.md
+++ b/docs/solutions/integration-issues/convex-auth-provider-must-sync-shared-query-client-20260520.md
@@ -1,0 +1,111 @@
+---
+title: ConvexAuthProvider must sync shared query clients
+date: 2026-05-20
+category: integration-issues
+module: react-auth-query-client
+problem_type: integration_issue
+component: authentication
+symptoms:
+  - TanStack Query apps create a shared ConvexQueryClient outside React
+  - ConvexAuthProvider owns the kitcn auth store inside React
+  - client components need a child useAuthStore bridge to sync the query client
+  - scaffolded auth providers import useAuthStore only for provider wiring
+root_cause: async_timing
+resolution_type: code_fix
+severity: medium
+tags: [auth, react, tanstack-query, convex-query-client, provider]
+---
+
+# ConvexAuthProvider must sync shared query clients
+
+## Problem
+
+kitcn auth apps using TanStack Query had two auth paths: route loaders used
+`syncConvexAuthForStartLoader()`, while mounted client components still needed a
+small child component to pass `useAuthStore()` into the shared
+`ConvexQueryClient`.
+
+That made scaffolded providers expose an internal bridge as app code.
+
+## Symptoms
+
+- Auth-enabled provider snippets import `useAuthStore()` only to wire
+  `getConvexQueryClientSingleton({ authStore, ... })`.
+- Start apps with loaders fix loader auth, but still need a client-side bridge
+  inside `ConvexAuthProvider`.
+- Protected component queries rely on callers remembering to sync the shared
+  query client with the provider-owned auth store.
+
+## What Didn't Work
+
+- Leaving the bridge in every app works, but it leaks provider internals into
+  scaffolded user code.
+- Moving the bridge to a child effect is too late for render-time consumers and
+  still requires every app to wire the same pattern.
+- Relying on loader sync alone only handles router loader timing; it does not
+  attach the React auth store to client component query subscriptions.
+
+## Solution
+
+Add a `convexQueryClient` prop to `ConvexAuthProvider` and sync it with the
+internal auth store before children render:
+
+```tsx
+<ConvexAuthProvider
+  authClient={authClient}
+  client={convex}
+  convexQueryClient={convexQueryClient}
+>
+  {children}
+</ConvexAuthProvider>
+```
+
+Generated providers now create the shared clients before rendering the provider
+and pass the query client directly:
+
+```tsx
+const queryClient = getQueryClientSingleton(createQueryClient);
+const convexQueryClient = getConvexQueryClientSingleton({
+  convex,
+  queryClient,
+});
+
+return (
+  <ConvexAuthProvider
+    authClient={authClient}
+    client={convex}
+    convexQueryClient={convexQueryClient}
+  >
+    <TanstackQueryClientProvider client={queryClient}>
+      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+        {children}
+      </CRPCProvider>
+    </TanstackQueryClientProvider>
+  </ConvexAuthProvider>
+);
+```
+
+## Why This Works
+
+`ConvexAuthProvider` is the component that creates and owns the kitcn auth store.
+The shared query client is still created outside that provider, but the provider
+can update it as soon as `useAuthStore()` is available and before descendant
+queries render.
+
+Loader auth remains separate: loaders run before React mounts, so they still use
+`syncConvexAuthForStartLoader()`.
+
+## Prevention
+
+- Do not put `useAuthStore()` in scaffolded app providers just to wire auth.
+- For mounted React trees, pass the shared `ConvexQueryClient` to
+  `ConvexAuthProvider`.
+- Keep a provider test proving the query client is synced before children
+  render.
+- Keep Start docs split between loader auth sync and React provider auth sync.
+
+## Related Issues
+
+- [start-loader-auth-must-prime-convex-query-client-before-provider-20260519.md](./start-loader-auth-must-prime-convex-query-client-before-provider-20260519.md)
+- [react-auth-hooks-must-read-synced-store-state-during-token-catch-up-20260410.md](./react-auth-hooks-must-read-synced-store-state-during-token-catch-up-20260410.md)
+- [react-query-peer-drift-creates-duplicate-contexts-20260325.md](./react-query-peer-drift-creates-duplicate-contexts-20260325.md)

--- a/fixtures/expo-auth/src/lib/convex/convex-provider.tsx
+++ b/fixtures/expo-auth/src/lib/convex/convex-provider.tsx
@@ -5,7 +5,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import type { ReactNode } from 'react';
 
@@ -21,11 +20,17 @@ export function AppConvexProvider({
   children: ReactNode;
 }) {
   const router = useRouter();
+  const queryClient = getQueryClientSingleton(createQueryClient);
+  const convexQueryClient = getConvexQueryClientSingleton({
+    convex,
+    queryClient,
+  });
 
   return (
     <ConvexAuthProvider
       authClient={authClient}
       client={convex}
+      convexQueryClient={convexQueryClient}
       onMutationUnauthorized={() => {
         router.push('/auth');
       }}
@@ -33,25 +38,11 @@ export function AppConvexProvider({
         router.push('/auth');
       }}
     >
-      <QueryProvider>{children}</QueryProvider>
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
     </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
-  const queryClient = getQueryClientSingleton(createQueryClient);
-  const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
-    convex,
-    queryClient,
-  });
-
-  return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
   );
 }

--- a/fixtures/next-auth/lib/convex/convex-provider.tsx
+++ b/fixtures/next-auth/lib/convex/convex-provider.tsx
@@ -6,7 +6,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
@@ -23,11 +22,17 @@ export function AppConvexProvider({
   children: ReactNode;
 }) {
   const router = useRouter();
+  const queryClient = getQueryClientSingleton(createQueryClient);
+  const convexQueryClient = getConvexQueryClientSingleton({
+    convex,
+    queryClient,
+  });
 
   return (
     <ConvexAuthProvider
       authClient={authClient}
       client={convex}
+      convexQueryClient={convexQueryClient}
       onMutationUnauthorized={() => {
         router.push('/auth');
       }}
@@ -35,25 +40,11 @@ export function AppConvexProvider({
         router.push('/auth');
       }}
     >
-      <QueryProvider>{children}</QueryProvider>
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
     </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
-  const queryClient = getQueryClientSingleton(createQueryClient);
-  const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
-    convex,
-    queryClient,
-  });
-
-  return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
   );
 }

--- a/fixtures/start-auth/src/lib/convex/convex-provider.tsx
+++ b/fixtures/start-auth/src/lib/convex/convex-provider.tsx
@@ -6,7 +6,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import type { ReactNode } from 'react';
 
@@ -21,27 +20,23 @@ export function AppConvexProvider({
 }: {
   children: ReactNode;
 }) {
-  return (
-    <ConvexAuthProvider authClient={authClient} client={convex}>
-      <QueryProvider>{children}</QueryProvider>
-    </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
   const queryClient = getQueryClientSingleton(createQueryClient);
   const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
     convex,
     queryClient,
   });
 
   return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
+    <ConvexAuthProvider
+      authClient={authClient}
+      client={convex}
+      convexQueryClient={convexQueryClient}
+    >
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
+    </ConvexAuthProvider>
   );
 }

--- a/fixtures/vite-auth/src/lib/convex/convex-provider.tsx
+++ b/fixtures/vite-auth/src/lib/convex/convex-provider.tsx
@@ -6,7 +6,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import type { ReactNode } from 'react';
 
@@ -23,31 +22,24 @@ export function AppConvexProvider({
   children: ReactNode;
   token?: string;
 }) {
-  return (
-    <ConvexAuthProvider
-      authClient={authClient}
-      client={convex}
-      initialToken={token}
-    >
-      <QueryProvider>{children}</QueryProvider>
-    </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
   const queryClient = getQueryClientSingleton(createQueryClient);
   const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
     convex,
     queryClient,
   });
 
   return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
+    <ConvexAuthProvider
+      authClient={authClient}
+      client={convex}
+      convexQueryClient={convexQueryClient}
+      initialToken={token}
+    >
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
+    </ConvexAuthProvider>
   );
 }

--- a/packages/kitcn/skills/kitcn/references/features/auth.md
+++ b/packages/kitcn/skills/kitcn/references/features/auth.md
@@ -387,6 +387,7 @@ All from `kitcn/react`:
 <ConvexAuthProvider
   client={convex}
   authClient={authClient}
+  convexQueryClient={convexQueryClient} // when using TanStack Query
   initialToken={token}           // from SSR (caller.getToken())
   onMutationUnauthorized={() => router.push('/login')}
   onQueryUnauthorized={({ queryName }) => console.log(`Unauth: ${queryName}`)}

--- a/packages/kitcn/skills/kitcn/references/features/react.md
+++ b/packages/kitcn/skills/kitcn/references/features/react.md
@@ -113,35 +113,30 @@ function QueryProvider({ children }) {
 **With auth** — swap `ConvexProvider` for `ConvexAuthProvider`:
 ```tsx
 import { ConvexAuthProvider } from 'kitcn/auth/client';
-import { ConvexReactClient, getConvexQueryClientSingleton, getQueryClientSingleton, useAuthStore } from 'kitcn/react';
+import { ConvexReactClient, getConvexQueryClientSingleton, getQueryClientSingleton } from 'kitcn/react';
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export function AppConvexProvider({ children, token }: { children: ReactNode; token?: string }) {
   const router = useRouter();
+  const queryClient = getQueryClientSingleton(createQueryClient);
+  const convexQueryClient = getConvexQueryClientSingleton({ convex, queryClient });
+
   return (
     <ConvexAuthProvider
       authClient={authClient}
       client={convex}
+      convexQueryClient={convexQueryClient}
       initialToken={token}
       onMutationUnauthorized={() => router.push('/login')}
       onQueryUnauthorized={() => router.push('/login')}
     >
-      <QueryProvider>{children}</QueryProvider>
+      <QueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </QueryClientProvider>
     </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }) {
-  const authStore = useAuthStore(); // pass to singleton
-  const queryClient = getQueryClientSingleton(createQueryClient);
-  const convexQueryClient = getConvexQueryClientSingleton({ authStore, convex, queryClient });
-  return (
-    <QueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </QueryClientProvider>
   );
 }
 ```
@@ -156,7 +151,7 @@ function QueryProvider({ children }) {
 `getConvexQueryClientSingleton` options:
 - `convex` — ConvexReactClient
 - `queryClient` — TanStack QueryClient
-- `authStore` — from `useAuthStore()` (auth apps only)
+- `authStore` — optional manual auth-store bridge
 - `unsubscribeDelay` — ms before unsubscribing after unmount (default 3000). Covers StrictMode + quick back-nav.
 
 ### ConvexQueryClient (Bridge)

--- a/packages/kitcn/skills/kitcn/references/setup/react.md
+++ b/packages/kitcn/skills/kitcn/references/setup/react.md
@@ -119,7 +119,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from "kitcn/react";
 import type { ReactNode } from "react";
 
@@ -136,33 +135,25 @@ export function AppConvexProvider({
   children: ReactNode;
   token?: string;
 }) {
-  return (
-    <ConvexAuthProvider
-      authClient={authClient}
-      client={convex}
-      initialToken={token}
-    >
-      <QueryProvider>{children}</QueryProvider>
-    </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
-
   const queryClient = getQueryClientSingleton(createQueryClient);
   const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
     convex,
     queryClient,
   });
 
   return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
+    <ConvexAuthProvider
+      authClient={authClient}
+      client={convex}
+      convexQueryClient={convexQueryClient}
+      initialToken={token}
+    >
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
+    </ConvexAuthProvider>
   );
 }
 ```

--- a/packages/kitcn/src/auth-client/convex-auth-provider.test.tsx
+++ b/packages/kitcn/src/auth-client/convex-auth-provider.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import {
   decodeJwtExp,
@@ -29,6 +29,50 @@ describe('ConvexAuthProvider', () => {
     } catch {
       // Happy DOM may reject some URL transitions; don't let cleanup fail the suite.
     }
+  });
+
+  test('syncs ConvexQueryClient with the auth store before children render', () => {
+    const client = {
+      setAuth: () => {},
+      clearAuth: () => {},
+    };
+
+    const authClient = {
+      useSession: () => ({ data: null, isPending: true }),
+      convex: { token: mock(async () => ({ data: { token: makeJwt(7200) } })) },
+      getSession: async () => null,
+      updateSession: () => {},
+      crossDomain: {
+        oneTimeToken: {
+          verify: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    let syncedStore: ReturnType<typeof useAuthStore> | undefined;
+    const convexQueryClient = {
+      updateAuthStore: mock((authStore: ReturnType<typeof useAuthStore>) => {
+        syncedStore = authStore;
+      }),
+    };
+
+    function StoreProbe() {
+      const authStore = useAuthStore();
+      expect(syncedStore?.store).toBe(authStore.store);
+      return null;
+    }
+
+    render(
+      <ConvexAuthProvider
+        authClient={authClient as any}
+        client={client as any}
+        convexQueryClient={convexQueryClient}
+      >
+        <StoreProbe />
+      </ConvexAuthProvider>
+    );
+
+    expect(convexQueryClient.updateAuthStore).toHaveBeenCalled();
   });
 
   test('provides fetchAccessToken that returns cached SSR token while session is pending', async () => {

--- a/packages/kitcn/src/auth-client/convex-auth-provider.tsx
+++ b/packages/kitcn/src/auth-client/convex-auth-provider.tsx
@@ -20,6 +20,7 @@ import {
 import {
   AUTH_SESSION_SYNC_GRACE_MS,
   AuthProvider,
+  type AuthStore,
   decodeJwtExp,
   FetchAccessTokenContext,
   isSessionSyncGraceActive,
@@ -43,12 +44,18 @@ type IConvexReactClient = {
   clearAuth(): void;
 };
 
+export type ConvexAuthProviderQueryClient = {
+  updateAuthStore: (authStore?: AuthStore) => void;
+};
+
 export type ConvexAuthProviderProps = {
   children: ReactNode;
   /** Convex client instance */
   client: ConvexReactClient;
   /** Better Auth client instance */
   authClient: AuthClient;
+  /** Shared Convex query client to sync with auth state */
+  convexQueryClient?: ConvexAuthProviderQueryClient;
   /** Initial session token (from SSR) */
   initialToken?: string;
   /** Callback when mutation called while unauthorized */
@@ -171,6 +178,7 @@ export function ConvexAuthProvider({
   children,
   client,
   authClient,
+  convexQueryClient,
   initialToken,
   onMutationUnauthorized,
   onQueryUnauthorized,
@@ -197,7 +205,11 @@ export function ConvexAuthProvider({
       onMutationUnauthorized={onMutationUnauthorized ?? defaultMutationHandler}
       onQueryUnauthorized={onQueryUnauthorized ?? (() => {})}
     >
-      <ConvexAuthProviderInner authClient={authClient} client={client}>
+      <ConvexAuthProviderInner
+        authClient={authClient}
+        client={client}
+        convexQueryClient={convexQueryClient}
+      >
         {children}
       </ConvexAuthProviderInner>
     </AuthProvider>
@@ -212,12 +224,16 @@ function ConvexAuthProviderInner({
   children,
   client,
   authClient,
+  convexQueryClient,
 }: {
   children: ReactNode;
   client: ConvexReactClient;
   authClient: AuthClient;
+  convexQueryClient?: ConvexAuthProviderQueryClient;
 }) {
   const authStore = useAuthStore();
+  convexQueryClient?.updateAuthStore(authStore);
+
   const { data: session, isPending } = authClient.useSession();
 
   // Use refs to avoid recreating fetchAccessToken on session refetch (tab focus)

--- a/packages/kitcn/src/cli/registry/items/auth/auth-convex-provider.template.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-convex-provider.template.ts
@@ -6,7 +6,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
@@ -23,11 +22,17 @@ export function AppConvexProvider({
   children: ReactNode;
 }) {
   const router = useRouter();
+  const queryClient = getQueryClientSingleton(createQueryClient);
+  const convexQueryClient = getConvexQueryClientSingleton({
+    convex,
+    queryClient,
+  });
 
   return (
     <ConvexAuthProvider
       authClient={authClient}
       client={convex}
+      convexQueryClient={convexQueryClient}
       onMutationUnauthorized={() => {
         router.push('/auth');
       }}
@@ -35,26 +40,12 @@ export function AppConvexProvider({
         router.push('/auth');
       }}
     >
-      <QueryProvider>{children}</QueryProvider>
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
     </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
-  const queryClient = getQueryClientSingleton(createQueryClient);
-  const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
-    convex,
-    queryClient,
-  });
-
-  return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
   );
 }
 `;

--- a/packages/kitcn/src/cli/registry/items/auth/auth-expo-convex-provider.template.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-expo-convex-provider.template.ts
@@ -5,7 +5,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import type { ReactNode } from 'react';
 
@@ -21,11 +20,17 @@ export function AppConvexProvider({
   children: ReactNode;
 }) {
   const router = useRouter();
+  const queryClient = getQueryClientSingleton(createQueryClient);
+  const convexQueryClient = getConvexQueryClientSingleton({
+    convex,
+    queryClient,
+  });
 
   return (
     <ConvexAuthProvider
       authClient={authClient}
       client={convex}
+      convexQueryClient={convexQueryClient}
       onMutationUnauthorized={() => {
         router.push('/auth');
       }}
@@ -33,26 +38,12 @@ export function AppConvexProvider({
         router.push('/auth');
       }}
     >
-      <QueryProvider>{children}</QueryProvider>
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
     </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
-  const queryClient = getQueryClientSingleton(createQueryClient);
-  const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
-    convex,
-    queryClient,
-  });
-
-  return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
   );
 }
 `;

--- a/packages/kitcn/src/cli/registry/items/auth/auth-react-convex-provider.template.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-react-convex-provider.template.ts
@@ -6,7 +6,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import type { ReactNode } from 'react';
 
@@ -23,32 +22,25 @@ export function AppConvexProvider({
   children: ReactNode;
   token?: string;
 }) {
-  return (
-    <ConvexAuthProvider
-      authClient={authClient}
-      client={convex}
-      initialToken={token}
-    >
-      <QueryProvider>{children}</QueryProvider>
-    </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
   const queryClient = getQueryClientSingleton(createQueryClient);
   const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
     convex,
     queryClient,
   });
 
   return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
+    <ConvexAuthProvider
+      authClient={authClient}
+      client={convex}
+      convexQueryClient={convexQueryClient}
+      initialToken={token}
+    >
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
+    </ConvexAuthProvider>
   );
 }
 `;

--- a/packages/kitcn/src/cli/registry/items/auth/auth-start-convex-provider.template.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-start-convex-provider.template.ts
@@ -6,7 +6,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import type { ReactNode } from 'react';
 
@@ -21,28 +20,24 @@ export function AppConvexProvider({
 }: {
   children: ReactNode;
 }) {
-  return (
-    <ConvexAuthProvider authClient={authClient} client={convex}>
-      <QueryProvider>{children}</QueryProvider>
-    </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
   const queryClient = getQueryClientSingleton(createQueryClient);
   const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
     convex,
     queryClient,
   });
 
   return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
+    <ConvexAuthProvider
+      authClient={authClient}
+      client={convex}
+      convexQueryClient={convexQueryClient}
+    >
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
+    </ConvexAuthProvider>
   );
 }
 `;

--- a/www/content/docs/auth/client.mdx
+++ b/www/content/docs/auth/client.mdx
@@ -415,6 +415,7 @@ function App() {
 |------|------|-------------|
 | `client` | `ConvexReactClient` | Convex client instance |
 | `authClient` | `AuthClient` | Better Auth client instance |
+| `convexQueryClient` | `ConvexQueryClient?` | Shared TanStack Query client bridge |
 | `initialToken` | `string?` | Initial session token (from SSR) |
 | `onMutationUnauthorized` | `() => void` | Called when mutation is blocked |
 | `onQueryUnauthorized` | `({ queryName }) => void` | Called when query is blocked |

--- a/www/content/docs/migrations/auth.mdx
+++ b/www/content/docs/migrations/auth.mdx
@@ -960,6 +960,7 @@ function RootComponent() {
     <ConvexAuthProvider
       client={context.convexQueryClient.convexClient}
       authClient={authClient}
+      convexQueryClient={context.convexQueryClient}
       initialToken={context.token}
     >
       <Outlet />

--- a/www/content/docs/react/index.mdx
+++ b/www/content/docs/react/index.mdx
@@ -193,7 +193,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
@@ -212,37 +211,28 @@ export function AppConvexProvider({
   token?: string;
 }) {
   const router = useRouter();
-
-  return (
-    <ConvexAuthProvider
-      authClient={authClient}
-      client={convex}
-      initialToken={token}
-      onMutationUnauthorized={() => router.push('/login')}
-      onQueryUnauthorized={() => router.push('/login')}
-    >
-      <QueryProvider>{children}</QueryProvider>
-    </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
-
   const queryClient = getQueryClientSingleton(createQueryClient);
   const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
     convex,
     queryClient,
   });
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-        <ReactQueryDevtools initialIsOpen={false} />
-      </CRPCProvider>
-    </QueryClientProvider>
+    <ConvexAuthProvider
+      authClient={authClient}
+      client={convex}
+      convexQueryClient={convexQueryClient}
+      initialToken={token}
+      onMutationUnauthorized={() => router.push('/login')}
+      onQueryUnauthorized={() => router.push('/login')}
+    >
+      <QueryClientProvider client={queryClient}>
+        <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
+          {children}
+          <ReactQueryDevtools initialIsOpen={false} />
+        </CRPCProvider>
+      </QueryClientProvider>
+    </ConvexAuthProvider>
   );
 }
 ```
@@ -252,7 +242,7 @@ Key differences from "Without Auth":
 | Feature | Description |
 |---------|-------------|
 | `ConvexAuthProvider` | Wraps everything with auth state management |
-| `useAuthStore()` | Passes auth state to `getConvexQueryClientSingleton` |
+| `convexQueryClient` | Syncs auth state to the shared query client |
 | `onQueryUnauthorized` | Handles auth failures with redirect |
 
 See [Auth Server](/docs/auth/server) for backend configuration.
@@ -355,4 +345,3 @@ Unlike traditional REST APIs that use polling, Convex pushes updates via WebSock
 | `gcTime` | `5 min` | Cached data persists for back-navigation after unmount |
 | `refetchOnMount` | `false` | No need to refetch - subscription provides latest data |
 | `refetchOnWindowFocus` | `false` | WebSocket already pushed any changes |
-

--- a/www/content/docs/tanstack-start.mdx
+++ b/www/content/docs/tanstack-start.mdx
@@ -221,7 +221,6 @@ import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  useAuthStore,
 } from 'kitcn/react';
 import type { ReactNode } from 'react';
 
@@ -236,28 +235,27 @@ export function AppConvexProvider({
 }: {
   children: ReactNode;
 }) {
-  return (
-    <ConvexAuthProvider authClient={authClient} client={convex}>
-      <QueryProvider>{children}</QueryProvider>
-    </ConvexAuthProvider>
-  );
-}
-
-function QueryProvider({ children }: { children: ReactNode }) {
-  const authStore = useAuthStore();
   const queryClient = getQueryClientSingleton(createQueryClient);
   const convexQueryClient = getConvexQueryClientSingleton({
-    authStore,
     convex,
     queryClient,
   });
 
   return (
-    <TanstackQueryClientProvider client={queryClient}>
-      <CRPCProvider convexClient={convex} convexQueryClient={convexQueryClient}>
-        {children}
-      </CRPCProvider>
-    </TanstackQueryClientProvider>
+    <ConvexAuthProvider
+      authClient={authClient}
+      client={convex}
+      convexQueryClient={convexQueryClient}
+    >
+      <TanstackQueryClientProvider client={queryClient}>
+        <CRPCProvider
+          convexClient={convex}
+          convexQueryClient={convexQueryClient}
+        >
+          {children}
+        </CRPCProvider>
+      </TanstackQueryClientProvider>
+    </ConvexAuthProvider>
   );
 }
 ```


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## What changed

- Add `convexQueryClient` to `ConvexAuthProvider` so the provider syncs its internal auth store to the shared query client before children render.
- Remove scaffolded `useAuthStore()` bridge wiring from auth provider templates and regenerated fixtures.
- Update React/Start/auth docs, generated kitcn skill references, and add a changeset plus solution note.

## Verified

- `bun test ./packages/kitcn/src/auth-client/convex-auth-provider.test.tsx`
- `bun run fixtures:sync`
- `bun run fixtures:check`
- `bun --cwd packages/kitcn build`
- `bun lint:fix`
- `bun typecheck`
- `cd packages/kitcn && bunx @tanstack/intent validate skills`
- `bun run intent:stale`
- `bun check`

## Notes

- The first `bun check` run reached fixture auto-check and hung in a Start scaffold child process; it was terminated and rerun cleanly. The rerun passed.
