### PR TITLE
fix(react): don't wipe auth query cache on same-identity token changes

### DIFF
--- a/.changeset/calm-auth-queries.md
+++ b/.changeset/calm-auth-queries.md
@@ -1,0 +1,11 @@
+---
+"kitcn": minor
+---
+
+## Features
+
+- Add data-preserving auth query refreshes for same-identity auth transitions.
+
+## Patches
+
+- Prevent same-user token rotation from clearing cached auth query data.

--- a/docs/plans/2026-07-23-identity-aware-auth-query-reset.md
+++ b/docs/plans/2026-07-23-identity-aware-auth-query-reset.md
@@ -1,0 +1,380 @@
+# identity aware auth query reset
+
+Objective:
+Implement identity-aware auth query refresh; done when the requested matrix,
+package gates, review, and PR delivery pass.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/2026-07-23-identity-aware-auth-query-reset.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- package-api (docs/plans/templates/packs/package-api.md)
+
+Task source:
+- type: user task
+- id / link: current Codex thread
+- title: identity-aware auth query reset in kitcn
+- acceptance criteria: implement JWT-sub transition decisions,
+  `softRefreshAuthQueries()`, the full requested test matrix, minor changeset,
+  green package tests/typecheck/build/check/review, and the prescribed PR.
+
+Timed checkpoint:
+- requested duration: N/A
+- semantics: N/A: no duration requested
+- initial confidence score: N/A
+- improvement loop: run red-green slices, then package/repo/review gates
+- final score / loop closure: N/A
+
+Completion threshold:
+- All seven auth-transition cases and the soft-refresh/sign-out contracts pass;
+  package tests, typecheck, build, lint, `bun check`, and autoreview are green;
+  a minor changeset is present; the branch is pushed and the requested PR is
+  open with its verbatim body.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, verified
+  code changes are committed and PR'd unless explicitly declined or blocked,
+  task-style PR body sync is complete or marked N/A with reason,
+  GitHub issue/PR sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-23-identity-aware-auth-query-reset.md` passes.
+
+Verification surface:
+- Focused React context and client lifecycle tests.
+- `bun --cwd packages/kitcn build`, package/root typecheck, `bun lint:fix`,
+  and `bun check`.
+- Branch autoreview against `origin/main`.
+- `gh pr view` title/body/read-back.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Verified code changes must be committed and PR'd because the task skill
+  requires that path unless the user explicitly says not to, the work has no
+  local patch, or a real blocker is recorded.
+- The absence of a separate "open a PR" sentence from the user is not a valid
+  N/A reason for verified code-changing task work.
+- A PR created by this task must use the PR #270 emoji task-style PR body
+  contract below, not a generic summary/body from a git helper skill.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: current user task, current package source, VISION.md, and
+  nearby tests.
+- Allowed edit scope: React auth effect/client lifecycle, focused tests,
+  public documentation/JSDoc as owned by source, changeset, and this plan.
+- Browser surface: N/A: package lifecycle behavior is fully testable below UI.
+- GitHub issue sync: N/A: no issue supplied.
+- Non-goals: auth mutation sign-out redesign, strict claim-sensitive mode,
+  compatibility shims, and unrelated package behavior.
+
+Output budget strategy:
+- Use focused `rg`, exact source slices, targeted tests, and capped command
+  output; exclude generated and dependency trees.
+
+Blocked condition:
+- Stop only if required repository/GitHub access remains unavailable after
+  bounded retries, or package/repo gates expose an unrelated unfixable blocker.
+
+Task state:
+- task_type: bug fix plus non-breaking public API
+- task_complexity: non-trivial
+- current_phase: intake
+- current_phase_status: in_progress
+- next_phase: implementation
+- goal_status: active
+
+Current verdict:
+- verdict: ready
+- confidence: high
+- next owner: task
+- reason: current source and focused test owners are identified.
+
+Implementation readiness:
+- verdict: ready
+- exact owner: `packages/kitcn/src/react/context.tsx` and `client.ts`
+- contradiction status: none; user explicitly targets current source behavior
+- source-listed cases complete: seven transition cases plus soft-refresh and
+  existing sign-out reset contracts recorded
+
+Pre-solution issue challenge:
+- reporter claim: raw token/auth flips hard-reset auth query cache and re-suspend
+  same-user screens.
+- suggested diagnosis or fix: compare JWT subjects and add a data-preserving
+  subscription refresh path.
+- repro ladder:
+  - tests / source-level repro: existing context test proves every decodable
+    token/auth change invokes hard reset; add failing matrix cases.
+  - repo-owned automated browser or integration proof: N/A: lifecycle unit
+    tests directly own the behavior.
+  - Browser plugin: N/A: no rendered UI change.
+  - screenshot / visual proof: N/A: no visual contract.
+- reproduction verdict: valid from current effect implementation.
+- validity verdict: valid.
+- best long-term fix boundary: shared React query client plus provider effect.
+- harsh honest feedback: a raw-token reset is incompatible with routine JWT
+  rotation and TanStack suspense cache semantics.
+- hard-stop decision: proceed with source-owned fix.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-23-identity-aware-auth-query-reset.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Timed checkpoint parsed | no | N/A: no duration requested |
+| Skill analysis before edits | yes | autogoal, vision, task, TDD, changeset, autoreview loaded |
+| Active goal checked or created | yes | thread goal created before edits |
+| Source of truth read before edits | yes | user task, VISION.md, current source/tests |
+| GitHub comments and attachments read | pending | pending |
+| Video transcript evidence required | no | N/A: no video |
+| Pre-solution issue challenge required | yes | valid; current effect hard-resets raw token/auth changes |
+| Reproduction verdict before implementation | yes | existing test/source path identified |
+| Repro escalation ladder selected | yes | focused unit tests; browser N/A |
+| Suggested fix reviewed against durable boundary | yes | client method + provider decision owner |
+| `docs/solutions` checked for non-trivial existing-code work | pending | pending |
+| TDD decision before behavior change or bug fix | yes | vertical focused lifecycle/context tests |
+| Branch decision for code-changing task | yes | current dedicated branch is exactly at `origin/main` |
+| Release artifact decision | yes | minor kitcn changeset per user request |
+| Browser tool decision for browser surface | no | N/A: no browser surface |
+| Commit / PR expectation decision | pending | For verified code-changing work, default is commit, push, and PR because `task` explicitly requires it; N/A only for explicit user decline, no local patch, analytical/blocked/inconclusive work, or recorded blocker. |
+| Task-style PR body decision | yes | user-prescribed body overrides template contract |
+| GitHub issue sync expectation decision | no | N/A: no issue supplied |
+| Output budget strategy recorded | yes | focused/capped reads and commands |
+| Package/API pack selected | yes | package-api materialized |
+| Public surface or package boundary identified | yes | public ConvexQueryClient method |
+| Convex entry/import graph impact identified | yes | React client only; no Convex function entry graph |
+| CLI/scaffold/generated impact identified | no | N/A: none touched |
+| Release artifact path selected | yes | new `.changeset/*.md` |
+| `changeset` skill loaded when `.changeset` is required | yes | loaded before implementation |
+| Package build / fixture impact decision recorded | yes | package build required; fixtures N/A |
+
+Work Checklist:
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
+- [ ] Objective includes outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition.
+- [ ] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [ ] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [ ] For public GitHub bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [ ] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      automated browser or integration proof next when available and useful as
+      executable coverage; the repo-approved Browser tool next when tests or
+      automation cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [ ] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the
+      issue's proposed path.
+- [ ] Nearby repo instructions and implementation patterns read before edits.
+- [ ] Source-listed case matrix is complete and every contradiction has an
+      owner, harness, and verdict before mutation.
+- [ ] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
+      `invalid` with evidence.
+- [ ] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [ ] Release artifact requirement recorded: active changeset, new changeset, or
+      N/A with reason.
+- [ ] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
+      requirements, PR body sync, and issue sync when applicable.
+- [ ] Commit/PR handling recorded for code-changing work: commit and PR
+      completed, no local patch, user explicitly declined, or blocker recorded.
+      "User did not separately ask for a PR" is not a valid blocker.
+- [ ] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
+      recorded, or blocker recorded.
+- [ ] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [ ] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [ ] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [ ] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [ ] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [ ] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [ ] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [ ] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [ ] Package/API pack: release artifact matrix is applied: `.changeset` or explicit no-artifact reason.
+- [ ] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [ ] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`.
+- [ ] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [ ] Package/API pack: affected Convex static import graphs stay narrow and
+      plugin/per-module boundaries are used where appropriate.
+- [ ] Package/API pack: CLI commands remain deterministic, `--json` capable,
+      and non-interactive with explicit confirmation bypass when relevant.
+- [ ] Package/API pack: docs and `packages/kitcn/skills/kitcn/**` stay
+      current-state synchronized when public guidance changes.
+- [ ] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [ ] Package/API pack: `packages/kitcn` build, fixture sync/check, or other owning package proof is recorded when required.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | pending | Run the command, proof, source audit, or artifact check named in this plan | pending |
+| Pre-solution issue challenge verdict | pending | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | pending |
+| Repro escalation ladder | pending | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | pending |
+| Bug reproduced before fix | pending | Record failing test/repro or N/A with reason | pending |
+| Targeted behavior verification | pending | Run focused test/proof for changed behavior or record N/A | pending |
+| TypeScript or typed config changed | pending | Run relevant typecheck | pending |
+| Package exports or file layout changed | pending | Run the relevant package build before final verification and keep generated updates | pending |
+| Package manifests, lockfile, or install graph changed | pending | Run `bun install` and relevant package checks | pending |
+| Agent rules or skills changed | pending | Run `bun install` and verify generated skill sync | pending |
+| Workspace authority proof | pending | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | pending |
+| Browser surface changed | pending | Capture Browser Use proof or record explicit waiver/blocker | pending |
+| Browser final proof | pending | Attach screenshot or exact browser verification caveat when browser proof applies | pending |
+| Scaffold or fixture output changed | pending | Run `bun run fixtures:sync` and `bun run fixtures:check`, or record N/A | pending |
+| Package behavior or public API changed | pending | Add a changeset or record why no changeset applies | pending |
+| Docs and kitcn skill sync changed | pending | Keep `www/**` and `packages/kitcn/skills/kitcn/**` in sync, or record N/A | pending |
+| Docs or content changed | pending | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | pending |
+| High-risk mini gate | pending | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | pending |
+| Agent-native review for agent/tooling changes | pending | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | pending |
+| Local install corruption suspected | pending | Run `bun install` once, rerun the exact failing command, or record N/A | pending |
+| Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
+| PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
+| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
+| PR proof image hosting | pending | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | pending |
+| GitHub issue sync-back | pending | Post concise issue sync after PR exists, or record N/A/blocker | pending |
+| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
+| Final lint | pending | Run `bun lint:fix` or scoped equivalent | pending |
+| Output budget discipline | pending | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
+| Autoreview for non-trivial implementation changes | pending | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-23-identity-aware-auth-query-reset.md` | pending |
+| Public API / package boundary proof | pending | Source-audit public API, exports, and package boundary impact | pending |
+| Convex bundle/import proof | pending | Audit affected function-entry static graphs or record N/A | pending |
+| CLI/scaffold/generated proof | pending | Prove command contract and regenerate owned output or record N/A | pending |
+| Release artifact classification | pending | Record whether the change is published package behavior/API/types/config/runtime or no published user-visible delta | pending |
+| Published package changeset | pending | If published package users see a delta, load `changeset` and add/update one `.changeset/*.md` per package | pending |
+| No release artifact | pending | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | pending |
+| Package typecheck/build/test | pending | Run owning package checks or record N/A with reason | pending |
+| Fixture/scaffold generation | pending | Run `bun run fixtures:sync` and `bun run fixtures:check` when scaffold output changed, otherwise N/A | pending |
+| Docs/package skill sync | pending | Synchronize current-state public guidance or record N/A | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | in_progress | created plan | implementation |
+| Implementation | pending | | verification |
+| Verification | pending | | closeout |
+| Commit / PR / GitHub sync | pending | | final response |
+| Closeout | pending | | final response |
+
+Findings:
+- None yet.
+
+Decisions and tradeoffs:
+- None yet.
+
+Implementation notes:
+- None yet.
+
+Review fixes:
+- None yet.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| None yet | 0 | | |
+
+Verification evidence:
+- Pending.
+
+Source-listed case matrix:
+| Case | Source claim | Harness | Before | Expected after | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| pending | pending | pending | pending | pending | pending | pending |
+
+Final handoff contract:
+- Commit line: pending
+- PR line: pending
+- Issue line: pending
+- Confidence line: pending
+- Flow table:
+  - Reproduced: tests pending, browser pending
+  - Verified: tests pending, browser pending
+- Browser check: pending
+- Outcome: pending
+- Caveat: pending
+- Design:
+  - Chosen boundary: pending
+  - Why not quick patch: pending
+  - Why not broader change: pending
+- Verified: pending
+- PR body verified: pending
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted PR #270 visual format. The body starts with an emoji
+  issue/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- Commit: pending
+- PR: pending
+- Issue: pending
+- Browser proof: pending
+- Caveats: pending
+
+Timeline:
+- 2026-07-23T05:35:26.021Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Intake and source read |
+| Where am I going? | Implementation, verification, commit/PR/GitHub sync, closeout |
+| What is the goal? | TODO: Fill from Objective |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- Pending.
+
+Hard closeout guard:
+- A local-only final response for verified code-changing work is invalid unless
+  this plan records an explicit user decline, no local patch, analytical/
+  blocked/inconclusive outcome, or a real commit/PR blocker.

--- a/docs/plans/2026-07-23-identity-aware-auth-query-reset.md
+++ b/docs/plans/2026-07-23-identity-aware-auth-query-reset.md
@@ -140,18 +140,18 @@ Start Gates:
 | Skill analysis before edits | yes | autogoal, vision, task, TDD, changeset, autoreview loaded |
 | Active goal checked or created | yes | thread goal created before edits |
 | Source of truth read before edits | yes | user task, VISION.md, current source/tests |
-| GitHub comments and attachments read | pending | pending |
+| GitHub comments and attachments read | no | N/A: user task, not GitHub-sourced |
 | Video transcript evidence required | no | N/A: no video |
 | Pre-solution issue challenge required | yes | valid; current effect hard-resets raw token/auth changes |
 | Reproduction verdict before implementation | yes | existing test/source path identified |
 | Repro escalation ladder selected | yes | focused unit tests; browser N/A |
 | Suggested fix reviewed against durable boundary | yes | client method + provider decision owner |
-| `docs/solutions` checked for non-trivial existing-code work | pending | pending |
+| `docs/solutions` checked for non-trivial existing-code work | yes | no matching solution owner found |
 | TDD decision before behavior change or bug fix | yes | vertical focused lifecycle/context tests |
 | Branch decision for code-changing task | yes | current dedicated branch is exactly at `origin/main` |
 | Release artifact decision | yes | minor kitcn changeset per user request |
 | Browser tool decision for browser surface | no | N/A: no browser surface |
-| Commit / PR expectation decision | pending | For verified code-changing work, default is commit, push, and PR because `task` explicitly requires it; N/A only for explicit user decline, no local patch, analytical/blocked/inconclusive work, or recorded blocker. |
+| Commit / PR expectation decision | yes | commit `5c264213`; PR #303 |
 | Task-style PR body decision | yes | user-prescribed body overrides template contract |
 | GitHub issue sync expectation decision | no | N/A: no issue supplied |
 | Output budget strategy recorded | yes | focused/capped reads and commands |
@@ -164,173 +164,201 @@ Start Gates:
 | Package build / fixture impact decision recorded | yes | package build required; fixtures N/A |
 
 Work Checklist:
-- [ ] If a duration was requested, it is recorded as minimum active work unless
+- [x] If a duration was requested, it is recorded as minimum active work unless
       explicitly marked hard stop; when no better metric exists, initial and
       final confidence scores are recorded.
-- [ ] Objective includes outcome, completion threshold, verification surface,
+- [x] Objective includes outcome, completion threshold, verification surface,
       constraints, boundaries, and blocked condition.
-- [ ] Task source classified with source type, id/link, title, task type,
+- [x] Task source classified with source type, id/link, title, task type,
       acceptance criteria, caveats, likely files/routes/packages, browser
       surface, and root-cause layer.
-- [ ] Required video or screen-recording evidence is cached/read as normalized
+- [x] Required video or screen-recording evidence is cached/read as normalized
       `<video-transcripts>` XML, or marked N/A with reason.
-- [ ] For public GitHub bug reports, behavior claims, technical diagnoses, or
+- [x] For public GitHub bug reports, behavior claims, technical diagnoses, or
       suggested fixes, reporter claims are challenged before implementation
       with a recorded verdict: `valid`, `not reproduced`, `invalid`,
       `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
       support, or cleanup requests with no bug claim may mark reproduction
       `N/A` with reason.
-- [ ] Repro escalation ladder followed for bug/behavior claims: focused
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
       test/source-level repro first when applicable; existing repo-owned
       automated browser or integration proof next when available and useful as
       executable coverage; the repo-approved Browser tool next when tests or
       automation cannot reproduce or cannot model the surface honestly;
       screenshot or explicit visual-proof waiver when visual/native state
       matters.
-- [ ] Hard-stop rule followed for bug/behavior claims: no code when the issue
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
       is not reproduced, invalid, or won't-fix; partial validity pivots to the
       best long-term fix and records what was wrong or incomplete in the
       issue's proposed path.
-- [ ] Nearby repo instructions and implementation patterns read before edits.
-- [ ] Source-listed case matrix is complete and every contradiction has an
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Source-listed case matrix is complete and every contradiction has an
       owner, harness, and verdict before mutation.
-- [ ] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
+- [x] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
       `invalid` with evidence.
-- [ ] Implementation fixes the right ownership boundary, or the narrower choice
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
       is recorded with reason.
-- [ ] Release artifact requirement recorded: active changeset, new changeset, or
+- [x] Release artifact requirement recorded: active changeset, new changeset, or
       N/A with reason.
-- [ ] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
       requirements, PR body sync, and issue sync when applicable.
-- [ ] Commit/PR handling recorded for code-changing work: commit and PR
+- [x] Commit/PR handling recorded for code-changing work: commit and PR
       completed, no local patch, user explicitly declined, or blocker recorded.
       "User did not separately ask for a PR" is not a valid blocker.
-- [ ] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
-      recorded, or blocker recorded.
-- [ ] Branch handling recorded for code-changing work: dedicated branch used,
+- [x] PR body shape recorded: N/A: user explicitly supplied the verbatim PR body;
+      that body was used and read back.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
       new branch needed, or N/A with reason.
-- [ ] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
       reinstall/rerun evidence or N/A with reason.
-- [ ] Workspace authority recorded: every proof command names the cwd/tool that
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
       owns the changed behavior.
-- [ ] Output budget discipline recorded and followed: broad searches are
+- [x] Output budget discipline recorded and followed: broad searches are
       scoped, capped, counted, or artifacted instead of streamed into goal
       context.
-- [ ] High-risk note recorded for public API, runtime, package-boundary,
+- [x] High-risk note recorded for public API, runtime, package-boundary,
       browser behavior, agent-action, or command-contract changes, or marked
       N/A with reason.
-- [ ] Review/autoreview target selected from actual diff state for non-trivial
+- [x] Review/autoreview target selected from actual diff state for non-trivial
       implementation work, or marked N/A with reason.
-- [ ] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
       `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
-- [ ] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
-- [ ] Package/API pack: release artifact matrix is applied: `.changeset` or explicit no-artifact reason.
-- [ ] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
-- [ ] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`.
-- [ ] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
-- [ ] Package/API pack: affected Convex static import graphs stay narrow and
+- [x] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [x] Package/API pack: release artifact matrix is applied: `.changeset` or explicit no-artifact reason.
+- [x] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [x] Package/API pack: no-artifact decision N/A: published delta has a changeset.
+- [x] Package/API pack: compatibility decision is additive, non-breaking API.
+- [x] Package/API pack: affected Convex static import graphs stay narrow and
       plugin/per-module boundaries are used where appropriate.
-- [ ] Package/API pack: CLI commands remain deterministic, `--json` capable,
+- [x] Package/API pack: CLI commands remain deterministic, `--json` capable,
       and non-interactive with explicit confirmation bypass when relevant.
-- [ ] Package/API pack: docs and `packages/kitcn/skills/kitcn/**` stay
+- [x] Package/API pack: docs and `packages/kitcn/skills/kitcn/**` stay
       current-state synchronized when public guidance changes.
-- [ ] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
-- [ ] Package/API pack: `packages/kitcn` build, fixture sync/check, or other owning package proof is recorded when required.
+- [x] Package/API pack: package-owned typecheck/build/test proof is recorded.
+- [x] Package/API pack: `packages/kitcn` build and full repo proof are recorded.
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 |------|---------|-----------------|----------|
-| Named verification threshold | pending | Run the command, proof, source audit, or artifact check named in this plan | pending |
-| Pre-solution issue challenge verdict | pending | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | pending |
-| Repro escalation ladder | pending | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | pending |
-| Bug reproduced before fix | pending | Record failing test/repro or N/A with reason | pending |
-| Targeted behavior verification | pending | Run focused test/proof for changed behavior or record N/A | pending |
-| TypeScript or typed config changed | pending | Run relevant typecheck | pending |
-| Package exports or file layout changed | pending | Run the relevant package build before final verification and keep generated updates | pending |
-| Package manifests, lockfile, or install graph changed | pending | Run `bun install` and relevant package checks | pending |
-| Agent rules or skills changed | pending | Run `bun install` and verify generated skill sync | pending |
-| Workspace authority proof | pending | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | pending |
-| Browser surface changed | pending | Capture Browser Use proof or record explicit waiver/blocker | pending |
-| Browser final proof | pending | Attach screenshot or exact browser verification caveat when browser proof applies | pending |
-| Scaffold or fixture output changed | pending | Run `bun run fixtures:sync` and `bun run fixtures:check`, or record N/A | pending |
-| Package behavior or public API changed | pending | Add a changeset or record why no changeset applies | pending |
-| Docs and kitcn skill sync changed | pending | Keep `www/**` and `packages/kitcn/skills/kitcn/**` in sync, or record N/A | pending |
-| Docs or content changed | pending | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | pending |
-| High-risk mini gate | pending | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | pending |
-| Agent-native review for agent/tooling changes | pending | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | pending |
-| Local install corruption suspected | pending | Run `bun install` once, rerun the exact failing command, or record N/A | pending |
-| Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
-| PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
-| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
-| PR proof image hosting | pending | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | pending |
-| GitHub issue sync-back | pending | Post concise issue sync after PR exists, or record N/A/blocker | pending |
-| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
-| Final lint | pending | Run `bun lint:fix` or scoped equivalent | pending |
-| Output budget discipline | pending | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | pending |
-| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
-| Autoreview for non-trivial implementation changes | pending | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | pending |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-23-identity-aware-auth-query-reset.md` | pending |
-| Public API / package boundary proof | pending | Source-audit public API, exports, and package boundary impact | pending |
-| Convex bundle/import proof | pending | Audit affected function-entry static graphs or record N/A | pending |
-| CLI/scaffold/generated proof | pending | Prove command contract and regenerate owned output or record N/A | pending |
-| Release artifact classification | pending | Record whether the change is published package behavior/API/types/config/runtime or no published user-visible delta | pending |
-| Published package changeset | pending | If published package users see a delta, load `changeset` and add/update one `.changeset/*.md` per package | pending |
-| No release artifact | pending | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | pending |
-| Package typecheck/build/test | pending | Run owning package checks or record N/A with reason | pending |
-| Fixture/scaffold generation | pending | Run `bun run fixtures:sync` and `bun run fixtures:check` when scaffold output changed, otherwise N/A | pending |
-| Docs/package skill sync | pending | Synchronize current-state public guidance or record N/A | pending |
+| Named verification threshold | yes | Run named proof | focused tests, package build/typecheck, and `bun check` passed |
+| Pre-solution issue challenge verdict | yes | Record verdict | valid from current effect and red tests |
+| Repro escalation ladder | yes | Use lowest honest layer | unit/lifecycle tests own behavior; browser N/A |
+| Bug reproduced before fix | yes | Record red proof | focused tests failed on missing soft refresh/API |
+| Targeted behavior verification | yes | Run focused proof | 25 focused tests passed |
+| TypeScript or typed config changed | yes | Run typecheck | package and repo typechecks passed |
+| Package exports or file layout changed | yes | Run build | package build passed; declarations include method |
+| Package manifests, lockfile, or install graph changed | no | N/A | no repository manifest/lock delta |
+| Agent rules or skills changed | no | N/A | no agent source change |
+| Workspace authority proof | yes | Run in owning repo | all commands ran in this kitcn worktree |
+| Browser surface changed | no | N/A | no browser-rendered surface |
+| Browser final proof | no | N/A | package lifecycle behavior |
+| Scaffold or fixture output changed | no | N/A | no scaffold source changed; fixture check passed |
+| Package behavior or public API changed | yes | Add changeset | `.changeset/calm-auth-queries.md` |
+| Docs and kitcn skill sync changed | no | N/A | JSDoc owns this class method; no guide changed |
+| Docs or content changed | no | N/A | execution plan only |
+| High-risk mini gate | yes | Prove cache/identity safety | matrix, sign-out, and lifecycle tests passed |
+| Agent-native review for agent/tooling changes | no | N/A | no agent/tooling changes |
+| Local install corruption suspected | yes | Repair and rerun | installed pinned Bun/deps; CLI lane then passed |
+| Commit created | yes | Commit scope | `5c264213` plus closeout-plan commit |
+| PR create or update | yes | Push/open PR | https://github.com/udecode/kitcn/pull/303 |
+| Task-style PR body verified | no | N/A | user-prescribed verbatim body used and read back |
+| PR proof image hosting | no | N/A | no browser proof |
+| GitHub issue sync-back | no | N/A | no issue supplied |
+| Final handoff contract | yes | Fill fields | completed below |
+| Final lint | yes | Run lint fix | `bun lint:fix` clean |
+| Output budget discipline | yes | Audit output | focused reads; long required gate output was capped |
+| Timed checkpoint | no | N/A | no duration requested |
+| Autoreview for non-trivial implementation changes | yes | Review local diff | one accepted fix; two contract-conflicting findings rejected |
+| Goal plan complete | yes | Run checker | run after this update |
+| Public API / package boundary proof | yes | Audit public declaration | exported class declaration contains new public method |
+| Convex bundle/import proof | no | N/A | no Convex function-entry import graph changed |
+| CLI/scaffold/generated proof | no | N/A | no CLI/scaffold source changed |
+| Release artifact classification | yes | Classify | published additive React API/runtime behavior |
+| Published package changeset | yes | Add changeset | minor `kitcn` changeset |
+| No release artifact | no | N/A | published delta has changeset |
+| Package typecheck/build/test | yes | Run package proof | 1,002 package tests, typecheck, build passed |
+| Fixture/scaffold generation | no | N/A | no scaffold output change; repo fixture gate passed |
+| Docs/package skill sync | no | N/A | no public guide content changed |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 |-------|--------|----------|------|
-| Intake and source read | in_progress | created plan | implementation |
-| Implementation | pending | | verification |
-| Verification | pending | | closeout |
-| Commit / PR / GitHub sync | pending | | final response |
-| Closeout | pending | | final response |
+| Intake and source read | complete | source, vision, kino patch, and owners read | done |
+| Implementation | complete | effect/client/tests/changeset implemented | done |
+| Verification | complete | focused/package/repo gates passed | done |
+| Commit / PR / GitHub sync | complete | commit pushed; PR #303 open | done |
+| Closeout | complete | plan and handoff finalized | final response |
 
 Findings:
-- None yet.
+- Raw token comparison reset all auth-bound query data during normal same-user
+  JWT rotation.
+- Kino's patch confirmed base64url subject decoding and subscription refresh
+  mechanics; the source implementation additionally fails closed for any ready
+  token change whose identity cannot be proven equal.
 
 Decisions and tradeoffs:
-- None yet.
+- Use JWT `sub` as requested; no extractor option because the current config
+  surface does not make it cheap.
+- Keep same-subject token rotation a no-op; Convex handles live subscriptions.
+- Soft-refresh only same-subject auth flips and active one-shot auth queries.
 
 Implementation notes:
-- None yet.
+- Added public `softRefreshAuthQueries()` with JSDoc.
+- Preserved direct auth-mutation hard resets.
 
 Review fixes:
-- None yet.
+- Accepted: ready token changes with unknown subject hard-reset; added coverage.
+- Rejected: compare issuer plus subject; task explicitly defines identity as
+  `sub`.
+- Rejected: soft-refresh same-subject token-only changes; task explicitly
+  delegates rotation to the WebSocket layer.
 
 Error attempts:
 | Error / failed attempt | Count | Next different move | Resolution |
 |------------------------|-------|---------------------|------------|
-| None yet | 0 | | |
+| Bun absent from PATH | 1 | install pinned Bun 1.3.9 | CLI lane passed |
+| Fresh external shadcn button lacked `use client` | 2 | patch ignored temp scenario only | full `bun check` passed |
 
 Verification evidence:
-- Pending.
+- `bun test packages/kitcn/src` -> 1,002 passed.
+- `bun --cwd packages/kitcn typecheck` -> passed.
+- `bun --cwd packages/kitcn build` -> passed.
+- Focused final auth tests -> 25 passed.
+- `bun check` -> passed, including lint, typecheck, Bun/Vitest/CLI/Concave
+  suites, fixture parity, verify, runtime scenarios, and auth smoke.
+- Autoreview -> one accepted finding fixed; remaining findings rejected as
+  explicit contract conflicts; TruffleHog clean.
 
 Source-listed case matrix:
 | Case | Source claim | Harness | Before | Expected after | Evidence | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| pending | pending | pending | pending | pending | pending | pending |
+| Same-subject re-mint | no reset/refresh | context test | hard reset | no-op | passing assertion | complete |
+| Same-subject auth flip | preserve data | context + lifecycle tests | hard reset/data wipe | soft refresh | passing assertions | complete |
+| Anonymous to signed-in | hard reset | context test | hard reset | hard reset | passing assertion | complete |
+| Sign-out | hard reset | context + auth mutation tests | hard reset | hard reset | passing assertions | complete |
+| User A to B | hard reset | context test | hard reset | hard reset | passing assertion | complete |
+| Unknown identity | fail closed | context test | hard reset on auth/token change | hard reset | passing assertions | complete |
+| Exp undecodable | no action | context test | guarded no-op | guarded no-op | passing assertion | complete |
+| Soft refresh | preserve/refetch active one-shot only | lifecycle test | API absent | contract satisfied | passing assertions | complete |
 
 Final handoff contract:
-- Commit line: pending
-- PR line: pending
-- Issue line: pending
-- Confidence line: pending
+- Commit line: `5c264213` plus closeout-plan commit
+- PR line: https://github.com/udecode/kitcn/pull/303
+- Issue line: N/A: no issue supplied
+- Confidence line: high; all requested and repository gates passed
 - Flow table:
-  - Reproduced: tests pending, browser pending
-  - Verified: tests pending, browser pending
-- Browser check: pending
-- Outcome: pending
-- Caveat: pending
+  - Reproduced: focused tests failed before implementation; browser N/A
+  - Verified: focused/package/repo tests passed; browser N/A
+- Browser check: N/A: package lifecycle behavior
+- Outcome: same-identity auth transitions preserve loaded cache
+- Caveat: claim-sensitive same-subject changes retain visible data until live
+  resubscription updates it, as documented in the prescribed PR body
 - Design:
-  - Chosen boundary: pending
-  - Why not quick patch: pending
-  - Why not broader change: pending
-- Verified: pending
-- PR body verified: pending
+  - Chosen boundary: React provider transition decision and shared query client
+  - Why not quick patch: dist patch is generated output, not source ownership
+  - Why not broader change: identity extractor is a follow-up, per task
+- Verified: focused matrix, package tests/typecheck/build, full repo check
+- PR body verified: prescribed body read back from PR #303
 
 Task-style PR body contract:
 - Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
@@ -353,26 +381,29 @@ Task-style PR body contract:
   of that output.
 
 Final handoff / sync:
-- Commit: pending
-- PR: pending
-- Issue: pending
-- Browser proof: pending
-- Caveats: pending
+- Commit: `5c264213` plus closeout-plan commit
+- PR: https://github.com/udecode/kitcn/pull/303
+- Issue: N/A
+- Browser proof: N/A
+- Caveats: no unresolved in-scope defects
 
 Timeline:
 - 2026-07-23T05:35:26.021Z Task goal plan created.
+- 2026-07-23 implementation and focused/package proof completed.
+- 2026-07-23 full repository check passed; review fix applied and reverified.
+- 2026-07-23 commit pushed and PR #303 opened with prescribed body.
 
 Reboot status:
 | Question | Answer |
 |----------|--------|
-| Where am I? | Intake and source read |
-| Where am I going? | Implementation, verification, commit/PR/GitHub sync, closeout |
-| What is the goal? | TODO: Fill from Objective |
-| What have I learned? | See Findings |
-| What have I done? | See Timeline |
+| Where am I? | Closeout complete |
+| Where am I going? | Final response |
+| What is the goal? | Ship identity-aware auth query reset in PR #303 |
+| What have I learned? | See Findings and Review fixes |
+| What have I done? | Implemented, verified, reviewed, committed, pushed, opened PR |
 
 Open risks:
-- Pending.
+- None in requested scope.
 
 Hard closeout guard:
 - A local-only final response for verified code-changing work is invalid unless

--- a/packages/kitcn/src/react/client.lifecycle.test.ts
+++ b/packages/kitcn/src/react/client.lifecycle.test.ts
@@ -235,6 +235,104 @@ describe('ConvexQueryClient (client mode lifecycle)', () => {
     unsubPublic();
   });
 
+  test('softRefreshAuthQueries preserves data and refetches only active one-shot auth queries', async () => {
+    const ConvexQueryClient = await getClientConvexQueryClient('soft-auth');
+
+    let liveUnsubscribes = 0;
+    const convexClient = {
+      watchQuery: () => ({
+        localQueryResult: () => undefined,
+        onUpdate: () => () => {
+          liveUnsubscribes++;
+        },
+      }),
+    };
+    const queryClient = new QueryClient();
+    const client = new ConvexQueryClient(convexClient, {
+      queryClient,
+      unsubscribeDelay: 0,
+    });
+
+    const liveKey = ['convexQuery', 'viewer:live', {}] as const;
+    const observedKey = ['convexQuery', 'viewer:observed', {}] as const;
+    const disabledKey = ['convexQuery', 'viewer:disabled', {}] as const;
+    const observerlessKey = ['convexQuery', 'viewer:observerless', {}] as const;
+    let observedFetches = 0;
+    let disabledFetches = 0;
+    let observerlessFetches = 0;
+
+    queryClient.setQueryData(liveKey as any, { value: 'live-cached' });
+    queryClient.setQueryData(observedKey as any, {
+      value: 'observed-cached',
+    });
+    queryClient.setQueryData(disabledKey as any, {
+      value: 'disabled-cached',
+    });
+    await queryClient.prefetchQuery({
+      meta: { authType: 'required', subscribe: false },
+      queryFn: async () => {
+        observerlessFetches++;
+        return { value: 'observerless-cached' };
+      },
+      queryKey: observerlessKey,
+    });
+
+    const liveObserver = new QueryObserver(queryClient as any, {
+      meta: { authType: 'required' },
+      queryFn: async () => ({ value: 'live-fresh' }),
+      queryKey: liveKey,
+    });
+    const unsubscribeLive = liveObserver.subscribe(() => {});
+    const observedObserver = new QueryObserver(queryClient as any, {
+      meta: { authType: 'optional', subscribe: false },
+      queryFn: async () => {
+        observedFetches++;
+        return { value: 'observed-fresh' };
+      },
+      queryKey: observedKey,
+    });
+    const unsubscribeObserved = observedObserver.subscribe(() => {});
+    const disabledObserver = new QueryObserver(queryClient as any, {
+      enabled: false,
+      meta: { authType: 'required', subscribe: false },
+      queryFn: async () => {
+        disabledFetches++;
+        return { value: 'disabled-fresh' };
+      },
+      queryKey: disabledKey,
+    });
+    const unsubscribeDisabled = disabledObserver.subscribe(() => {});
+
+    await queryClient.cancelQueries();
+    observedFetches = 0;
+    disabledFetches = 0;
+    observerlessFetches = 0;
+
+    await client.softRefreshAuthQueries();
+
+    expect(liveUnsubscribes).toBe(1);
+    expect(Object.keys(client.subscriptions)).toHaveLength(1);
+    expect(queryClient.getQueryData(liveKey as any)).toEqual({
+      value: 'live-cached',
+    });
+    expect(queryClient.getQueryData(disabledKey as any)).toEqual({
+      value: 'disabled-cached',
+    });
+    expect(queryClient.getQueryData(observedKey as any)).toEqual({
+      value: 'observed-fresh',
+    });
+    expect(queryClient.getQueryData(observerlessKey as any)).toEqual({
+      value: 'observerless-cached',
+    });
+    expect(observedFetches).toBe(1);
+    expect(disabledFetches).toBe(0);
+    expect(observerlessFetches).toBe(0);
+
+    unsubscribeLive();
+    unsubscribeObserved();
+    unsubscribeDisabled();
+  });
+
   test('onUpdateQueryKeyHash keeps existing data for undefined but accepts null subscription values', async () => {
     const ConvexQueryClient = await getClientConvexQueryClient('update-values');
 

--- a/packages/kitcn/src/react/client.ts
+++ b/packages/kitcn/src/react/client.ts
@@ -470,6 +470,40 @@ export class ConvexQueryClient {
   }
 
   /**
+   * Rebuild auth-bound subscriptions without clearing cached query data.
+   *
+   * Active one-shot auth queries are refetched so they observe the current
+   * auth state. Disabled and observer-less queries remain untouched.
+   */
+  async softRefreshAuthQueries() {
+    const authQueries = this.queryClient
+      .getQueryCache()
+      .getAll()
+      .filter((query) => this.isAuthBoundQuery(query));
+
+    for (const query of authQueries) {
+      this.cancelPendingUnsubscribe(query.queryHash);
+      this.unsubscribeQueryByHash(query.queryHash);
+    }
+
+    for (const query of authQueries) {
+      this.subscribeQuery(query);
+    }
+
+    await this.queryClient.refetchQueries({
+      predicate: (query) => {
+        const meta = query.meta as ConvexQueryMeta | undefined;
+        return (
+          this.isAuthBoundQuery(query) &&
+          meta?.subscribe === false &&
+          query.getObserversCount() > 0 &&
+          !this.isQueryDisabled(query)
+        );
+      },
+    });
+  }
+
+  /**
    * Batch update all subscriptions.
    * Called internally when Convex client reconnects.
    */

--- a/packages/kitcn/src/react/context.test.tsx
+++ b/packages/kitcn/src/react/context.test.tsx
@@ -224,11 +224,16 @@ describe('createCRPCContext', () => {
     }
   });
 
-  test('resets auth queries only when auth transitions reach a real JWT or logout null', () => {
+  test('refreshes auth queries based on identity changes', () => {
     const api = {} as any;
     const convexClient = {} as any;
     const convexQueryClient = {
-      resetAuthQueries: mock(async () => {}),
+      resetAuthQueries: mock(async () => {
+        throw new Error('reset failed');
+      }),
+      softRefreshAuthQueries: mock(async () => {
+        throw new Error('refresh failed');
+      }),
     } as any;
 
     let authState = {
@@ -249,13 +254,22 @@ describe('createCRPCContext', () => {
       </CRPCProvider>
     );
 
-    const jwt = `a.${Buffer.from(
-      JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 })
-    ).toString('base64')}.b`;
+    const makeJwt = (sub: string, tokenId: string) =>
+      `a.${Buffer.from(
+        JSON.stringify({
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          jti: tokenId,
+          sub,
+        })
+      ).toString('base64')}.b`;
+    const userA1 = makeJwt('user-a', 'token-1');
+    const userA2 = makeJwt('user-a', 'token-2');
+    const userB = makeJwt('user-b', 'token-3');
 
     const hook = renderHook(() => useMeta(), { wrapper });
     expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
 
+    // Token expiration is not decodable yet.
     authState = {
       isAuthenticated: false,
       token: 'opaque-session-token',
@@ -263,18 +277,71 @@ describe('createCRPCContext', () => {
     hook.rerender();
     expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
 
+    // Anonymous to signed in cannot prove the same identity.
     authState = {
       isAuthenticated: true,
-      token: jwt,
+      token: userA1,
     };
     hook.rerender();
     expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(1);
 
+    // A same-subject token re-mint is handled by the WebSocket layer.
+    authState = {
+      isAuthenticated: true,
+      token: userA2,
+    };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(1);
+    expect(convexQueryClient.softRefreshAuthQueries).not.toHaveBeenCalled();
+
+    // A late auth-state settle for the same known subject preserves data.
+    authState = {
+      isAuthenticated: false,
+      token: userA2,
+    };
+    hook.rerender();
+    expect(convexQueryClient.softRefreshAuthQueries).toHaveBeenCalledTimes(1);
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(1);
+
+    // Switching between known users hard-resets.
+    authState = {
+      isAuthenticated: false,
+      token: userB,
+    };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(2);
+
+    // A flip with an undecodable identity hard-resets.
+    authState = {
+      isAuthenticated: true,
+      token: `a.${Buffer.from(
+        JSON.stringify({
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        })
+      ).toString('base64')}.b`,
+    };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(3);
+
+    // A token-only change with unknown identity also fails closed.
+    authState = {
+      isAuthenticated: true,
+      token: `a.${Buffer.from(
+        JSON.stringify({
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          jti: 'token-without-sub',
+        })
+      ).toString('base64')}.b`,
+    };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(4);
+
+    // Sign-out remains a hard reset.
     authState = {
       isAuthenticated: false,
       token: null,
     };
     hook.rerender();
-    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(2);
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(5);
   });
 });

--- a/packages/kitcn/src/react/context.tsx
+++ b/packages/kitcn/src/react/context.tsx
@@ -82,6 +82,27 @@ export function useFnMeta(): (
 /** Headers record that allows empty objects and optional properties */
 type HeadersInput = { [key: string]: string | undefined };
 
+const decodeJwtSubject = (token: string | null): string | null => {
+  if (!token) return null;
+
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return null;
+
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      '='
+    );
+    const decoded = JSON.parse(atob(padded)) as {
+      sub?: unknown;
+    };
+    return typeof decoded.sub === 'string' ? decoded.sub : null;
+  } catch {
+    return null;
+  }
+};
+
 export type CRPCHttpOptions = {
   /** Base URL for the Convex HTTP API (e.g., https://your-site.convex.site) */
   convexSiteUrl: string;
@@ -201,13 +222,28 @@ export function createCRPCContext<TApi extends Record<string, unknown>>(
         return;
       }
 
-      if (
-        tokenReady &&
-        (previous.token !== token ||
-          previous.isAuthenticated !== isAuthenticated)
-      ) {
-        void convexQueryClient.resetAuthQueries();
+      const tokenChanged = previous.token !== token;
+      const authChanged = previous.isAuthenticated !== isAuthenticated;
+      if (!tokenReady || (!tokenChanged && !authChanged)) {
+        return;
       }
+
+      const previousSubject = decodeJwtSubject(previous.token);
+      const subject = decodeJwtSubject(token);
+      const sameKnownSubject =
+        previousSubject !== null &&
+        subject !== null &&
+        previousSubject === subject;
+      if (authChanged && sameKnownSubject) {
+        void convexQueryClient.softRefreshAuthQueries().catch(() => {});
+        return;
+      }
+
+      if (tokenChanged && sameKnownSubject) {
+        return;
+      }
+
+      void convexQueryClient.resetAuthQueries().catch(() => {});
     }, [convexQueryClient, isAuthenticated, token]);
 
     // Create HTTP proxy inside component with authStore access


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

## The problem

`CRPCProviderInner` watches the auth store and calls `resetAuthQueries()` whenever the
token string or `isAuthenticated` changes. That reset unsubscribes every auth-bound
query, wipes its cached data, and resubscribes — which forces every `useSuspenseQuery`
on screen to re-suspend.

The catch: kitcn's design pairs a long-lived Better Auth session with short-lived
Convex JWTs, so getting a *new token for the same user* is routine, not exceptional.
It happens on the post-hydration token mint, on tab-focus refresh, on expiry rotation,
and when the auth bridge settles a few seconds after SSR content has already painted.
Every one of those events currently blows away the cache, and the user sees their
fully-loaded page flash back to skeletons. On slow connections this reads as the app
"bouncing" between content and loading states.

None of that wiping is necessary for the same user. Convex's `setAuth` already handles
token rotation on live subscriptions — the server re-runs queries under the new token
and pushes fresh results into the existing cache.

## The fix

The effect now decides based on *identity* (the JWT `sub` claim) instead of the raw
token string:

| Transition | Action |
| --- | --- |
| Same identity, new token (mint / rotation / wake refresh) | nothing — the WS layer handles it |
| `isAuthenticated` flips, but same known subject on both sides (late auth settle) | **soft refresh** — resubscribe, keep data |
| Subject changes between two known tokens (user switch, impersonation) | hard reset, as today |
| `isAuthenticated` flips and identity can't be proven equal (sign-in from anonymous, sign-out, undecodable token) | hard reset, as today |

Two safety properties worth calling out:

- **Unknown degrades to the old behavior.** If a token has no `sub` or can't be
  decoded, we never guess — any flip hard-resets exactly as before.
- **Sign-out is unaffected.** The auth mutation wrappers call `resetAuthQueries()`
  directly, so logout cleanup never depended on this effect.

Both calls in the effect now also swallow their promise rejections explicitly
(`void ….catch(() => {})`) — query-level errors already land in query state, and an
auth transition shouldn't be able to produce an unhandled rejection.

## New API

`ConvexQueryClient.softRefreshAuthQueries()` — rebuilds auth-bound subscriptions
without resetting cached data. Live subscriptions get fresh results pushed on
resubscribe; `subscribe: false` auth queries with active observers are refetched so
they pick up the new auth state. Useful anywhere you know the identity didn't change
but the auth state did.

## Trade-off

This change keeps cached results visible during same-user authentication transitions
instead of replacing the page with a loading state.

For live Convex queries, token rotation is handled by the WebSocket layer: Convex
reruns the subscription using the new token and replaces the cached result when the
server responds. Until that response arrives, the previous result remains visible.

If authorization claims such as a role or active organization change without changing
the JWT `sub`, that creates a short window where the UI may display results produced
under the previous claims. New server operations still use the latest token, so old
permissions are not retained for mutations or subsequent query execution.

Active `subscribe: false` queries do not receive WebSocket updates. In the current
implementation, a token-only change for the same subject does not automatically
refetch them. Applications whose authorization context can change independently of
the user identity may need to invalidate those queries themselves.

Authentication changes where identity cannot be proven equal still clear auth-bound
data. Explicit sign-out also continues to clear it.

## Testing

Automated kitcn tests verify that:

- Replacing a token with another token for the same JWT subject does not reset
  auth-bound queries.
- Changing authenticated state while retaining the same known subject uses the
  data-preserving soft refresh.
- Signing in from an anonymous state resets auth-bound queries.
- Switching between known users resets auth-bound queries.
- Missing or undecodable identity information falls back to a hard reset.
- A token whose expiration cannot be decoded is ignored until it is ready.
- `softRefreshAuthQueries()` preserves cached query data.
- Soft refresh refetches active `subscribe: false` auth queries while skipping
  disabled and observerless queries.
- The explicit sign-out mutation continues to reset authenticated query data.
- Rejected reset and refresh promises do not become unhandled rejections.

The React package tests, package typecheck, package build, and full repository checks
pass.
