### PR TITLE
Fix auth adapter runtime parity

### DIFF
--- a/.changeset/calm-auth-pagination.md
+++ b/.changeset/calm-auth-pagination.md
@@ -1,0 +1,8 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix unbounded auth queries hanging after 200 rows.
+- Prevent action contexts from exposing mutation-only transaction options.

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "bun-types": "^1.3.9",
         "concurrently": "^9.2.1",
         "convex-test": "^0.0.41",
+        "convex-type-test": "npm:convex@1.42.3",
         "eslint": "10.0.2",
         "eslint-plugin-react-hooks": "7.0.1",
         "fast-check": "^4.5.3",
@@ -1295,6 +1296,8 @@
 
     "convex-test": ["convex-test@0.0.41", "", { "peerDependencies": { "convex": "^1.16.4" } }, "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ=="],
 
+    "convex-type-test": ["convex@1.42.3", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-7Tz/lH6UlZdiqzLPF/zrlH6Rlo/DOp836dL+GZkUMEQ2jaGGNnBIiIDcOOiEqtfSehuQ65r/rdNMnb4LupowaA=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-es": ["cookie-es@2.0.1", "", {}, "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA=="],
@@ -2405,7 +2408,7 @@
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "www": ["www@workspace:www"],
 
@@ -2751,6 +2754,10 @@
 
     "convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
+    "convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "convex-type-test/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
     "copy-anything/is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
@@ -2800,6 +2807,8 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "msw/path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -2929,13 +2938,23 @@
 
     "@concavejs/core/convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
+    "@concavejs/core/convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "@concavejs/docstore-bun-sqlite/convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "@concavejs/docstore-bun-sqlite/convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "@concavejs/docstore-sqlite-base/convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
+    "@concavejs/docstore-sqlite-base/convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "@concavejs/runtime-base/convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
+    "@concavejs/runtime-base/convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "@concavejs/runtime-bun/convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "@concavejs/runtime-bun/convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -2970,6 +2989,58 @@
     "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.2", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.2", "@babel/helper-validator-identifier": "^8.0.0-rc.2" } }, "sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw=="],
 
     "conf/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "convex-type-test/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "convex-type-test/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "convex-type-test/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "convex-type-test/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "convex-type-test/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "convex-type-test/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "convex-type-test/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "convex-type-test/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "convex-type-test/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "convex-type-test/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "convex-type-test/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "convex-type-test/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "convex-type-test/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "convex-type-test/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "convex-type-test/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "convex-type-test/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "convex-type-test/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "convex-type-test/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
 
     "convex/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
 

--- a/docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
+++ b/docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
@@ -36,9 +36,9 @@ Timed checkpoint:
 - semantics: N/A: no timed request
 - initial confidence score: 95%
 - improvement loop: red-green each source-listed case, then full verification
-- final score / loop closure: 100%; the autoreview finding is repaired, all
-  repeated local gates pass, final rereview is clean, and authoritative GitHub
-  checks pass
+- final score / loop closure: 99%; implementation-head checks passed, but the
+  closeout head hit a Vercel `git_info_fail` before build startup and requires a
+  fresh deployment attempt
 
 Completion threshold:
 - Both source-listed cases fail before their fix and pass after it against the
@@ -110,9 +110,10 @@ Task state:
 - task_type: package runtime and type compatibility bugfix
 - task_complexity: non-trivial measurable
 - current_phase: closeout
-- current_phase_status: local and authoritative remote checks green
-- next_phase: validate plans and push closeout evidence
-- goal_status: ready for completion after plan validation and closeout push
+- current_phase_status: closeout-head Vercel retry required
+- next_phase: push recorded retry state, wait for fresh remote checks, and
+  revalidate plans
+- goal_status: active until the fresh PR head is green
 
 Current verdict:
 - verdict: valid
@@ -308,7 +309,7 @@ Completion Gates:
 | Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | Broad command output was redirected to temporary logs and tailed; searches and diffs were capped. |
 | Timed checkpoint | no | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | N/A: no duration requested. |
 | Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | Final local rereview: TruffleHog clean, no accepted/actionable findings, patch correct at 0.91. |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` | Final closeout validator exited 0. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` | Prior closeout validator exited 0; rerun after the Vercel retry resolves. |
 | Docs source-backed claim audit | yes | Verify docs claims against current source or record N/A | Internal solution claims match frozen upstream commits, local source, and focused regressions. |
 | Docs links / routes / previews | no | Verify leaf links, routes, anchors, and preview names or record N/A | N/A: no links, routes, anchors, or previews changed. |
 | Docs MDX/content parser | no | Run the relevant `www` docs parser/build for MDX/content changes, or record N/A | N/A: no `www` or MDX content changed. |
@@ -330,7 +331,7 @@ Phase / pass table:
 | Implementation | complete | three red-green cycles at shared owners | done |
 | Verification | complete | review finding repaired with red/green type proof; repeated full `bun check` and final rereview pass | done |
 | Commit / PR / GitHub sync | complete | implementation commit pushed; ready PR #311 open and body verified | remote checks |
-| Closeout | complete | all local gates, final rereview, PR body proof, and authoritative GitHub checks pass | validate plans and push evidence |
+| Closeout | in progress | implementation-head checks passed; closeout head failed before Vercel build startup with `git_info_fail` | push retry evidence and wait for fresh checks |
 
 Findings:
 - The upstream pagination fix maps byte-for-byte to KitCN's shared helper, which
@@ -392,6 +393,7 @@ Error attempts:
 | First type fixture omitted the required `RunMutationCtx` data-model generic | 1 | Use `GenericDataModel` explicitly | Remaining red errors isolated the intended invalid third argument. |
 | Final autoreview proved the type lane was false-green on Convex 1.38 | 1 | Resolve the dedicated lane against a pinned Convex version that exposes mutation-only options and add a positive control | Convex 1.42.3 lane fails on a production revert and passes on the fix. |
 | Normal package typecheck compiled the Convex 1.42-only positive control against Convex 1.38 | 1 | Isolate `*.test-d.ts` to the dedicated config instead of weakening either assertion | Package typecheck and the dedicated Convex 1.42 lane both pass. |
+| Closeout-head Vercel deployment failed at `build-container-init` | 1 | Inspect the deployment owner, then push the recorded external failure to trigger a fresh Git-backed deployment | Vercel reports `git_info_fail` with no build/error log; fresh head required. |
 | First `bun check` failed on `fixtures/next` lucide registry drift | 1 | Use the scenarios-owned target sync/check instead of hand editing | `fixtures/next/package.json` regenerated to `^1.28.0`; targeted check passed. |
 | Second `bun check` failed on the same drift in `fixtures/next-auth` | 1 | Stop before broad fixture expansion and request approval as required by the sync skill | Remaining affected fixtures: `next-auth`, `start`, `start-auth`, `vite`, `vite-auth`. |
 
@@ -489,7 +491,9 @@ Final handoff / sync:
 - PR: `https://github.com/udecode/kitcn/pull/311`
 - Issue: N/A: upstream sync task, no KitCN issue
 - Browser proof: N/A: no browser surface
-- Caveats: browser proof is N/A; CI, Vercel, and release-policy checks pass.
+- Caveats: implementation-head CI, Vercel, and release-policy checks passed;
+  the closeout head needs a fresh Vercel attempt after pre-build
+  `git_info_fail`.
 
 Timeline:
 - 2026-07-30T12:05:36.311Z Task goal plan created.
@@ -520,6 +524,9 @@ Timeline:
 - 2026-07-30T15:30:00+0200 Authoritative GitHub CI passed in 8m34s; Vercel and
   release-policy checks are also green.
 - 2026-07-30T15:31:00+0200 Final child and parent goal validators exited 0.
+- 2026-07-30T15:33:00+0200 Closeout-head Vercel failed at
+  `build-container-init` with `git_info_fail` and no build logs; recorded the
+  external failure before triggering a fresh head.
 
 Reboot status:
 | Question | Answer |
@@ -531,7 +538,7 @@ Reboot status:
 | What have I done? | See Timeline |
 
 Open risks:
-- None.
+- Fresh closeout-head Vercel and CI checks must pass.
 
 Hard closeout guard:
 - A local-only final response for verified code-changing work is invalid unless

--- a/docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
+++ b/docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
@@ -36,9 +36,9 @@ Timed checkpoint:
 - semantics: N/A: no timed request
 - initial confidence score: 95%
 - improvement loop: red-green each source-listed case, then full verification
-- final score / loop closure: 99%; the autoreview finding is repaired, all
-  repeated local gates pass, and final rereview is clean; GitHub delivery and
-  remote checks remain
+- final score / loop closure: 100%; the autoreview finding is repaired, all
+  repeated local gates pass, final rereview is clean, and authoritative GitHub
+  checks pass
 
 Completion threshold:
 - Both source-listed cases fail before their fix and pass after it against the
@@ -109,10 +109,10 @@ Blocked condition:
 Task state:
 - task_type: package runtime and type compatibility bugfix
 - task_complexity: non-trivial measurable
-- current_phase: GitHub delivery
-- current_phase_status: final autoreview clean
-- next_phase: commit, PR, and remote checks
-- goal_status: resumed after explicit user approval
+- current_phase: closeout
+- current_phase_status: local and authoritative remote checks green
+- next_phase: validate plans and push closeout evidence
+- goal_status: ready for completion after plan validation and closeout push
 
 Current verdict:
 - verdict: valid
@@ -237,7 +237,7 @@ Work Checklist:
       N/A with reason.
 - [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
       requirements, PR body sync, and issue sync when applicable.
-- [ ] Commit/PR handling recorded for code-changing work: commit and PR
+- [x] Commit/PR handling recorded for code-changing work: commit and PR
       completed, no local patch, user explicitly declined, or blocker recorded.
       "User did not separately ask for a PR" is not a valid blocker.
 - [x] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
@@ -298,17 +298,17 @@ Completion Gates:
 | High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | Failure modes are infinite pagination and mutation-only options exposed to actions; shared-owner red/green proof covers both. |
 | Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: no agent/tooling files changed. |
 | Local install corruption suspected | no | Run `bun install` once, rerun the exact failing command, or record N/A | N/A: no corruption-shaped failure; `bun install` was used only to restore the lockfile baseline after the Convex 1.42 type repro. |
-| Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
-| PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
-| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
+| Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | Entire checkout committed as `e4d7c985ec97963bdfb745cccee81991fde0a744`. |
+| PR create or update | yes | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | Pushed branch and opened ready PR `https://github.com/udecode/kitcn/pull/311`. |
+| Task-style PR body verified | yes | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | `gh pr view 311 --json body` confirms the release block, fix/confidence lines, exact proof table, four required sections, and no self-link. |
 | PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no browser proof applies. |
 | GitHub issue sync-back | no | Post concise issue sync after PR exists, or record N/A/blocker | N/A: this task originates from the fork sync, not a KitCN issue. |
-| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | Filled below with commit, PR, issue N/A, confidence, flow proof, browser N/A, outcome, caveat, design, verification, and body proof. |
 | Final lint | yes | Run `bun lint:fix` or scoped equivalent | Final `bun lint:fix` checked 874 files with no fixes. |
 | Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | Broad command output was redirected to temporary logs and tailed; searches and diffs were capped. |
 | Timed checkpoint | no | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | N/A: no duration requested. |
 | Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | Final local rereview: TruffleHog clean, no accepted/actionable findings, patch correct at 0.91. |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` | Final closeout validator exited 0. |
 | Docs source-backed claim audit | yes | Verify docs claims against current source or record N/A | Internal solution claims match frozen upstream commits, local source, and focused regressions. |
 | Docs links / routes / previews | no | Verify leaf links, routes, anchors, and preview names or record N/A | N/A: no links, routes, anchors, or previews changed. |
 | Docs MDX/content parser | no | Run the relevant `www` docs parser/build for MDX/content changes, or record N/A | N/A: no `www` or MDX content changed. |
@@ -329,8 +329,8 @@ Phase / pass table:
 | Intake and source read | complete | source, owner, regressions, branch, and release path recorded | done |
 | Implementation | complete | three red-green cycles at shared owners | done |
 | Verification | complete | review finding repaired with red/green type proof; repeated full `bun check` and final rereview pass | done |
-| Commit / PR / GitHub sync | pending | | final response |
-| Closeout | pending | | final response |
+| Commit / PR / GitHub sync | complete | implementation commit pushed; ready PR #311 open and body verified | remote checks |
+| Closeout | complete | all local gates, final rereview, PR body proof, and authoritative GitHub checks pass | validate plans and push evidence |
 
 Findings:
 - The upstream pagination fix maps byte-for-byte to KitCN's shared helper, which
@@ -438,22 +438,31 @@ Source-listed case matrix:
 | no forward progress | A non-done empty page with the same cursor can loop forever. | `adapter.test.ts` exported-helper regression with two-query cap | failed with test cap instead of invariant | helper throws clear error after first page | focused red/green command | verified |
 
 Final handoff contract:
-- Commit line: pending
-- PR line: pending
-- Issue line: pending
-- Confidence line: pending
+- Commit line: `e4d7c985ec97963bdfb745cccee81991fde0a744`
+- PR line: `https://github.com/udecode/kitcn/pull/311`
+- Issue line: N/A: upstream sync task, no KitCN issue
+- Confidence line: 🟢 95-100% confidence
 - Flow table:
-  - Reproduced: tests pending, browser pending
-  - Verified: tests pending, browser pending
-- Browser check: pending
-- Outcome: pending
-- Caveat: pending
+  - Reproduced: 🔴 three focused source/type regressions; browser N/A
+  - Verified: 🟢 31 focused tests, real Convex 1.42 type lane, package build,
+    repeated full `bun check`; browser N/A
+- Browser check: N/A: package runtime/type behavior has no UI route
+- Outcome: unbounded auth queries continue after 200 rows, stalled pages abort,
+  and shared mutation callers expose only the action-safe call shape.
+- Caveat: six generated shadcn fixture manifests advanced only
+  `lucide-react ^1.27.0` to `^1.28.0` after explicit approval; all targeted
+  checks and the full gate pass.
 - Design:
-  - Chosen boundary: pending
-  - Why not quick patch: pending
-  - Why not broader change: pending
-- Verified: pending
-- PR body verified: pending
+  - Chosen boundary: shared pagination helper and shared context utility.
+  - Why not quick patch: caller-level guards would leave other HTTP/database
+    adapter consumers vulnerable and preserve the invalid union method type.
+  - Why not broader change: no dependency, wrapper, example, or public API
+    migration is required; the dedicated type alias is test-only.
+- Verified: focused red/green tests, Convex 1.38 package gates, pinned Convex
+  1.42 type lane with production-revert failure proof, all six fixture checks,
+  repeated `bun check`, final lint, and clean final autoreview.
+- PR body verified: `gh pr view 311 --repo udecode/kitcn --json body` matches the
+  required task format and release block.
 
 Task-style PR body contract:
 - Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
@@ -476,12 +485,11 @@ Task-style PR body contract:
   of that output.
 
 Final handoff / sync:
-- Commit: pending
-- PR: pending
-- Issue: pending
-- Browser proof: pending
-- Caveats: the user approved regenerating the five additional shadcn-owned
-  fixture snapshots for `lucide-react ^1.28.0`; final gates are in progress.
+- Commit: `e4d7c985ec97963bdfb745cccee81991fde0a744`
+- PR: `https://github.com/udecode/kitcn/pull/311`
+- Issue: N/A: upstream sync task, no KitCN issue
+- Browser proof: N/A: no browser surface
+- Caveats: browser proof is N/A; CI, Vercel, and release-policy checks pass.
 
 Timeline:
 - 2026-07-30T12:05:36.311Z Task goal plan created.
@@ -507,18 +515,23 @@ Timeline:
   repair.
 - 2026-07-30T15:18:00+0200 Final local autoreview found no accepted/actionable
   issues and judged the patch correct.
+- 2026-07-30T15:20:00+0200 Committed and pushed the entire checkout, opened
+  ready PR #311, and verified its task-style body.
+- 2026-07-30T15:30:00+0200 Authoritative GitHub CI passed in 8m34s; Vercel and
+  release-policy checks are also green.
+- 2026-07-30T15:31:00+0200 Final child and parent goal validators exited 0.
 
 Reboot status:
 | Question | Answer |
 |----------|--------|
-| Where am I? | Final verification and review |
-| Where am I going? | Commit, PR, remote checks, closeout |
+| Where am I? | Final plan validation |
+| Where am I going? | Push closeout evidence and confirm PR head |
 | What is the goal? | Fix terminating auth pagination and action-safe mutation typing, then ship a verified task-style PR. |
 | What have I learned? | See Findings |
 | What have I done? | See Timeline |
 
 Open risks:
-- Pending.
+- None.
 
 Hard closeout guard:
 - A local-only final response for verified code-changing work is invalid unless

--- a/docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
+++ b/docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
@@ -1,0 +1,526 @@
+# fix auth adapter runtime sync
+
+Objective:
+Fix KitCN auth runtime parity with the synced upstream; done when unbounded
+pagination terminates, shared runMutation typing is action-safe, checks pass,
+and a PR exists.
+
+Goal plan:
+docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- docs (docs/plans/templates/packs/docs.md)
+- package-api (docs/plans/templates/packs/package-api.md)
+
+Task source:
+- type: upstream sync audit
+- id / link:
+  `docs/plans/2026-07-30-sync-convex-auth.md`,
+  `get-convex/better-auth@6f940f9`, and
+  `get-convex/better-auth@38fa19a`
+- title: port action-safe runMutation typing and terminating auth pagination
+- acceptance criteria: unbounded auth adapter pagination proceeds beyond 200
+  rows and aborts a page that cannot make progress; `RunMutationCtx` exposes
+  only the mutation call shape valid from action contexts; focused tests,
+  package build, typecheck, lint, autoreview, and `bun check` pass; a KitCN
+  changeset, durable solution note, commit, push, and task-style PR exist.
+
+Timed checkpoint:
+- requested duration: N/A
+- semantics: N/A: no timed request
+- initial confidence score: 95%
+- improvement loop: red-green each source-listed case, then full verification
+- final score / loop closure: 99%; the autoreview finding is repaired, all
+  repeated local gates pass, and final rereview is clean; GitHub delivery and
+  remote checks remain
+
+Completion threshold:
+- Both source-listed cases fail before their fix and pass after it against the
+  public helper/type surface.
+- Published package change has one patch changeset and a source-backed
+  `docs/solutions/integration-issues` note.
+- Focused tests, `bun --cwd packages/kitcn build`, `bun typecheck`,
+  `bun lint:fix`, final autoreview, and `bun check` pass.
+- The entire checkout is committed, pushed, and opened as a task-style PR.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, verified
+  code changes are committed and PR'd unless explicitly declined or blocked,
+  task-style PR body sync is complete or marked N/A with reason,
+  GitHub issue/PR sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` passes.
+
+Verification surface:
+- `bun test packages/kitcn/src/auth/adapter.test.ts` for unbounded and
+  no-forward-progress pagination.
+- Focused `tsc --noEmit` on
+  `packages/kitcn/src/server/context-utils.test-d.ts`, Vitest's `--typecheck`
+  lane, and `bun typecheck` for action-safe `runMutation` typing.
+- `bun --cwd packages/kitcn build`, `bun lint:fix`, and `bun check`.
+- Source audit of the shared adapter/context owners and unchanged public
+  exports/import graphs.
+- `.agents/skills/autoreview/scripts/autoreview --mode local`.
+- `gh pr view --json body,url,state` for task-style PR proof.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Verified code changes must be committed and PR'd because the task skill
+  requires that path unless the user explicitly says not to, the work has no
+  local patch, or a real blocker is recorded.
+- The absence of a separate "open a PR" sentence from the user is not a valid
+  N/A reason for verified code-changing task work.
+- A PR created by this task must use the PR #270 emoji task-style PR body
+  contract below, not a generic summary/body from a git helper skill.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: linked sync plan, frozen upstream commits `6f940f9` and
+  `38fa19a`, current Convex server types, local adapter/context implementations,
+  and prior auth sync/Better Auth 1.6 solution notes.
+- Allowed edit scope: shared auth pagination and context types, focused tests
+  plus their direct Vitest type-test registration, one KitCN changeset, this
+  task/sync plan, one durable solution note, and the six user-approved generated
+  fixture dependency snapshots.
+- Browser surface: N/A: package runtime and type-only behavior, no UI route.
+- GitHub issue sync: N/A: task originates from a repository sync, not a public
+  KitCN issue.
+- Non-goals: authored dependency bumps, cross-domain wrapper changes, upstream
+  examples, scaffold source changes, and new public API.
+
+Output budget strategy:
+- Use exact owner files, focused test output, capped build/check output, and
+  concise GitHub JSON. Do not stream package locks, full generated trees, or
+  bot-heavy PR comment histories.
+
+Blocked condition:
+- Block only if the source regressions cannot be reproduced, the durable fixes
+  conflict with supported Convex 1.38, package/check failures remain after one
+  install repair when the failure shape is local dependency rot, or push/PR
+  permissions fail. The user approved refreshing the five additional generated
+  fixture snapshots; no current blocker remains.
+
+Task state:
+- task_type: package runtime and type compatibility bugfix
+- task_complexity: non-trivial measurable
+- current_phase: GitHub delivery
+- current_phase_status: final autoreview clean
+- next_phase: commit, PR, and remote checks
+- goal_status: resumed after explicit user approval
+
+Current verdict:
+- verdict: valid
+- confidence: high
+- next owner: task
+- reason: local source contains exact pre-fix code from both upstream commits.
+
+Implementation readiness:
+- verdict: ready
+- exact owner: `packages/kitcn/src/auth/adapter.ts` and
+  `packages/kitcn/src/server/context-utils.ts`
+- contradiction status: none; both fixes preserve supported Convex 1.38 while
+  repairing behavior exposed on newer Convex
+- source-listed cases complete: yes; two cases in matrix below
+
+Pre-solution issue challenge:
+- reporter claim: unbounded `count` / `findMany` can loop forever after the
+  first 200 rows, and the shared context exposes a mutation-only runner shape
+  when the runtime may be an action.
+- suggested diagnosis or fix: use an infinite budget only when the caller has
+  no limit, abort non-progressing pages, and type the common runner from
+  `GenericActionCtx`.
+- repro ladder:
+  - tests / source-level repro: focused public `handlePagination` and
+    `RunMutationCtx` regressions selected; red evidence required before fixes.
+  - repo-owned automated browser or integration proof: N/A: no browser/runtime
+    route is needed to model either package behavior.
+  - Browser plugin: N/A: no UI/browser surface.
+  - screenshot / visual proof: N/A: no visual state.
+- reproduction verdict: valid; all three focused regressions failed before
+  their owning fix for the expected reason
+- validity verdict: valid
+- best long-term fix boundary: the two shared owners used by all adapter/context
+  consumers, not individual HTTP/database callers
+- harsh honest feedback: the pagination expression is a textbook infinite-loop
+  bug, not an edge-case preference; requesting zero rows while keeping the
+  cursor cannot terminate.
+- hard-stop decision: proceed only after each focused regression fails for the
+  expected reason.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Timed checkpoint parsed | no | N/A: no duration requested. |
+| Skill analysis before edits | yes | Read `sync-convex-auth`, `autogoal`, `task`, `tdd`, and `changeset` before implementation. |
+| Active goal checked or created | yes | Active sync goal owns this linked task plan. |
+| Source of truth read before edits | yes | Read frozen upstream patches, current Convex types, exact local owners, and prior auth institutional notes. |
+| GitHub comments and attachments read | no | N/A: no KitCN issue; upstream commit patches are the frozen source. |
+| Video transcript evidence required | no | N/A: no video. |
+| Pre-solution issue challenge required | yes | Exact source comparison proves both claims; focused red tests required next. |
+| Reproduction verdict before implementation | yes | Verdict valid; no implementation source changed yet. |
+| Repro escalation ladder selected | yes | Focused source-level tests; browser/visual lanes N/A. |
+| Suggested fix reviewed against durable boundary | yes | Both changes land once in shared owners used by all affected consumers. |
+| `docs/solutions` checked for non-trivial existing-code work | yes | Read prior upstream-sync and Better Auth 1.6 structural-wrapper notes. |
+| TDD decision before behavior change or bug fix | yes | Vertical cycles: unbounded pagination, no-progress guard, then action-safe type. |
+| Branch decision for code-changing task | yes | Created `codex/sync-convex-auth-runtime-fixes` from current `origin/main`. |
+| Release artifact decision | yes | Published KitCN patch requires a new changeset; only README/config currently exist. |
+| Browser tool decision for browser surface | no | N/A: no browser surface. |
+| Commit / PR expectation decision | yes | Verified code-changing work will commit the entire checkout, push, and open a PR as required by `task`. |
+| Task-style PR body decision | yes | Use the required PR #270 emoji task format. |
+| GitHub issue sync expectation decision | no | N/A: no KitCN issue. |
+| Output budget strategy recorded | yes | Exact owner reads and capped command output only. |
+| Docs pack selected | yes | Internal durable solution note only. |
+| Docs guidance loaded | yes | Read `docs/README.md`; `www` doc guidance is N/A. |
+| Docs lane selected | yes | `docs/solutions/integration-issues`. |
+| Target docs and nearest sibling docs read | yes | Read the prior Convex Better Auth sync and Better Auth 1.6 integration notes. |
+| Docs style doctrine read | no | N/A: no `www/**` public reference docs. |
+| Documented source owner identified | yes | Shared adapter/context source plus frozen upstream patches. |
+| Package/API pack selected | yes | Published KitCN runtime/type behavior changes. |
+| Public surface or package boundary identified | yes | Exported `RunMutationCtx` type and adapter factory behavior. |
+| Convex entry/import graph impact identified | yes | No new imports or static entry graph expansion. |
+| CLI/scaffold/generated impact identified | yes | No CLI/template source changed; fresh shadcn generation moved six fixture manifests from `lucide-react ^1.27.0` to `^1.28.0`. |
+| Release artifact path selected | yes | New `.changeset/*.md` for `kitcn` patch. |
+| `changeset` skill loaded when `.changeset` is required | yes | Read skill and source rule completely. |
+| Package build / fixture impact decision recorded | yes | Package build required; six generated fixtures required an approved registry-drift refresh and matching targeted checks. |
+
+Work Checklist:
+- [x] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded. N/A: no duration.
+- [x] Objective includes outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public GitHub bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      automated browser or integration proof next when available and useful as
+      executable coverage; the repo-approved Browser tool next when tests or
+      automation cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the
+      issue's proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Source-listed case matrix is complete and every contradiction has an
+      owner, harness, and verdict before mutation.
+- [x] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
+      `invalid` with evidence.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: active changeset, new changeset, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
+      requirements, PR body sync, and issue sync when applicable.
+- [ ] Commit/PR handling recorded for code-changing work: commit and PR
+      completed, no local patch, user explicitly declined, or blocker recorded.
+      "User did not separately ask for a PR" is not a valid blocker.
+- [x] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
+      recorded, or blocker recorded.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Docs pack: docs lane, target docs, nearest sibling docs, and source owner are recorded.
+- [x] Docs pack: every named API, import, option, route, component, transform, demo, and preview is source-backed or marked N/A with reason.
+- [x] Docs pack: docs use current-state reference voice, not changelog voice.
+- [x] Docs pack: links, anchors, and previews target real leaf pages or are marked N/A with reason.
+- [x] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [x] Package/API pack: release artifact matrix is applied: `.changeset` or explicit no-artifact reason.
+- [x] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [x] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`. N/A: this diff has a published KitCN patch delta and a changeset.
+- [x] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [x] Package/API pack: affected Convex static import graphs stay narrow and
+      plugin/per-module boundaries are used where appropriate.
+- [x] Package/API pack: CLI commands remain deterministic, `--json` capable,
+      and non-interactive with explicit confirmation bypass when relevant.
+- [x] Package/API pack: docs and `packages/kitcn/skills/kitcn/**` stay
+      current-state synchronized when public guidance changes.
+- [x] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [x] Package/API pack: `packages/kitcn` build, fixture sync/check, or other owning package proof is recorded when required.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | The repaired Convex 1.42 type lane passes and fails on production revert; repeated focused/package/full gates pass. |
+| Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | Recorded above before implementation; verdict valid. |
+| Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | Source-level red/green tests apply; integration, Browser, and screenshots are N/A for package-only behavior. |
+| Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | Three focused regressions failed before their owning fixes for the expected reason. |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | 31 focused runtime tests and the Vitest type-test lane pass. |
+| TypeScript or typed config changed | yes | Run relevant typecheck | Focused `tsc`, Vitest typecheck, package typecheck, and root `bun typecheck` pass. |
+| Package exports or file layout changed | yes | Run the relevant package build before final verification and keep generated updates | `bun --cwd packages/kitcn build` passes; public export names and paths are unchanged. |
+| Package manifests, lockfile, or install graph changed | yes | Run `bun install` and relevant package checks | `bun install` added pinned `convex-type-test@1.42.3`; regular gates keep Convex 1.38, and all six generated fixture checks pass. |
+| Agent rules or skills changed | no | Run `bun install` and verify generated skill sync | N/A: no agent rules or skills changed. |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | All commands ran in `/Users/zbeyens/git/better-convex`; package checks used `packages/kitcn`. |
+| Browser surface changed | no | Capture Browser Use proof or record explicit waiver/blocker | N/A: package runtime/type behavior has no UI route. |
+| Browser final proof | no | Attach screenshot or exact browser verification caveat when browser proof applies | N/A: no visual state. |
+| Scaffold or fixture output changed | yes | Run `bun run fixtures:sync` and `bun run fixtures:check`, or record N/A | Scenarios-owned targeted sync/check passes for `next`, `next-auth`, `start`, `start-auth`, `vite`, and `vite-auth`; each diff is one generated dependency line. |
+| Package behavior or public API changed | yes | Add a changeset or record why no changeset applies | `.changeset/calm-auth-pagination.md` records a KitCN patch. |
+| Docs and kitcn skill sync changed | no | Keep `www/**` and `packages/kitcn/skills/kitcn/**` in sync, or record N/A | N/A: no public docs or published skill guidance changed. |
+| Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | Internal solution and plans are source-backed; no MDX, links, or rendered route changed. |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | Failure modes are infinite pagination and mutation-only options exposed to actions; shared-owner red/green proof covers both. |
+| Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: no agent/tooling files changed. |
+| Local install corruption suspected | no | Run `bun install` once, rerun the exact failing command, or record N/A | N/A: no corruption-shaped failure; `bun install` was used only to restore the lockfile baseline after the Convex 1.42 type repro. |
+| Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
+| PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
+| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no browser proof applies. |
+| GitHub issue sync-back | no | Post concise issue sync after PR exists, or record N/A/blocker | N/A: this task originates from the fork sync, not a KitCN issue. |
+| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
+| Final lint | yes | Run `bun lint:fix` or scoped equivalent | Final `bun lint:fix` checked 874 files with no fixes. |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | Broad command output was redirected to temporary logs and tailed; searches and diffs were capped. |
+| Timed checkpoint | no | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | N/A: no duration requested. |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | Final local rereview: TruffleHog clean, no accepted/actionable findings, patch correct at 0.91. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` | pending |
+| Docs source-backed claim audit | yes | Verify docs claims against current source or record N/A | Internal solution claims match frozen upstream commits, local source, and focused regressions. |
+| Docs links / routes / previews | no | Verify leaf links, routes, anchors, and preview names or record N/A | N/A: no links, routes, anchors, or previews changed. |
+| Docs MDX/content parser | no | Run the relevant `www` docs parser/build for MDX/content changes, or record N/A | N/A: no `www` or MDX content changed. |
+| Kitcn docs sync | no | If `www/**` changed, update matching `packages/kitcn/skills/kitcn/**` content or record N/A | N/A: no `www/**` change. |
+| Public API / package boundary proof | yes | Source-audit public API, exports, and package boundary impact | Names/exports remain unchanged; only shared pagination behavior and the invalid third-argument type surface narrow. |
+| Convex bundle/import proof | yes | Audit affected function-entry static graphs or record N/A | No imports were added; function-entry static graphs do not expand. |
+| CLI/scaffold/generated proof | yes | Prove command contract and regenerate owned output or record N/A | No CLI/scaffold source changed; all six affected generated fixtures match fresh scenario output. |
+| Release artifact classification | yes | Record whether the change is published package behavior/API/types/config/runtime or no published user-visible delta | Published KitCN patch: auth adapter runtime behavior and action-safe context type. |
+| Published package changeset | yes | If published package users see a delta, load `changeset` and add/update one `.changeset/*.md` per package | `.changeset/calm-auth-pagination.md` is a patch changeset for `kitcn`. |
+| No release artifact | no | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | N/A: a published patch artifact is required and present. |
+| Package typecheck/build/test | yes | Run owning package checks or record N/A with reason | 31 focused tests, dedicated type-test lane, package typecheck, package build, and root typecheck pass. |
+| Fixture/scaffold generation | yes | Run `bun run fixtures:sync` and `bun run fixtures:check` when scaffold output changed, otherwise N/A | Targeted scenario sync/check passes for all six affected fixtures. |
+| Docs/package skill sync | no | Synchronize current-state public guidance or record N/A | N/A: no public docs or package skill guidance changed. |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | source, owner, regressions, branch, and release path recorded | done |
+| Implementation | complete | three red-green cycles at shared owners | done |
+| Verification | complete | review finding repaired with red/green type proof; repeated full `bun check` and final rereview pass | done |
+| Commit / PR / GitHub sync | pending | | final response |
+| Closeout | pending | | final response |
+
+Findings:
+- The upstream pagination fix maps byte-for-byte to KitCN's shared helper, which
+  serves both HTTP and database adapters.
+- The installed Convex 1.42.3 types expose mutation-only transaction options,
+  while branch metadata remains compatible with Convex 1.38. The type fix is a
+  safe common subset, not a minimum-version bump.
+- Cross-domain plugin typing is intentionally excluded because KitCN owns
+  structural wrappers and does not depend on the upstream package.
+- Full `bun check` reached external shadcn registry drift: all six shadcn
+  fixtures recorded `lucide-react ^1.27.0`, while fresh generation installs
+  `^1.28.0`. User-approved targeted syncs changed exactly one generated line
+  per fixture, and all six matching checks pass.
+
+Decisions and tradeoffs:
+- Keep the public surface names unchanged; narrow only an invalid call shape.
+- Test pagination through the exported helper and types through a committed
+  type regression.
+- Do not broaden into authored dependencies, examples, scaffold source, or
+  public docs; the generated fixture refresh is the exact approved exception.
+
+Implementation notes:
+- Changed the absent-limit budget only; explicit limits and the 200-row page cap
+  retain their current behavior.
+- Added a termination invariant after state update: a non-final page must
+  advance the cursor or produce rows/count.
+- Typed `RunMutationCtx.runMutation` from `GenericActionCtx`, the safe callable
+  surface common to mutation and action contexts.
+- Added patch changeset `.changeset/calm-auth-pagination.md` and a durable
+  integration solution note.
+- Registered `packages/**/*.test-d.ts` in Vitest's integration project so the
+  committed type regression is checked instead of merely transpiled.
+- Pinned the dedicated type-test resolver to `convex@1.42.3`, where mutation
+  contexts expose transaction limits, while regular package gates keep the
+  minimum supported Convex 1.38 baseline.
+- Excluded `*.test-d.ts` from the normal package tsconfig and cleared that
+  exclusion in the dedicated config, so each Convex version owns one honest
+  type lane.
+
+Review fixes:
+- Scope baseline before autoreview: branch
+  `codex/sync-convex-auth-runtime-fixes`; shared adapter/context behavior; two
+  source files, three focused test/config files, one changeset, one solution
+  note, and two plans. Review-triggered growth beyond this owner boundary or
+  twice this file/LOC footprint requires reclassification.
+- An initial local autoreview before fixture closeout exited clean at `0.96`.
+- Final-bundle autoreview found one actionable P2: the committed type lane used
+  Convex 1.38, so reverting production to `GenericMutationCtx` would still pass.
+- Added the pinned `convex-type-test` alias and a mutation-context control call.
+  The lane fails with an unused `@ts-expect-error` when production is reverted
+  and passes after restoring `GenericActionCtx`. Final rereview remains.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| `vitest --typecheck` filter did not include `*.types.test.ts` | 1 | Check current Vitest type-test discovery rules | Official docs require `*.test-d.ts` by default. |
+| Normal `.vitest.ts` execution reported green despite TypeScript diagnostics | 1 | Move the fixture to `*.test-d.ts` and run Vitest `--typecheck` | Type fixture now uses Vitest's actual non-runtime type-test lane. |
+| First registered Vitest type lane used the root tsconfig and emitted 1,189 unrelated fixture errors | 1 | Give the lane a KitCN-only type-test tsconfig | Added `packages/kitcn/tsconfig.type-tests.json`; the dedicated lane passes. |
+| First type fixture omitted the required `RunMutationCtx` data-model generic | 1 | Use `GenericDataModel` explicitly | Remaining red errors isolated the intended invalid third argument. |
+| Final autoreview proved the type lane was false-green on Convex 1.38 | 1 | Resolve the dedicated lane against a pinned Convex version that exposes mutation-only options and add a positive control | Convex 1.42.3 lane fails on a production revert and passes on the fix. |
+| Normal package typecheck compiled the Convex 1.42-only positive control against Convex 1.38 | 1 | Isolate `*.test-d.ts` to the dedicated config instead of weakening either assertion | Package typecheck and the dedicated Convex 1.42 lane both pass. |
+| First `bun check` failed on `fixtures/next` lucide registry drift | 1 | Use the scenarios-owned target sync/check instead of hand editing | `fixtures/next/package.json` regenerated to `^1.28.0`; targeted check passed. |
+| Second `bun check` failed on the same drift in `fixtures/next-auth` | 1 | Stop before broad fixture expansion and request approval as required by the sync skill | Remaining affected fixtures: `next-auth`, `start`, `start-auth`, `vite`, `vite-auth`. |
+
+Verification evidence:
+- RED, this checkout with installed Convex 1.42.3:
+  `bun test packages/kitcn/src/auth/adapter.test.ts` failed because the second
+  unbounded request asked for zero rows.
+- GREEN: the same adapter command passed 28 tests after both pagination fixes.
+- RED, this checkout with installed Convex 1.42.3: focused `tsc --noEmit`
+  reported unused `@ts-expect-error` and incompatible action-runner equality
+  before changing `RunMutationCtx`.
+- GREEN: focused `tsc --noEmit`, Vitest's `*.test-d.ts` lane, and combined
+  adapter / context runtime tests passed after the type fix.
+- On the locked Convex 1.38 baseline: 31 focused runtime tests, root
+  `bun typecheck`, and `bun --cwd packages/kitcn build` exited 0.
+- The committed Vitest type-test lane resolves pinned Convex 1.42.3. Its
+  mutation-context control accepts transaction limits; reverting production to
+  `GenericMutationCtx` fails with an unused `@ts-expect-error`; restoring
+  `GenericActionCtx` passes with no type errors.
+- After isolating `*.test-d.ts` to its dedicated config, package typecheck,
+  package build, focused runtime tests, the Convex 1.42 type lane, and lint all
+  exit 0.
+- `bun check` passed lint, typecheck, unit, CLI, Concave, and earlier fixture
+  lanes before failing only on generated shadcn dependency drift.
+- `bun tooling/fixtures.ts sync next --backend concave` changed only
+  `fixtures/next/package.json`; its matching targeted check exited 0.
+- Read-only targeted checks for `next-auth`, `start`, `start-auth`, `vite`, and
+  `vite-auth` each reported exactly one diff:
+  `lucide-react ^1.27.0` to `^1.28.0`; no other snapshot drift surfaced.
+- User-approved targeted sync/check passes for `next`, `next-auth`, `start`,
+  `start-auth`, `vite`, and `vite-auth`; the committed diff is one dependency
+  line per fixture.
+- The pre-rereview `bun check` exited 0 after all lint, typecheck, test, CLI,
+  Concave, fixture, and scenario lanes; the post-fix rerun supersedes it.
+- The post-fix repeated `bun check` exited 0 across all repository gates.
+- Final local autoreview: TruffleHog clean; no accepted/actionable findings;
+  patch correct with overall confidence `0.91`.
+
+Source-listed case matrix:
+| Case | Source claim | Harness | Before | Expected after | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| unbounded pagination | More than 200 rows requests zero items and may loop forever. | `adapter.test.ts` exported-helper regression | failed: second request received `numItems: 0` | 201 rows terminate | focused red/green command | verified |
+| action-safe runner type | A union that may hold an action exposes mutation-only transaction options on Convex 1.42. | `context-utils.test-d.ts` with third-argument rejection | failed: `@ts-expect-error` unused | mutation-only option rejected | focused explicit `tsc` red/green plus Vitest type-test lane | verified |
+| no forward progress | A non-done empty page with the same cursor can loop forever. | `adapter.test.ts` exported-helper regression with two-query cap | failed with test cap instead of invariant | helper throws clear error after first page | focused red/green command | verified |
+
+Final handoff contract:
+- Commit line: pending
+- PR line: pending
+- Issue line: pending
+- Confidence line: pending
+- Flow table:
+  - Reproduced: tests pending, browser pending
+  - Verified: tests pending, browser pending
+- Browser check: pending
+- Outcome: pending
+- Caveat: pending
+- Design:
+  - Chosen boundary: pending
+  - Why not quick patch: pending
+  - Why not broader change: pending
+- Verified: pending
+- PR body verified: pending
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted PR #270 visual format. The body starts with an emoji
+  issue/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- Commit: pending
+- PR: pending
+- Issue: pending
+- Browser proof: pending
+- Caveats: the user approved regenerating the five additional shadcn-owned
+  fixture snapshots for `lucide-react ^1.28.0`; final gates are in progress.
+
+Timeline:
+- 2026-07-30T12:05:36.311Z Task goal plan created.
+- 2026-07-30T12:20:00Z Filled task contract, source matrix, branch, TDD, docs,
+  release, and verification decisions.
+- 2026-07-30T14:11:00+0200 Completed three red-green cycles and added the
+  changeset plus durable solution note.
+- 2026-07-30T14:25:00+0200 Full gate isolated repeated shadcn registry drift;
+  targeted `next` sync/check passed, then `next-auth` proved five more
+  snapshots require explicit scope approval.
+- 2026-07-30T14:30:00+0200 Read-only targeted checks proved every remaining
+  affected fixture has exactly the same one-line dependency drift.
+- 2026-07-30T14:31:00+0200 The same explicit-approval blocker reached three
+  consecutive goal turns; goal marked blocked until the user approves.
+- 2026-07-30T14:48:00+0200 User approved the five exact generated fixture
+  refreshes; verification and PR closeout resumed.
+- 2026-07-30T14:53:58+0200 Refreshed and verified all six affected fixtures;
+  each snapshot changed only `lucide-react ^1.27.0` to `^1.28.0`.
+- 2026-07-30T15:01:00+0200 Final `bun check` passed all repository gates.
+- 2026-07-30T15:07:44+0200 Repaired the autoreview P2 with a pinned Convex
+  1.42.3 type lane; it fails on a production revert and passes on the fix.
+- 2026-07-30T15:15:00+0200 Repeated final `bun check` passed after the type-lane
+  repair.
+- 2026-07-30T15:18:00+0200 Final local autoreview found no accepted/actionable
+  issues and judged the patch correct.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Final verification and review |
+| Where am I going? | Commit, PR, remote checks, closeout |
+| What is the goal? | Fix terminating auth pagination and action-safe mutation typing, then ship a verified task-style PR. |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- Pending.
+
+Hard closeout guard:
+- A local-only final response for verified code-changing work is invalid unless
+  this plan records an explicit user decline, no local patch, analytical/
+  blocked/inconclusive outcome, or a real commit/PR blocker.

--- a/docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
+++ b/docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md
@@ -36,9 +36,8 @@ Timed checkpoint:
 - semantics: N/A: no timed request
 - initial confidence score: 95%
 - improvement loop: red-green each source-listed case, then full verification
-- final score / loop closure: 99%; implementation-head checks passed, but the
-  closeout head hit a Vercel `git_info_fail` before build startup and requires a
-  fresh deployment attempt
+- final score / loop closure: 100%; the Vercel `git_info_fail` was transient,
+  and the fresh retry head passed CI, Vercel, and release-policy checks
 
 Completion threshold:
 - Both source-listed cases fail before their fix and pass after it against the
@@ -110,10 +109,9 @@ Task state:
 - task_type: package runtime and type compatibility bugfix
 - task_complexity: non-trivial measurable
 - current_phase: closeout
-- current_phase_status: closeout-head Vercel retry required
-- next_phase: push recorded retry state, wait for fresh remote checks, and
-  revalidate plans
-- goal_status: active until the fresh PR head is green
+- current_phase_status: fresh retry head green
+- next_phase: validate plans and push immutable closeout
+- goal_status: ready for completion after the immutable closeout push
 
 Current verdict:
 - verdict: valid
@@ -309,7 +307,7 @@ Completion Gates:
 | Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | Broad command output was redirected to temporary logs and tailed; searches and diffs were capped. |
 | Timed checkpoint | no | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | N/A: no duration requested. |
 | Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | Final local rereview: TruffleHog clean, no accepted/actionable findings, patch correct at 0.91. |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` | Prior closeout validator exited 0; rerun after the Vercel retry resolves. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md` | Retry resolved; final validator exited 0. |
 | Docs source-backed claim audit | yes | Verify docs claims against current source or record N/A | Internal solution claims match frozen upstream commits, local source, and focused regressions. |
 | Docs links / routes / previews | no | Verify leaf links, routes, anchors, and preview names or record N/A | N/A: no links, routes, anchors, or previews changed. |
 | Docs MDX/content parser | no | Run the relevant `www` docs parser/build for MDX/content changes, or record N/A | N/A: no `www` or MDX content changed. |
@@ -331,7 +329,7 @@ Phase / pass table:
 | Implementation | complete | three red-green cycles at shared owners | done |
 | Verification | complete | review finding repaired with red/green type proof; repeated full `bun check` and final rereview pass | done |
 | Commit / PR / GitHub sync | complete | implementation commit pushed; ready PR #311 open and body verified | remote checks |
-| Closeout | in progress | implementation-head checks passed; closeout head failed before Vercel build startup with `git_info_fail` | push retry evidence and wait for fresh checks |
+| Closeout | complete | retry head `cadc6e5b` passed CI in 6m32s plus Vercel and release-policy checks | validate plans and push immutable closeout |
 
 Findings:
 - The upstream pagination fix maps byte-for-byte to KitCN's shared helper, which
@@ -393,7 +391,7 @@ Error attempts:
 | First type fixture omitted the required `RunMutationCtx` data-model generic | 1 | Use `GenericDataModel` explicitly | Remaining red errors isolated the intended invalid third argument. |
 | Final autoreview proved the type lane was false-green on Convex 1.38 | 1 | Resolve the dedicated lane against a pinned Convex version that exposes mutation-only options and add a positive control | Convex 1.42.3 lane fails on a production revert and passes on the fix. |
 | Normal package typecheck compiled the Convex 1.42-only positive control against Convex 1.38 | 1 | Isolate `*.test-d.ts` to the dedicated config instead of weakening either assertion | Package typecheck and the dedicated Convex 1.42 lane both pass. |
-| Closeout-head Vercel deployment failed at `build-container-init` | 1 | Inspect the deployment owner, then push the recorded external failure to trigger a fresh Git-backed deployment | Vercel reports `git_info_fail` with no build/error log; fresh head required. |
+| Closeout-head Vercel deployment failed at `build-container-init` | 1 | Inspect the deployment owner, then push the recorded external failure to trigger a fresh Git-backed deployment | Vercel reported `git_info_fail` with no build/error log; fresh retry head `cadc6e5b` passed Vercel and CI. |
 | First `bun check` failed on `fixtures/next` lucide registry drift | 1 | Use the scenarios-owned target sync/check instead of hand editing | `fixtures/next/package.json` regenerated to `^1.28.0`; targeted check passed. |
 | Second `bun check` failed on the same drift in `fixtures/next-auth` | 1 | Stop before broad fixture expansion and request approval as required by the sync skill | Remaining affected fixtures: `next-auth`, `start`, `start-auth`, `vite`, `vite-auth`. |
 
@@ -491,9 +489,8 @@ Final handoff / sync:
 - PR: `https://github.com/udecode/kitcn/pull/311`
 - Issue: N/A: upstream sync task, no KitCN issue
 - Browser proof: N/A: no browser surface
-- Caveats: implementation-head CI, Vercel, and release-policy checks passed;
-  the closeout head needs a fresh Vercel attempt after pre-build
-  `git_info_fail`.
+- Caveats: browser proof is N/A; the one pre-build Vercel `git_info_fail` was
+  transient, and the fresh retry head passed all checks.
 
 Timeline:
 - 2026-07-30T12:05:36.311Z Task goal plan created.
@@ -527,6 +524,8 @@ Timeline:
 - 2026-07-30T15:33:00+0200 Closeout-head Vercel failed at
   `build-container-init` with `git_info_fail` and no build logs; recorded the
   external failure before triggering a fresh head.
+- 2026-07-30T15:42:00+0200 Fresh retry head `cadc6e5b` passed CI in 6m32s,
+  Vercel, preview comments, and release-policy checks.
 
 Reboot status:
 | Question | Answer |
@@ -538,7 +537,7 @@ Reboot status:
 | What have I done? | See Timeline |
 
 Open risks:
-- Fresh closeout-head Vercel and CI checks must pass.
+- None.
 
 Hard closeout guard:
 - A local-only final response for verified code-changing work is invalid unless

--- a/docs/plans/2026-07-30-sync-convex-auth.md
+++ b/docs/plans/2026-07-30-sync-convex-auth.md
@@ -238,9 +238,9 @@ Completion Gates:
 | Package/scaffold/docs gates delegated | yes | Ensure delegated prompt includes package build, fixture, docs, or skills checks when applicable | Changeset, solution note, package build, typecheck, review, full check, and user-approved generated-fixture checks are required. |
 | Workspace authority proof | yes | Record cwd/tool for every proof surface | Upstream Git evidence comes from `../convex-better-auth`; KitCN source evidence comes from this checkout. |
 | Autoreview for local implementation patch | yes | Run autoreview if this sync plan itself changes implementation code; otherwise N/A | Linked task final local rereview: TruffleHog clean, no accepted/actionable findings, patch correct at 0.91. |
-| Final output contract | pending | Record terse audit table and delegation/no-action result | pending |
+| Final output contract | yes | Record terse audit table and delegation/no-action result | Fork refs/range, seven-commit ledger, selected slice, skipped scope, implementation evidence, and PR #311 are recorded. |
 | Output budget discipline | yes | Verify no unbounded high-volume output was streamed, or record recovery | One broad PR-comments read and one broad local search were truncated; all subsequent evidence used commit metadata and exact file slices. |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md` | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md` | Final closeout validator exited 0. |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
@@ -250,7 +250,7 @@ Phase / pass table:
 | Upstream diff audit | complete | all seven commits and 17 files classified | done |
 | Local KitCN impact audit | complete | exact copied owners and institutional notes read | done |
 | Classification and decision | complete | compatibility + pagination slice selected | delegated task |
-| Delegation / closeout | in progress | review P2 repaired; repeated full `bun check` and final rereview green | ship PR |
+| Delegation / closeout | complete | PR #311 open; body verified; CI, Vercel, and release-policy checks green | validate plans and push evidence |
 
 Findings:
 - Kitcn doctrine favors direct upstream ownership and deletion of obsolete auth
@@ -328,6 +328,9 @@ Verification evidence:
   `lucide-react ^1.27.0` to `^1.28.0`.
 - command, this checkout: repeated post-fix `bun check` passes all repository
   gates.
+- command, GitHub: PR #311 is open from the expected branch at implementation
+  commit `e4d7c985`; task-style body verified with `gh pr view`.
+- command, GitHub: CI passed in 8m34s; Vercel and release-policy checks pass.
 
 Final handoff / sync:
 - Fork/upstream: `zbeyens/convex-better-auth` / `get-convex/better-auth`
@@ -336,19 +339,22 @@ Final handoff / sync:
 - Fork sync: fast-forward complete; `fork/main` equals upstream at `c628916`.
 - Decision: delegate the two exact local runtime matches; skip upstream-owned
   plugin typing, examples, release metadata, and CI churn.
-- Decision: pending
-- Delegated PR: pending
-- Fork sync: pending
-- Caveats: pending
+- Decision: shipped terminating pagination and action-safe shared mutation
+  typing; no other upstream changes require local code.
+- Delegated PR: `https://github.com/udecode/kitcn/pull/311`
+- Fork sync: direct fast-forward complete; post-sync 0 behind / 0 ahead.
+- Caveats: browser proof is N/A; six user-approved generated fixture manifests
+  moved only `lucide-react ^1.27.0` to `^1.28.0`; all local and remote checks
+  pass.
 
 Reboot status:
 | Question | Answer |
 |----------|--------|
-| Where am I? | Linked task final review |
-| Where am I going? | Commit, PR, remote checks, closeout |
+| Where am I? | Final plan validation |
+| Where am I going? | Push closeout evidence and confirm PR head |
 | What is the goal? | Safely sync the fork, classify the frozen upstream range, and ship one useful kitcn auth slice or prove no action. |
 | What have I learned? | Two upstream fixes map exactly to shared KitCN owners; the remaining changes are no-ops locally. |
-| What have I done? | Fast-forwarded the fork, classified all seven commits, implemented the selected slice, and verified all affected generated fixtures. |
+| What have I done? | Fast-forwarded the fork, classified all seven commits, implemented and verified the selected slice, and opened PR #311. |
 
 Open risks:
-- PR creation and remote checks remain.
+- None.

--- a/docs/plans/2026-07-30-sync-convex-auth.md
+++ b/docs/plans/2026-07-30-sync-convex-auth.md
@@ -1,0 +1,354 @@
+# sync convex auth
+
+Objective:
+Sync convex-better-auth fork and ship the highest-leverage kitcn auth slice;
+done when fork sync and a verified PR or sourced no-action verdict exist; plan
+docs/plans/2026-07-30-sync-convex-auth.md.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/2026-07-30-sync-convex-auth.md
+
+Template:
+docs/plans/templates/sync-convex-auth.md
+
+Primary template:
+docs/plans/templates/sync-convex-auth.md
+
+Applied packs:
+- none
+
+Linked plans:
+- `docs/plans/2026-07-30-fix-auth-adapter-runtime-sync.md`
+
+Completion threshold:
+- Fork/upstream refs, behind/ahead counts, exact commit range, upstream diff
+  summary, fork sync status, local KitCN surface audit, docs/solutions audit,
+  classification ledger, selected slice or no-action verdict, ambiguity
+  decisions, delegated `task` prompt/result or N/A reason, and final evidence
+  are recorded.
+- Closure is legal only when every upstream change in the compared range is
+  classified, every non-`no-op` classification has evidence and a decision, the
+  fork is fast-forwarded/PR'd or a blocker is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md` passes.
+
+Verification surface:
+- `gh repo view` or fallback evidence for fork/upstream identity.
+- `git -C ../convex-better-auth fetch <fork-remote> --tags` and upstream
+  fetch.
+- `git -C ../convex-better-auth rev-list --count ...` for behind/ahead counts.
+- `git -C ../convex-better-auth log ...` and `git diff --name-status ...`.
+- Fork sync proof: fast-forward push result, fork PR URL, already-synced ref, or
+  divergent/blocker evidence.
+- Patch reads for relevant upstream files.
+- Local `rg` surface audit across `packages`, `www`, `.agents`, `docs`,
+  `tooling`, `fixtures`, and `example`.
+- `docs/solutions` / `docs/plans` note audit.
+- Delegated `task` final handoff, or no-action/blocked verdict with evidence.
+
+Constraints:
+- Use evidence, not vibes.
+- Snapshot the pre-sync compare range, then sync the fork itself when safe.
+- Never force push `zbeyens/convex-better-auth`.
+- Pull only upstream changes that matter to KitCN auth integration.
+- Stop and ask before importing optional e2e suites, broad fixtures, examples,
+  release plumbing, or dev-only test infrastructure unless they are the direct
+  verification path for the selected required fix.
+- Prefer deleting obsolete KitCN glue over adding more glue.
+- Do not open a vanity PR when no actionable opportunity exists.
+- Do not use this template as the delegated implementation task plan; delegate
+  implementation through `task`.
+
+Boundaries:
+- Source of truth: `sync-convex-auth` skill, fork/upstream metadata,
+  `../convex-better-auth` commits and patches, local KitCN auth surfaces, and
+  institutional notes under `docs/solutions` / `docs/plans`.
+- Allowed sync-audit scope: fork/upstream refs, upstream diff evidence,
+  fork fast-forward/PR state, classification ledger, local surface map, selected
+  slice, delegated `task` prompt, and final sync verdict.
+- Delegated implementation scope: owned by the delegated `task` plan and PR.
+- Browser surface: N/A unless upstream change or local KitCN impact requires
+  real browser proof.
+- GitHub sync: N/A unless the sync run starts from an issue or PR.
+- Non-goals: force-pushing a diverged fork, importing optional test/example
+  infrastructure without approval, and coding inside the sync audit plan.
+
+Output budget strategy:
+- Use `rg`, `git diff --name-status`, commit summaries, and scoped patch reads
+  before broad diffs.
+- Cap command output or save large compare data as artifacts.
+- Group large upstream ranges by subsystem before reading patches.
+- Record only evidence needed to justify relevance, irrelevance, or ambiguity.
+
+Blocked condition:
+- Blocked only if upstream cannot be identified after documented fallbacks,
+  required fork/upstream refs cannot be fetched, the compare is too large to
+  classify without a user-selected bound, the fork has diverged and needs a
+  merge/rebase decision, direct fork sync and fork PR creation both fail, or the
+  highest-leverage opportunity is ambiguous and needs user approval. The user
+  approved the five proven one-line generated fixture refreshes; no current
+  blocker remains.
+
+Sync refs:
+- Fork: `zbeyens/convex-better-auth`
+- Upstream: `get-convex/better-auth`
+- Fork branch/ref:
+  `main@c8df6790a496ab066f72139be16767c9c235df91`
+- Upstream branch/ref:
+  `main@c628916b451a6b4cff0f5464f134475464b1a6da`
+- Behind count: 7
+- Ahead count: 0
+- Exact range:
+  `c8df6790a496ab066f72139be16767c9c235df91..c628916b451a6b4cff0f5464f134475464b1a6da`
+- Fork sync status: `fast-forward pushed`
+- Post-sync fork ref or PR:
+  `main@c628916b451a6b4cff0f5464f134475464b1a6da`; 0 behind, 0 ahead
+
+Sync verdict:
+- verdict: actionable sync completed; KitCN implementation selected
+- selected slice: safe `runMutation` context typing plus terminating unbounded
+  auth-adapter pagination
+- class: compatibility + bugfix
+- decision reason: both upstream fixes map directly to copied KitCN owners;
+  the pagination bug can hang `count` / unbounded `findMany` above 200 rows,
+  while the context type currently exposes mutation-only transaction options
+  to action callers on newer Convex versions
+- next owner: linked task closeout
+
+Ambiguity / approval ledger:
+| Item | Why ambiguous | Decision | Evidence |
+|------|---------------|----------|----------|
+| Cross-domain client typing | Upstream fixed its own public plugin type, while KitCN carries structural wrappers. | No local patch. | `docs/plans/195-fix-cross-domain-client-types.md` fixes upstream ownership; the local Better Auth 1.6 solution records that KitCN no longer imports or depends on `@convex-dev/better-auth`. |
+| Upstream examples and regenerated npm locks | The Resend bump and lock churn do not prove KitCN behavior. | No local patch. | Only `examples/**` manifests/locks changed; KitCN owns different examples and dependency pins. |
+| Upstream release / CI maintenance | Releases and checkout action updates are fork maintenance, not KitCN runtime. | No local patch. | `b51ec4d`, `dd9f1ee`, and `c628916` touch workflow/version/changelog/package release surfaces only. |
+
+Classification ledger:
+| Class | Upstream change | Evidence | KitCN surface | Decision |
+|-------|-----------------|----------|---------------|----------|
+| cleanup | `b51ec4d` updates `actions/checkout` to v6. | Frozen-range commit/file summary. | No KitCN auth runtime owner. | No local patch. |
+| no-op | `e18fdf4` repairs `crossDomainClient()` typing. | Upstream patch plus `docs/plans/195-fix-cross-domain-client-types.md`. | KitCN structural wrappers in `packages/kitcn/src/auth-client/types.ts` and `packages/kitcn/src/solid/types.ts`; no upstream package dependency. | Keep local wrappers; upstream is the correct owner. |
+| no-op | `c176fc4` updates Resend in upstream examples and regenerates locks. | Frozen-range name-status/stat. | No matching KitCN auth runtime behavior. | Do not import example/lock churn. |
+| compatibility | `6f940f9` types shared `runMutation` from `GenericActionCtx`. | Upstream `src/utils/index.ts` patch; Convex 1.42 mutation contexts accept transaction options while action contexts do not. | `packages/kitcn/src/server/context-utils.ts` contains the same older `GenericMutationCtx['runMutation']` declaration. | Implement the action-safe common call surface with a type regression. |
+| no-op | `dd9f1ee` releases upstream `0.12.4`. | Version/changelog/package metadata only. | KitCN vendors the used runtime surfaces and has no `@convex-dev/better-auth` dependency. | No package bump. |
+| bugfix | `38fa19a` fixes unbounded `count` / `findMany` pagination and adds a forward-progress guard. | Upstream adapter patch and 201-row regression test. | `packages/kitcn/src/auth/adapter.ts` has the exact `(limit ?? 200) - docs.length` loop in the shared HTTP/DB pagination owner; existing tests stop below the failing boundary. | Implement at the shared helper with unbounded and no-progress regressions. |
+| no-op | `c628916` releases upstream `0.12.5`. | Version/changelog/package metadata only. | No direct package dependency. | No package bump. |
+
+Delegated task prompt:
+```md
+Use `kitcn:task` and `kitcn:tdd`.
+
+Port the two directly applicable runtime fixes from the frozen
+`convex-better-auth` range:
+
+1. In `packages/kitcn/src/server/context-utils.ts`, type
+   `RunMutationCtx.runMutation` from `GenericActionCtx` so callers only receive
+   the mutation-call shape valid in both mutation and action contexts. Add a
+   type regression proving action callers cannot pass mutation-only
+   transaction options on Convex versions that expose them.
+2. In the shared `packages/kitcn/src/auth/adapter.ts` pagination helper, keep an
+   unbounded request budget when no limit exists and abort a non-done page that
+   neither advances the cursor nor produces rows/count. Add red regressions for
+   a 201-row-equivalent unbounded result and for no forward progress.
+
+Do not add `@convex-dev/better-auth`, copy upstream examples, or alter the
+cross-domain wrappers. Add the required KitCN changeset and durable solution
+note. Run focused tests/type proof, `bun --cwd packages/kitcn build`,
+`bun typecheck`, `bun lint:fix`, final autoreview, and `bun check`. Commit,
+push, and open a task-style PR.
+```
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until the named sync audit
+  evidence is recorded below and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md`
+  passes.
+- Do not create hook state for this goal. This file plus the active goal are
+  the durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| `sync-convex-auth` skill loaded | yes | Read `.agents/skills/sync-convex-auth/SKILL.md` completely. |
+| Active goal checked or created | yes | Previous goal was complete; created the matching sync objective for this plan. |
+| Source of truth read before audit | yes | User request, sync skill, `autogoal`, `task`, `VISION.md`, and `docs/README.md` read. |
+| Fork/upstream discovery strategy selected | yes | Start with GitHub fork metadata; use npm/local clone/known upstream only as ordered fallbacks. |
+| Output budget strategy recorded | yes | File/commit summaries first, scoped patches second; generated/build trees excluded. |
+| Optional-scope approval boundary recorded | yes | Slow e2e, broad examples/fixtures, release plumbing, and dev-only infrastructure require user approval unless direct proof for a required fix. |
+| Delegation boundary recorded | yes | This plan owns fork sync/audit; a linked `task` child owns any kitcn implementation and PR. |
+
+Work Checklist:
+- [x] Objective, threshold, verification surface, constraints, boundaries, and
+      blocked condition are filled from the active sync goal.
+- [x] Fork, upstream, branches/refs, behind count, ahead count, and exact range
+      are recorded.
+- [x] Local clone exists or is created, fork/upstream remotes are identified by
+      URL, and fork/upstream refs are fetched.
+- [x] Fork sync is executed when fast-forward-safe, represented by a fork PR
+      when direct push is blocked, or stopped with a recorded blocker when the
+      fork diverged.
+- [x] Post-sync fork ref or fork PR URL is recorded before KitCN implementation
+      delegation.
+- [x] Upstream commit list and file summary are read.
+- [x] Relevant upstream patches are read; large compares are grouped before
+      deep patch review.
+- [x] Local KitCN auth surfaces are searched and relevant hits are read.
+- [x] `docs/solutions` and `docs/plans` institutional notes are searched and
+      relevant hits are read.
+- [x] Every upstream change or file group is classified as `security`,
+      `compatibility`, `bugfix`, `feature`, `cleanup`, `docs`, `tests`, or
+      `no-op`.
+- [x] Every non-`no-op` item records commit evidence, diff evidence, local KitCN
+      files affected, expected implementation surface, verification command(s),
+      confidence, and decision.
+- [x] Optional or ambiguous additions are either explicitly approved, rejected,
+      or recorded as a blocker before implementation.
+- [x] Highest-leverage slice is selected using the skill priority order, or a
+      no-action verdict is recorded with evidence.
+- [x] Delegated `task` prompt is recorded exactly enough for implementation, or
+      N/A reason is recorded because no actionable opportunity exists.
+- [x] Final sync output matches the skill output contract before delegation or
+      no-action closeout.
+- [x] Workspace authority recorded: each proof names the repo/tool that owns the
+      evidence.
+- [x] Output budget discipline recorded and followed.
+- [x] Autoreview decision recorded for any local implementation patch, or N/A
+      reason recorded for audit-only/no-local-patch work.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Fork/upstream identity | yes | Record `gh repo view` or fallback evidence | GitHub parent was null; npm metadata and local remote URLs identify `get-convex/better-auth`. |
+| Ref fetch | yes | Fetch fork and upstream refs/tags in `../convex-better-auth` | Both `fork` and `origin` fetches exited 0. |
+| Behind/ahead counts | yes | Record `rev-list --count` results | Pre-sync 7 behind / 0 ahead; post-sync 0 / 0. |
+| Commit range | yes | Record exact compared range and commit summary | Frozen SHA range and seven commits recorded above. |
+| Fork sync | yes | Fast-forward/push fork, open fork PR, record already-synced state, or record divergence blocker | Direct fast-forward push succeeded without force. |
+| Post-sync fork proof | yes | Fetch/read post-sync fork ref or record fork PR URL | `fork/main` resolves to `c628916b451a6b4cff0f5464f134475464b1a6da`. |
+| Upstream diff summary | yes | Record `diff --name-status` and relevant patch evidence | Seven commits / 17 files grouped; runtime patches read directly. |
+| Local KitCN surface audit | yes | Run/read scoped `rg` across KitCN integration points | Read shared adapter, adapter tests, context utility, structural auth wrappers, and dependency ownership notes. |
+| Institutional note audit | yes | Search/read relevant `docs/solutions` and `docs/plans` notes | Read prior sync solution, Better Auth 1.6 wrapper solution, prior sync plan, and cross-domain task plan. |
+| Classification ledger complete | yes | Every upstream change or file group has class/evidence/decision | Ledger above covers all seven commits and changed file groups. |
+| Ambiguous optional scope | yes | Ask one pointed question or record explicit N/A | Optional examples, release plumbing, CI, and upstream-owned cross-domain typing explicitly rejected. |
+| Selected slice or no-action verdict | yes | Record priority choice, evidence, and confidence | Compatibility plus infinite-loop bugfix selected; confidence high from exact local source matches. |
+| Delegated task handoff | yes | Record exact delegated `task` prompt and final handoff, or N/A reason | Prompt above is ready for linked task execution. |
+| Browser surface changed | no | Capture Browser proof or record N/A | N/A: package runtime and type-only behavior; no UI route. |
+| Package/scaffold/docs gates delegated | yes | Ensure delegated prompt includes package build, fixture, docs, or skills checks when applicable | Changeset, solution note, package build, typecheck, review, full check, and user-approved generated-fixture checks are required. |
+| Workspace authority proof | yes | Record cwd/tool for every proof surface | Upstream Git evidence comes from `../convex-better-auth`; KitCN source evidence comes from this checkout. |
+| Autoreview for local implementation patch | yes | Run autoreview if this sync plan itself changes implementation code; otherwise N/A | Linked task final local rereview: TruffleHog clean, no accepted/actionable findings, patch correct at 0.91. |
+| Final output contract | pending | Record terse audit table and delegation/no-action result | pending |
+| Output budget discipline | yes | Verify no unbounded high-volume output was streamed, or record recovery | One broad PR-comments read and one broad local search were truncated; all subsequent evidence used commit metadata and exact file slices. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md` | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Setup refs | complete | exact refs and range recorded | done |
+| Fork sync | complete | fast-forward push; post-sync 0 behind / 0 ahead | done |
+| Upstream diff audit | complete | all seven commits and 17 files classified | done |
+| Local KitCN impact audit | complete | exact copied owners and institutional notes read | done |
+| Classification and decision | complete | compatibility + pagination slice selected | delegated task |
+| Delegation / closeout | in progress | review P2 repaired; repeated full `bun check` and final rereview green | ship PR |
+
+Findings:
+- Kitcn doctrine favors direct upstream ownership and deletion of obsolete auth
+  glue; upstream changes are not actionable merely because the fork was behind.
+- GitHub omits fork parent metadata, but npm package metadata, `fork`/`origin`
+  clone URLs, and `gh repo view get-convex/better-auth` independently identify
+  the upstream.
+- The frozen fork ref is exactly the merge base: 7 behind, 0 ahead, so direct
+  fast-forward sync is safe.
+- Direct push fast-forwarded fork `main` to upstream `c628916`; refetch proves
+  0 behind and 0 ahead.
+- `38fa19a` fixes an exact local copy bug: after collecting 200 unbounded rows,
+  KitCN requests `numItems: 0` while retaining the same cursor and can loop
+  forever. The same shared helper drives HTTP and database adapter consumers.
+- `6f940f9` narrows the shared `runMutation` surface to the action-safe call
+  shape. Convex 1.42 exposes transaction options only from mutation context;
+  KitCN currently leaks that mutation-only option through a union that may hold
+  an action context.
+- The upstream cross-domain type fix was already authored and verified at its
+  correct package owner. KitCN intentionally owns structural wrappers and does
+  not consume the upstream package.
+- The selected KitCN slice is implemented. User-approved targeted syncs changed
+  exactly one `lucide-react` dependency line in each of six generated shadcn
+  fixtures, and all six matching checks pass.
+
+Decisions and tradeoffs:
+- Use one-shot execution: sync the fork safely, classify the frozen pre-sync
+  range, then delegate at most one coherent kitcn slice.
+- Keep optional upstream test/example infrastructure out unless it is required
+  to prove a selected runtime or compatibility fix.
+- Ship both directly copied runtime fixes in one bounded auth-correctness task;
+  neither needs optional upstream infrastructure or a dependency bump.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| Broad `gh pr view --comments` included bot deployment logs and was truncated | 1 | Read PR title/body/files and exact source commits instead | Relevant human-authored fix intent was recovered from commit patches. |
+| Broad local auth search produced a capped result | 1 | Read exact owner files and prior plans/solutions | Local ownership and no-op decisions are now sourced. |
+| `bun check` reached repeated external shadcn fixture drift | 2 | Regenerated and verified only `next`, then stopped when `next-auth` proved a five-fixture expansion | User approved the five exact one-line generated refreshes. |
+
+Timeline:
+- 2026-07-30T11:57:57.509Z Sync audit plan created.
+- 2026-07-30T12:00:00Z Proved fork/upstream identity through GitHub, npm, and
+  local remote URLs; fetched both remotes and froze the 7-commit range.
+- 2026-07-30T12:02:00Z Fast-forward pushed upstream `origin/main` to fork
+  `main`; post-sync refetch proves exact equality.
+- 2026-07-30T12:16:00Z Classified all seven commits; selected action-safe
+  `runMutation` typing and terminating unbounded pagination for task execution.
+- 2026-07-30T14:48:00+0200 User approved the five remaining exact generated
+  fixture refreshes.
+- 2026-07-30T14:53:58+0200 All six affected fixture snapshots match fresh
+  generation; final full gate and review remain.
+
+Verification evidence:
+- command, `../convex-better-auth`: fetched `fork` and `origin`; fork ref
+  `c8df679`, upstream ref `c628916`, behind 7, ahead 0, merge base equals fork.
+- command, `../convex-better-auth`: pushed
+  `refs/remotes/origin/main:refs/heads/main`; fork now `c628916`, behind/ahead
+  both 0.
+- command, `../convex-better-auth`: frozen-range log lists seven commits from
+  `b51ec4d` through `c628916`; name-status lists 17 changed files.
+- source, `../convex-better-auth`: `6f940f9` changes the shared run-mutation
+  declaration from mutation to action context; `38fa19a` changes an absent
+  limit from 200 to Infinity and adds a no-progress guard.
+- source, this checkout: `packages/kitcn/src/server/context-utils.ts` and
+  `packages/kitcn/src/auth/adapter.ts` contain the exact pre-fix declarations.
+- source, this checkout: prior cross-domain and Better Auth 1.6 notes confirm
+  that KitCN owns structural wrappers and no longer imports the upstream
+  package.
+- command, this checkout: focused runtime/type tests, package build, root
+  typecheck, and lint pass; initial review was clean, while final-bundle review
+  found and prompted repair of a false-green Convex 1.38 type lane.
+- command, this checkout: targeted scenario sync/check passes for all six
+  affected shadcn fixtures; each committed change is exactly
+  `lucide-react ^1.27.0` to `^1.28.0`.
+- command, this checkout: repeated post-fix `bun check` passes all repository
+  gates.
+
+Final handoff / sync:
+- Fork/upstream: `zbeyens/convex-better-auth` / `get-convex/better-auth`
+- Range:
+  `c8df6790a496ab066f72139be16767c9c235df91..c628916b451a6b4cff0f5464f134475464b1a6da`
+- Fork sync: fast-forward complete; `fork/main` equals upstream at `c628916`.
+- Decision: delegate the two exact local runtime matches; skip upstream-owned
+  plugin typing, examples, release metadata, and CI churn.
+- Decision: pending
+- Delegated PR: pending
+- Fork sync: pending
+- Caveats: pending
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Linked task final review |
+| Where am I going? | Commit, PR, remote checks, closeout |
+| What is the goal? | Safely sync the fork, classify the frozen upstream range, and ship one useful kitcn auth slice or prove no action. |
+| What have I learned? | Two upstream fixes map exactly to shared KitCN owners; the remaining changes are no-ops locally. |
+| What have I done? | Fast-forwarded the fork, classified all seven commits, implemented the selected slice, and verified all affected generated fixtures. |
+
+Open risks:
+- PR creation and remote checks remain.

--- a/docs/plans/2026-07-30-sync-convex-auth.md
+++ b/docs/plans/2026-07-30-sync-convex-auth.md
@@ -240,7 +240,7 @@ Completion Gates:
 | Autoreview for local implementation patch | yes | Run autoreview if this sync plan itself changes implementation code; otherwise N/A | Linked task final local rereview: TruffleHog clean, no accepted/actionable findings, patch correct at 0.91. |
 | Final output contract | yes | Record terse audit table and delegation/no-action result | Fork refs/range, seven-commit ledger, selected slice, skipped scope, implementation evidence, and PR #311 are recorded. |
 | Output budget discipline | yes | Verify no unbounded high-volume output was streamed, or record recovery | One broad PR-comments read and one broad local search were truncated; all subsequent evidence used commit metadata and exact file slices. |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md` | Final closeout validator exited 0. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md` | Prior closeout validator exited 0; rerun after the Vercel retry resolves. |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
@@ -250,7 +250,7 @@ Phase / pass table:
 | Upstream diff audit | complete | all seven commits and 17 files classified | done |
 | Local KitCN impact audit | complete | exact copied owners and institutional notes read | done |
 | Classification and decision | complete | compatibility + pagination slice selected | delegated task |
-| Delegation / closeout | complete | PR #311 open; body verified; CI, Vercel, and release-policy checks green | validate plans and push evidence |
+| Delegation / closeout | in progress | implementation-head checks green; closeout head hit pre-build Vercel `git_info_fail` | trigger fresh head and wait for checks |
 
 Findings:
 - Kitcn doctrine favors direct upstream ownership and deletion of obsolete auth
@@ -290,6 +290,7 @@ Error attempts:
 | Broad `gh pr view --comments` included bot deployment logs and was truncated | 1 | Read PR title/body/files and exact source commits instead | Relevant human-authored fix intent was recovered from commit patches. |
 | Broad local auth search produced a capped result | 1 | Read exact owner files and prior plans/solutions | Local ownership and no-op decisions are now sourced. |
 | `bun check` reached repeated external shadcn fixture drift | 2 | Regenerated and verified only `next`, then stopped when `next-auth` proved a five-fixture expansion | User approved the five exact one-line generated refreshes. |
+| Closeout-head Vercel failed before build startup | 1 | Inspect the deployment record and trigger a fresh Git-backed head | `git_info_fail`; no build/error events exist, so this is not a code-build failure. |
 
 Timeline:
 - 2026-07-30T11:57:57.509Z Sync audit plan created.
@@ -330,7 +331,9 @@ Verification evidence:
   gates.
 - command, GitHub: PR #311 is open from the expected branch at implementation
   commit `e4d7c985`; task-style body verified with `gh pr view`.
-- command, GitHub: CI passed in 8m34s; Vercel and release-policy checks pass.
+- command, GitHub: implementation-head CI passed in 8m34s; Vercel and
+  release-policy checks passed. The closeout head then hit pre-build
+  `git_info_fail` and requires a fresh attempt.
 
 Final handoff / sync:
 - Fork/upstream: `zbeyens/convex-better-auth` / `get-convex/better-auth`
@@ -344,8 +347,8 @@ Final handoff / sync:
 - Delegated PR: `https://github.com/udecode/kitcn/pull/311`
 - Fork sync: direct fast-forward complete; post-sync 0 behind / 0 ahead.
 - Caveats: browser proof is N/A; six user-approved generated fixture manifests
-  moved only `lucide-react ^1.27.0` to `^1.28.0`; all local and remote checks
-  pass.
+  moved only `lucide-react ^1.27.0` to `^1.28.0`; implementation-head checks
+  pass, while a fresh closeout-head Vercel attempt remains.
 
 Reboot status:
 | Question | Answer |
@@ -357,4 +360,4 @@ Reboot status:
 | What have I done? | Fast-forwarded the fork, classified all seven commits, implemented and verified the selected slice, and opened PR #311. |
 
 Open risks:
-- None.
+- Fresh closeout-head Vercel and CI checks must pass.

--- a/docs/plans/2026-07-30-sync-convex-auth.md
+++ b/docs/plans/2026-07-30-sync-convex-auth.md
@@ -240,7 +240,7 @@ Completion Gates:
 | Autoreview for local implementation patch | yes | Run autoreview if this sync plan itself changes implementation code; otherwise N/A | Linked task final local rereview: TruffleHog clean, no accepted/actionable findings, patch correct at 0.91. |
 | Final output contract | yes | Record terse audit table and delegation/no-action result | Fork refs/range, seven-commit ledger, selected slice, skipped scope, implementation evidence, and PR #311 are recorded. |
 | Output budget discipline | yes | Verify no unbounded high-volume output was streamed, or record recovery | One broad PR-comments read and one broad local search were truncated; all subsequent evidence used commit metadata and exact file slices. |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md` | Prior closeout validator exited 0; rerun after the Vercel retry resolves. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-07-30-sync-convex-auth.md` | Retry resolved; final validator exited 0. |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
@@ -250,7 +250,7 @@ Phase / pass table:
 | Upstream diff audit | complete | all seven commits and 17 files classified | done |
 | Local KitCN impact audit | complete | exact copied owners and institutional notes read | done |
 | Classification and decision | complete | compatibility + pagination slice selected | delegated task |
-| Delegation / closeout | in progress | implementation-head checks green; closeout head hit pre-build Vercel `git_info_fail` | trigger fresh head and wait for checks |
+| Delegation / closeout | complete | fresh retry head `cadc6e5b` passed CI, Vercel, and release-policy checks | validate plans and push immutable closeout |
 
 Findings:
 - Kitcn doctrine favors direct upstream ownership and deletion of obsolete auth
@@ -290,7 +290,7 @@ Error attempts:
 | Broad `gh pr view --comments` included bot deployment logs and was truncated | 1 | Read PR title/body/files and exact source commits instead | Relevant human-authored fix intent was recovered from commit patches. |
 | Broad local auth search produced a capped result | 1 | Read exact owner files and prior plans/solutions | Local ownership and no-op decisions are now sourced. |
 | `bun check` reached repeated external shadcn fixture drift | 2 | Regenerated and verified only `next`, then stopped when `next-auth` proved a five-fixture expansion | User approved the five exact one-line generated refreshes. |
-| Closeout-head Vercel failed before build startup | 1 | Inspect the deployment record and trigger a fresh Git-backed head | `git_info_fail`; no build/error events exist, so this is not a code-build failure. |
+| Closeout-head Vercel failed before build startup | 1 | Inspect the deployment record and trigger a fresh Git-backed head | `git_info_fail` had no build/error events; fresh retry head `cadc6e5b` passed Vercel and CI. |
 
 Timeline:
 - 2026-07-30T11:57:57.509Z Sync audit plan created.
@@ -333,7 +333,8 @@ Verification evidence:
   commit `e4d7c985`; task-style body verified with `gh pr view`.
 - command, GitHub: implementation-head CI passed in 8m34s; Vercel and
   release-policy checks passed. The closeout head then hit pre-build
-  `git_info_fail` and requires a fresh attempt.
+  `git_info_fail`; fresh retry head `cadc6e5b` passed CI in 6m32s plus Vercel
+  and release-policy checks.
 
 Final handoff / sync:
 - Fork/upstream: `zbeyens/convex-better-auth` / `get-convex/better-auth`
@@ -347,8 +348,8 @@ Final handoff / sync:
 - Delegated PR: `https://github.com/udecode/kitcn/pull/311`
 - Fork sync: direct fast-forward complete; post-sync 0 behind / 0 ahead.
 - Caveats: browser proof is N/A; six user-approved generated fixture manifests
-  moved only `lucide-react ^1.27.0` to `^1.28.0`; implementation-head checks
-  pass, while a fresh closeout-head Vercel attempt remains.
+  moved only `lucide-react ^1.27.0` to `^1.28.0`; the one Vercel
+  `git_info_fail` was transient, and the fresh retry head passed all checks.
 
 Reboot status:
 | Question | Answer |
@@ -360,4 +361,4 @@ Reboot status:
 | What have I done? | Fast-forwarded the fork, classified all seven commits, implemented and verified the selected slice, and opened PR #311. |
 
 Open risks:
-- Fresh closeout-head Vercel and CI checks must pass.
+- None.

--- a/docs/solutions/integration-issues/convex-auth-pagination-needs-forward-progress-20260730.md
+++ b/docs/solutions/integration-issues/convex-auth-pagination-needs-forward-progress-20260730.md
@@ -1,0 +1,74 @@
+---
+title: Convex auth pagination needs an unbounded budget and forward progress
+date: 2026-07-30
+category: integration-issues
+module: auth-adapter
+problem_type: integration_issue
+component: authentication
+symptoms:
+  - unbounded auth count and findMany calls can loop after 200 rows
+  - shared runMutation contexts expose options unavailable from actions
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+tags: [auth, convex, better-auth, pagination, action]
+---
+
+# Convex auth pagination needs an unbounded budget and forward progress
+
+## Problem
+
+The shared auth pagination helper treated a missing caller limit as a 200-row
+total limit. After collecting the first page, it requested zero rows while
+retaining the cursor and could loop forever.
+
+The shared mutation runner type also used the mutation-context signature even
+though its runtime union includes action contexts. Newer Convex versions allow
+transaction-limit options only for nested calls inside mutations.
+
+## Symptoms
+
+- `count()` and unbounded `findMany()` do not terminate above 200 matching rows.
+- A stalled backend page can repeat forever when it is not done, returns
+  nothing, and leaves the cursor unchanged.
+- TypeScript permits a transaction-options argument on a context that may be an
+  action, even though action runners accept only the function reference and
+  arguments.
+
+## Solution
+
+Keep pagination unbounded only when the caller omits `limit`, while preserving
+the 200-row per-page cap. Abort when a non-final page neither advances the
+cursor nor produces rows or a count.
+
+Type the shared `runMutation` property from `GenericActionCtx`. Mutation
+contexts remain assignable because their runner supports the action-safe call
+shape plus mutation-only options.
+
+## Why This Works
+
+The page cap and total result limit are different constraints. An unbounded
+query still fetches at most 200 rows per request, but every subsequent request
+retains a positive budget until Convex reports completion.
+
+The action signature is the common callable surface across both runtime
+contexts. Consumers can call mutations safely without receiving options that
+only one branch of the union can honor.
+
+## Prevention
+
+1. Test unbounded pagination with more rows than the per-page cap.
+2. Require every non-final pagination step to advance its cursor or produce
+   output.
+3. Type union-context methods from the narrowest runtime that must support the
+   call.
+4. Run the type regression against a pinned Convex version that exposes
+   mutation-only transaction options, while keeping the package baseline at its
+   minimum supported version.
+5. Re-audit copied Convex Better Auth helpers whenever upstream changes their
+   termination or context contracts.
+
+## Related
+
+- `docs/solutions/integration-issues/convex-better-auth-upstream-sync-runtime-fixes-20260416.md`
+- `docs/solutions/integration-issues/better-auth-1-6-support-needs-structural-convex-auth-wrappers-20260416.md`

--- a/fixtures/next-auth/package.json
+++ b/fixtures/next-auth/package.json
@@ -9,7 +9,7 @@
     "convex": "1.38.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.27.0",
+    "lucide-react": "^1.28.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "19.2.4",

--- a/fixtures/next/package.json
+++ b/fixtures/next/package.json
@@ -8,7 +8,7 @@
     "convex": "1.38.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.27.0",
+    "lucide-react": "^1.28.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "19.2.4",

--- a/fixtures/start-auth/package.json
+++ b/fixtures/start-auth/package.json
@@ -17,7 +17,7 @@
     "convex": "1.38.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.27.0",
+    "lucide-react": "^1.28.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/start/package.json
+++ b/fixtures/start/package.json
@@ -16,7 +16,7 @@
     "convex": "1.38.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.27.0",
+    "lucide-react": "^1.28.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/vite-auth/package.json
+++ b/fixtures/vite-auth/package.json
@@ -11,7 +11,7 @@
     "convex": "1.38.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.27.0",
+    "lucide-react": "^1.28.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/vite/package.json
+++ b/fixtures/vite/package.json
@@ -10,7 +10,7 @@
     "convex": "1.38.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.27.0",
+    "lucide-react": "^1.28.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "bun-types": "^1.3.9",
     "concurrently": "^9.2.1",
     "convex-test": "^0.0.41",
+    "convex-type-test": "npm:convex@1.42.3",
     "eslint": "10.0.2",
     "eslint-plugin-react-hooks": "7.0.1",
     "fast-check": "^4.5.3",

--- a/packages/kitcn/src/auth/adapter.test.ts
+++ b/packages/kitcn/src/auth/adapter.test.ts
@@ -80,6 +80,48 @@ describe('handlePagination', () => {
     expect(state.docs).toEqual([]);
     expect(state.isDone).toBe(true);
   });
+
+  test('continues unbounded pagination beyond the first 200 rows', async () => {
+    let index = 0;
+    const state = await handlePagination(async ({ paginationOpts }) => {
+      if (paginationOpts.numItems === 0) {
+        throw new Error('pagination requested zero rows');
+      }
+
+      index++;
+      return {
+        continueCursor: `cursor-${index}`,
+        isDone: index === 2,
+        page:
+          index === 1
+            ? Array.from({ length: 200 }, (_, id) => ({ id }))
+            : [{ id: 200 }],
+        pageStatus: 'Done' as const,
+      };
+    });
+
+    expect(state.docs).toHaveLength(201);
+  });
+
+  test('aborts a page that cannot make forward progress', async () => {
+    let calls = 0;
+
+    await expect(
+      handlePagination(async () => {
+        calls++;
+        if (calls > 1) {
+          throw new Error('test query cap reached');
+        }
+
+        return {
+          continueCursor: null,
+          isDone: false,
+          page: [],
+          pageStatus: 'Done' as const,
+        };
+      })
+    ).rejects.toThrow('Pagination made no forward progress');
+  });
 });
 
 describe('adapterConfig', () => {

--- a/packages/kitcn/src/auth/adapter.ts
+++ b/packages/kitcn/src/auth/adapter.ts
@@ -70,17 +70,26 @@ export const handlePagination = async (
   };
 
   do {
+    const cursorBeforePage = state.cursor;
     const result = await next({
       paginationOpts: {
         cursor: state.cursor,
         numItems: Math.min(
           numItems ?? 200,
-          (limit ?? 200) - state.docs.length,
+          limit === undefined
+            ? Number.POSITIVE_INFINITY
+            : limit - state.docs.length,
           200
         ),
       },
     });
     onResult(result);
+
+    const advanced = state.cursor !== cursorBeforePage;
+    const produced = (result.page?.length ?? 0) > 0 || (result.count ?? 0) > 0;
+    if (!(state.isDone || advanced || produced)) {
+      throw new Error('Pagination made no forward progress');
+    }
   } while (!state.isDone);
 
   return state;

--- a/packages/kitcn/src/server/context-utils.test-d.ts
+++ b/packages/kitcn/src/server/context-utils.test-d.ts
@@ -1,0 +1,47 @@
+import type {
+  FunctionReference,
+  GenericDataModel,
+  GenericMutationCtx,
+} from 'convex/server';
+import { expectTypeOf, test } from 'vitest';
+import type { RunMutationCtx } from './context-utils';
+
+type TestMutation = FunctionReference<
+  'mutation',
+  'internal',
+  { value: string },
+  null
+>;
+
+const checkCommonRunMutationCalls = (
+  ctx: RunMutationCtx<GenericDataModel>,
+  mutation: TestMutation
+) => {
+  void ctx.runMutation(mutation, { value: 'accepted' });
+
+  void ctx.runMutation(
+    mutation,
+    { value: 'rejected' },
+    // @ts-expect-error transaction limits are unavailable from action contexts
+    { transactionLimits: { documentsRead: 1 } }
+  );
+};
+
+const checkMutationRunMutationOptions = (
+  ctx: GenericMutationCtx<GenericDataModel>,
+  mutation: TestMutation
+) => {
+  void ctx.runMutation(
+    mutation,
+    { value: 'accepted' },
+    { transactionLimits: { documentsRead: 1 } }
+  );
+};
+
+test('runMutation uses the call shape shared by mutation and action contexts', () => {
+  expectTypeOf<
+    RunMutationCtx<GenericDataModel>['runMutation']
+  >().toBeFunction();
+  expectTypeOf(checkCommonRunMutationCalls).toBeFunction();
+  expectTypeOf(checkMutationRunMutationOptions).toBeFunction();
+});

--- a/packages/kitcn/src/server/context-utils.ts
+++ b/packages/kitcn/src/server/context-utils.ts
@@ -14,7 +14,7 @@ export type RunMutationCtx<DataModel extends GenericDataModel> = (
   | GenericMutationCtx<DataModel>
   | GenericActionCtx<DataModel>
 ) & {
-  runMutation: GenericMutationCtx<DataModel>['runMutation'];
+  runMutation: GenericActionCtx<DataModel>['runMutation'];
 };
 
 export type SchedulerCtx<TCtx> = TCtx extends {

--- a/packages/kitcn/tsconfig.json
+++ b/packages/kitcn/tsconfig.json
@@ -16,6 +16,7 @@
   "include": ["src", "../../tooling/global.d.ts"],
   "exclude": [
     "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
     "src/**/*.test.tsx",
     "src/**/*.vitest.ts",
     "src/**/*.vitest.tsx"

--- a/packages/kitcn/tsconfig.type-tests.json
+++ b/packages/kitcn/tsconfig.type-tests.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "noEmit": true,
+    "paths": {
+      "convex/server": [
+        "node_modules/convex-type-test/dist/esm-types/server/index.d.ts"
+      ]
+    }
+  },
+  "exclude": [],
+  "include": ["src/**/*.test-d.ts", "../../tooling/global.d.ts"]
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -66,6 +66,11 @@ export default defineConfig({
             'packages/**/*.vitest.ts',
             'packages/**/*.vitest.tsx',
           ],
+          typecheck: {
+            enabled: true,
+            include: ['packages/**/*.test-d.ts'],
+            tsconfig: 'packages/kitcn/tsconfig.type-tests.json',
+          },
           exclude: ['**/node_modules/**', '**/tmp/**', '**/src/solid/**'],
         },
       },


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

🐛 Fixes ➖ N/A

🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 Unbounded pagination, stalled-page termination, and action-safe typing failed before their owning fixes. | ➖ N/A |
| Verified | 🟢 31 focused tests, Convex 1.42 type regression, package build, and full `bun check`. | ➖ N/A |

**✅ Outcome**

Unbounded auth queries continue past 200 rows and abort pages that cannot make progress. Shared mutation contexts expose only the call shape valid from actions.

**⚠️ Caveat**

Browser proof is N/A for package runtime and type behavior. Fresh shadcn generation also advanced `lucide-react` from `^1.27.0` to `^1.28.0` in six generated fixture manifests; each targeted fixture check passes.

**🏗️ Design**

- Preserve the 200-row request cap while using an infinite total budget only when callers omit `limit`.
- Require every non-final page to advance its cursor or produce rows/count.
- Type `RunMutationCtx.runMutation` from `GenericActionCtx`.
- Run the committed type regression against pinned Convex 1.42.3 while regular package gates keep the supported Convex 1.38 baseline.

**🧪 Verified**

- `bun test packages/kitcn/src/auth/adapter.test.ts packages/kitcn/src/server/context-utils.test.ts`
- `bunx vitest run packages/kitcn/src/server/context-utils.test-d.ts`
- Production-revert type proof: fails with unused `@ts-expect-error`, then passes after restoring `GenericActionCtx`
- `bun --cwd packages/kitcn typecheck`
- `bun --cwd packages/kitcn build`
- Targeted scenario sync/check for `next`, `next-auth`, `start`, `start-auth`, `vite`, and `vite-auth`
- `bun lint:fix`
- `bun check`
- Final autoreview: TruffleHog clean; no accepted/actionable findings; patch correct at 0.91
